### PR TITLE
Fix map defaults and keep view when no gear

### DIFF
--- a/src/hooks/useEquipmentById.ts
+++ b/src/hooks/useEquipmentById.ts
@@ -78,9 +78,9 @@ export const useEquipmentById = (id: string) => {
           responseRate: 95,
         },
         location: {
-          lat: Number(data.location_lat || 34.0522),
-          lng: Number(data.location_lng || -118.2437),
-          zip: data.location_zip || 'Los Angeles, CA',
+          lat: Number(data.location_lat || 0),
+          lng: Number(data.location_lng || 0),
+          zip: data.location_zip || '',
         },
         distance: 2.5,
         specifications: {

--- a/src/pages/EquipmentDetailPage.tsx
+++ b/src/pages/EquipmentDetailPage.tsx
@@ -71,8 +71,8 @@ const EquipmentDetailPage = () => {
         review_count: equipment.review_count || 0,
         owner: equipment.owner, // Use the actual owner data from the database
         location: equipment.location || {
-          lat: 34.0522, // Default to LA coordinates
-          lng: -118.2437,
+          lat: 0,
+          lng: 0,
           zip: ''
         },
         distance: 0,

--- a/src/services/equipment/equipmentConverter.ts
+++ b/src/services/equipment/equipmentConverter.ts
@@ -32,9 +32,9 @@ export const convertSupabaseToEquipment = async (item: any): Promise<Equipment> 
       responseRate: 95,
     },
     location: {
-      lat: Number(item.location_lat || 34.0522),
-      lng: Number(item.location_lng || -118.2437),
-      zip: item.location_zip || 'Los Angeles, CA',
+      lat: Number(item.location_lat || 0),
+      lng: Number(item.location_lng || 0),
+      zip: item.location_zip || '',
     },
     distance: 2.5, // Default distance
     specifications: {

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -135,8 +135,8 @@ export const initializeMap = (container: HTMLDivElement, token: string): mapboxg
   const map = new mapboxgl.Map({
     container,
     style: 'mapbox://styles/mapbox/streets-v12',
-    center: [-118.2437, 34.0522], // Los Angeles coordinates
-    zoom: 11
+    center: [0, 0], // Start centered on the world
+    zoom: 2
   });
 
   map.addControl(new mapboxgl.NavigationControl(), 'top-right');
@@ -152,9 +152,7 @@ export const initializeMap = (container: HTMLDivElement, token: string): mapboxg
 
 export const fitMapBounds = (map: mapboxgl.Map, locations: Array<{ location: { lat: number; lng: number; }; }>, isSingleView: boolean = false): void => {
   if (locations.length === 0) {
-    map.setCenter([-118.2437, 34.0522]);
-    map.setZoom(11);
-    return;
+    return; // Keep current view when no locations are provided
   }
 
   try {


### PR DESCRIPTION
## Summary
- avoid starting the map centered on Los Angeles
- keep current map view if there are no locations when gear items switch
- remove Los Angeles as default location for gear data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68619b3cf0308320a12def8db0e06ab0