### PR TITLE
Add Lightspeed POS mock import

### DIFF
--- a/src/services/lightspeed/lightspeedService.ts
+++ b/src/services/lightspeed/lightspeedService.ts
@@ -1,0 +1,27 @@
+import { supabase } from '@/integrations/supabase/client';
+import { mockLightspeedItems, LightspeedItem } from './mockLightspeedData';
+
+export const fetchMockLightspeedInventory = async (): Promise<LightspeedItem[]> => {
+  // Simulate API delay
+  await new Promise(res => setTimeout(res, 1000));
+  return mockLightspeedItems;
+};
+
+export const ingestLightspeedInventory = async (items: LightspeedItem[], userId: string) => {
+  for (const item of items) {
+    const { error } = await supabase.from('equipment').insert({
+      user_id: userId,
+      name: item.description,
+      category: item.category,
+      description: item.manufacturer || '',
+      price_per_day: item.price,
+      image_url: item.image,
+      location_zip: '00000',
+      status: 'available',
+      visible_on_map: true,
+    });
+    if (error) {
+      console.error('Error inserting Lightspeed item', item.itemID, error);
+    }
+  }
+};

--- a/src/services/lightspeed/mockLightspeedData.ts
+++ b/src/services/lightspeed/mockLightspeedData.ts
@@ -1,0 +1,39 @@
+export interface LightspeedItem {
+  itemID: string;
+  description: string;
+  price: number;
+  image: string;
+  category: string;
+  manufacturer?: string;
+  upc?: string;
+}
+
+export const mockLightspeedItems: LightspeedItem[] = [
+  {
+    itemID: 'LS-1',
+    description: 'Demo Carbon Mountain Bike',
+    price: 120,
+    image: 'https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e?auto=format&fit=crop&w=800&q=60',
+    category: 'mountain-bikes',
+    manufacturer: 'Demo Bikes',
+    upc: '111111',
+  },
+  {
+    itemID: 'LS-2',
+    description: 'All-Mountain Snowboard',
+    price: 60,
+    image: 'https://images.unsplash.com/photo-1542038332026-6d45e63d29ed?auto=format&fit=crop&w=800&q=60',
+    category: 'snowboards',
+    manufacturer: 'Snow Co',
+    upc: '222222',
+  },
+  {
+    itemID: 'LS-3',
+    description: '9ft Epoxy Longboard',
+    price: 45,
+    image: 'https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=800&q=60',
+    category: 'surfboards',
+    manufacturer: 'WaveWorks',
+    upc: '333333',
+  },
+];


### PR DESCRIPTION
## Summary
- add mock Lightspeed inventory data and ingest service
- ingest data when syncing from Lightspeed POS page
- show imported items under new inventory list with visibility toggles and pagination

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6862cbb78b788320b43bebd5fcf2bc11