### PR TITLE
Add SEO metadata hook with per-page tags

### DIFF
--- a/src/hooks/usePageMetadata.ts
+++ b/src/hooks/usePageMetadata.ts
@@ -1,0 +1,55 @@
+import { useEffect } from 'react';
+
+export interface PageMetadata {
+  title?: string;
+  description?: string;
+  image?: string;
+  type?: string;
+  schema?: Record<string, any>;
+}
+
+const setMeta = (attr: 'name' | 'property', key: string, value: string) => {
+  if (!value) return;
+  let element = document.head.querySelector(`meta[${attr}='${key}']`) as HTMLMetaElement | null;
+  if (!element) {
+    element = document.createElement('meta');
+    element.setAttribute(attr, key);
+    document.head.appendChild(element);
+  }
+  element.setAttribute('content', value);
+};
+
+const usePageMetadata = ({ title, description, image, type = 'website', schema }: PageMetadata) => {
+  useEffect(() => {
+    if (title) {
+      document.title = title;
+      setMeta('property', 'og:title', title);
+    }
+    if (description) {
+      setMeta('name', 'description', description);
+      setMeta('property', 'og:description', description);
+    }
+    if (image) {
+      setMeta('property', 'og:image', image);
+      setMeta('name', 'twitter:image', image);
+    }
+    setMeta('property', 'og:type', type);
+    setMeta('property', 'og:url', window.location.href);
+
+    const scriptId = 'structured-data';
+    let script = document.head.querySelector(`#${scriptId}`) as HTMLScriptElement | null;
+    if (schema) {
+      if (!script) {
+        script = document.createElement('script');
+        script.id = scriptId;
+        script.type = 'application/ld+json';
+        document.head.appendChild(script);
+      }
+      script.textContent = JSON.stringify(schema);
+    } else if (script) {
+      script.remove();
+    }
+  }, [title, description, image, type, schema]);
+};
+
+export default usePageMetadata;

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,6 +1,11 @@
 import { useEffect } from "react";
+import usePageMetadata from "@/hooks/usePageMetadata";
 
 const AboutPage = () => {
+  usePageMetadata({
+    title: 'About DemoStoke',
+    description: 'Learn how DemoStoke connects riders with local gear owners.'
+  });
   // Scroll to top on page load
   useEffect(() => {
     window.scrollTo(0, 0);

--- a/src/pages/AddGearForm.tsx
+++ b/src/pages/AddGearForm.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from "react";
+import usePageMetadata from "@/hooks/usePageMetadata";
 import FormHeader from "@/components/gear-form/FormHeader";
 import GearBasicInfo from "@/components/gear-form/GearBasicInfo";
 import GearSpecifications from "@/components/gear-form/GearSpecifications";
@@ -11,6 +12,10 @@ import { useDuplicatedGearData } from "@/hooks/gear-form/useDuplicatedGearData";
 import { useAuth } from "@/helpers";
 
 const AddGearForm = () => {
+  usePageMetadata({
+    title: 'Add Gear | DemoStoke',
+    description: 'List new gear for rent or demo on DemoStoke.'
+  });
   // Scroll to top on page load
   useEffect(() => {
     window.scrollTo(0, 0);

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -1,5 +1,6 @@
 
 import { useAuth } from "@/helpers";
+import usePageMetadata from "@/hooks/usePageMetadata";
 import UserManagementSection from "@/components/admin/UserManagementSection";
 import ManualUserCreationSection from "@/components/admin/ManualUserCreationSection";
 import VideoUploadSection from "@/components/admin/VideoUploadSection";
@@ -9,6 +10,10 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 const AdminPage = () => {
+  usePageMetadata({
+    title: 'Admin Dashboard | DemoStoke',
+    description: 'Administrative tools for managing DemoStoke.'
+  });
   const { user } = useAuth();
 
   if (!user) {

--- a/src/pages/AnalyticsPage.tsx
+++ b/src/pages/AnalyticsPage.tsx
@@ -1,5 +1,6 @@
 
 import { useState, useEffect } from "react";
+import usePageMetadata from "@/hooks/usePageMetadata";
 import { DateRange } from "react-day-picker";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -10,6 +11,10 @@ import RevenueChart from "@/components/analytics/RevenueChart";
 import { getAnalyticsData } from "@/lib/mockAnalyticsData";
 
 const AnalyticsPage = () => {
+  usePageMetadata({
+    title: 'Gear Analytics | DemoStoke',
+    description: 'View performance metrics for your gear listings.'
+  });
   const [dateRange, setDateRange] = useState<DateRange | undefined>(() => {
     const today = new Date();
     const thirtyDaysAgo = new Date();

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import usePageMetadata from "@/hooks/usePageMetadata";
 import { Link, useSearchParams, useNavigate } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -9,6 +10,10 @@ import { blogPosts, BlogPost } from "@/lib/blog";
 import { searchBlogPostsWithNLP } from "@/services/blogSearchService";
 
 const BlogPage = () => {
+  usePageMetadata({
+    title: 'DemoStoke Blog',
+    description: 'Tips, gear reviews and stories from the DemoStoke community.'
+  });
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
 

--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -1,4 +1,5 @@
 import { useParams, Link } from "react-router-dom";
+import usePageMetadata from "@/hooks/usePageMetadata";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { ArrowLeft, Clock, User, Calendar, Share2, ArrowUp } from "lucide-react";
@@ -12,6 +13,24 @@ const BlogPostPage = () => {
   const { slug } = useParams<{ slug: string; }>();
   const post = blogPosts.find(p => p.id === slug);
   const [showBackToTop, setShowBackToTop] = useState(false);
+
+  usePageMetadata({
+    title: post ? `${post.title} | DemoStoke` : 'Blog Post | DemoStoke',
+    description: post?.excerpt,
+    image: post?.heroImage,
+    type: 'article',
+    schema: post
+      ? {
+          '@context': 'https://schema.org',
+          '@type': 'BlogPosting',
+          headline: post.title,
+          description: post.excerpt,
+          image: post.heroImage,
+          datePublished: post.publishedAt,
+          author: { '@type': 'Person', name: post.author }
+        }
+      : undefined
+  });
 
   // Fetch related gear based on the blog post title
   const { data: relatedGear, isLoading: isLoadingRelatedGear } = useRelatedGear(post?.tags || []);

--- a/src/pages/BookingsPage.tsx
+++ b/src/pages/BookingsPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import usePageMetadata from "@/hooks/usePageMetadata";
 import { format, parseISO, addDays } from "date-fns";
 import { Calendar as CalendarIcon } from "lucide-react";
 
@@ -37,6 +38,10 @@ const getBookingDates = (bookings: Booking[]): Date[] => {
 type ViewMode = "myBookings" | "othersBookings";
 
 const BookingsPage = () => {
+  usePageMetadata({
+    title: 'My Bookings | DemoStoke',
+    description: 'View and manage your DemoStoke gear reservations.'
+  });
   const [date, setDate] = useState<Date | undefined>(new Date());
   const [viewMode, setViewMode] = useState<ViewMode>("myBookings");
   const isMobile = useIsMobile();

--- a/src/pages/ContactUsPage.tsx
+++ b/src/pages/ContactUsPage.tsx
@@ -1,5 +1,6 @@
 
 import { useState, useEffect } from "react";
+import usePageMetadata from "@/hooks/usePageMetadata";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -12,6 +13,10 @@ import { toast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
 
 const ContactUsPage = () => {
+  usePageMetadata({
+    title: 'Contact Us | DemoStoke',
+    description: 'Get in touch with the DemoStoke team.'
+  });
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);

--- a/src/pages/DemoCalendarPage.tsx
+++ b/src/pages/DemoCalendarPage.tsx
@@ -1,5 +1,6 @@
 
 import { useState } from "react";
+import usePageMetadata from "@/hooks/usePageMetadata";
 import { useAuth } from "@/helpers";
 import { useDemoEvents } from "@/hooks/useDemoEvents";
 import { useCalendarNavigation } from "@/hooks/useCalendarNavigation";
@@ -12,6 +13,10 @@ import { Button } from "@/components/ui/button";
 import { useNavigate } from "react-router-dom";
 
 const DemoCalendarPage = () => {
+  usePageMetadata({
+    title: 'Demo Events Calendar | DemoStoke',
+    description: 'Explore upcoming demo events and manage your own.'
+  });
   const { isAuthenticated } = useAuth();
   const { isAdmin, isLoading: isLoadingRole } = useIsAdmin();
   const navigate = useNavigate();

--- a/src/pages/EditGearForm.tsx
+++ b/src/pages/EditGearForm.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import usePageMetadata from "@/hooks/usePageMetadata";
 import { useParams, useNavigate } from "react-router-dom";
 import { useToast } from "@/hooks/use-toast";
 import { useEquipmentById } from "@/hooks/useEquipmentById";
@@ -16,6 +17,10 @@ import GearPricing from "@/components/gear-form/GearPricing";
 import FormActions from "@/components/gear-form/FormActions";
 
 const EditGearForm = () => {
+  usePageMetadata({
+    title: 'Edit Gear | DemoStoke',
+    description: 'Update your gear listing details on DemoStoke.'
+  });
   const { id } = useParams();
   const navigate = useNavigate();
   const { toast } = useToast();

--- a/src/pages/EquipmentDetailPage.tsx
+++ b/src/pages/EquipmentDetailPage.tsx
@@ -1,5 +1,6 @@
 
 import { useParams } from "react-router-dom";
+import usePageMetadata from "@/hooks/usePageMetadata";
 import { Button } from "@/components/ui/button";
 import { useEffect, useMemo, useState, useRef } from "react";
 import { useEquipmentById } from "@/hooks/useEquipmentById";
@@ -19,6 +20,11 @@ function isValidUUID(id: string) {
 }
 
 const EquipmentDetailPage = () => {
+  usePageMetadata({
+    title: 'Gear Details | DemoStoke',
+    description: 'View detailed information about this gear listing.',
+    type: 'product'
+  });
   const { id } = useParams<{ id: string; }>();
   const [waiverCompleted, setWaiverCompleted] = useState(false);
   const [showWaiver, setShowWaiver] = useState(false);

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -1,5 +1,6 @@
 
 import { useState, useEffect, useMemo } from "react";
+import usePageMetadata from "@/hooks/usePageMetadata";
 import { useLocation, useSearchParams, useMatch } from "react-router-dom";
 import { getEquipmentData } from "@/services/searchService";
 import MapComponent from "@/components/MapComponent";
@@ -11,6 +12,10 @@ import { useToast } from "@/hooks/use-toast";
 import { useEquipmentWithDynamicDistance } from "@/hooks/useEquipmentWithDynamicDistance";
 
 const ExplorePage = () => {
+  usePageMetadata({
+    title: 'Explore Gear | DemoStoke',
+    description: 'Find gear near you and book demos on DemoStoke.'
+  });
   const location = useLocation();
   const [searchParams] = useSearchParams();
   const { toast } = useToast();

--- a/src/pages/GearOwnerProfilePage.tsx
+++ b/src/pages/GearOwnerProfilePage.tsx
@@ -1,5 +1,6 @@
 
 import { useEffect } from "react";
+import usePageMetadata from "@/hooks/usePageMetadata";
 import { useParams } from "react-router-dom";
 import { Link } from "react-router-dom";
 import { mockEquipment, ownerPersonas } from "@/lib/mockData";
@@ -10,6 +11,10 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Separator } from "@/components/ui/separator";
 
 const GearOwnerProfilePage = () => {
+  usePageMetadata({
+    title: 'Gear Owner Profile | DemoStoke',
+    description: 'View information about this gear owner on DemoStoke.'
+  });
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,6 @@
 
 import { useState, useEffect, useRef } from "react";
+import usePageMetadata from "@/hooks/usePageMetadata";
 import HeroSection from "@/components/HeroSection";
 import HowItWorksSection from "@/components/home/HowItWorksSection";
 import FeaturedGearSection from "@/components/home/FeaturedGearSection";
@@ -25,6 +26,10 @@ import { supabase } from "@/integrations/supabase/client";
 import HCaptcha from "@/components/HCaptcha";
 
 const HomePage = () => {
+  usePageMetadata({
+    title: 'DemoStoke - Ride What Makes You Feel Alive',
+    description: 'Discover and demo outdoor gear from local riders on DemoStoke.'
+  });
   // Scroll to top on page load
   useEffect(() => {
     window.scrollTo(0, 0);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,11 @@
 // Update this page (the content is just a fallback if you fail to update the page)
+import usePageMetadata from "@/hooks/usePageMetadata";
 
 const Index = () => {
+  usePageMetadata({
+    title: 'DemoStoke',
+    description: 'Ride what makes you feel alive.'
+  });
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-100">
       <div className="text-center">

--- a/src/pages/LightspeedPOSPage.tsx
+++ b/src/pages/LightspeedPOSPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useMemo } from "react";
+import usePageMetadata from "@/hooks/usePageMetadata";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -18,6 +19,10 @@ import { useNavigate } from "react-router-dom";
 import { fetchMockLightspeedInventory, ingestLightspeedInventory } from "@/services/lightspeed/lightspeedService";
 
 const LightspeedPOSPage = () => {
+  usePageMetadata({
+    title: 'Lightspeed POS | DemoStoke',
+    description: 'Import and manage your Lightspeed inventory on DemoStoke.'
+  });
   // Scroll to top on page load
   useEffect(() => {
     window.scrollTo(0, 0);

--- a/src/pages/ListYourGearPage.tsx
+++ b/src/pages/ListYourGearPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from "react";
+import usePageMetadata from "@/hooks/usePageMetadata";
 import { Link, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -16,6 +17,10 @@ import {
 } from "lucide-react";
 
 const ListYourGearPage = () => {
+  usePageMetadata({
+    title: 'List Your Gear | DemoStoke',
+    description: 'Earn money by renting out your gear to the DemoStoke community.'
+  });
   // Scroll to top on page load
   useEffect(() => {
     window.scrollTo(0, 0);

--- a/src/pages/MyEquipmentPage.tsx
+++ b/src/pages/MyEquipmentPage.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom";
+import usePageMetadata from "@/hooks/usePageMetadata";
 import { useEffect, useState, useMemo } from "react";
 import { Edit, Trash2, Copy, ExternalLink, Eye, EyeOff } from "lucide-react";
 import { Snowflake, Waves, Bicycle } from "@phosphor-icons/react";
@@ -23,6 +24,10 @@ import { useUserEquipment, useDeleteEquipment, useUpdateEquipmentVisibility } fr
 import { UserEquipment } from "@/types/equipment";
 
 const MyEquipmentPage = () => {
+  usePageMetadata({
+    title: 'My Gear | DemoStoke',
+    description: 'Manage the equipment you have listed on DemoStoke.'
+  });
   const { toast } = useToast();
   const navigate = useNavigate();
   const { isAuthenticated, user } = useAuth();

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,10 +1,15 @@
 
 import { useEffect } from "react";
+import usePageMetadata from "@/hooks/usePageMetadata";
 import { Link, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { MapPin } from "lucide-react";
 
 const NotFound = () => {
+  usePageMetadata({
+    title: 'Page Not Found | DemoStoke',
+    description: 'The page you are looking for does not exist.'
+  });
   const location = useLocation();
 
   useEffect(() => {

--- a/src/pages/PrivatePartyPage.tsx
+++ b/src/pages/PrivatePartyPage.tsx
@@ -1,5 +1,6 @@
 
 import { useEffect } from "react";
+import usePageMetadata from "@/hooks/usePageMetadata";
 import { useParams, Link } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -40,6 +41,10 @@ const privateParties: { [key: string]: PrivateParty } = {
 };
 
 const PrivatePartyPage = () => {
+  usePageMetadata({
+    title: 'Private Party | DemoStoke',
+    description: 'Join or learn more about this private party on DemoStoke.'
+  });
   const { partyId } = useParams<{ partyId: string }>();
   const party = partyId ? privateParties[partyId] : null;
 

--- a/src/pages/RealUserProfilePage.tsx
+++ b/src/pages/RealUserProfilePage.tsx
@@ -1,5 +1,6 @@
 
 import { useEffect } from "react";
+import usePageMetadata from "@/hooks/usePageMetadata";
 import { useParams } from "react-router-dom";
 import { useUserProfile } from "@/hooks/useUserProfile";
 import { useUserStats } from "@/hooks/useUserStats";
@@ -18,6 +19,10 @@ import { UserProfileNotFound } from "@/components/profile/UserProfileNotFound";
 import type { UserProfile } from "@/types";
 
 const RealUserProfilePage = () => {
+  usePageMetadata({
+    title: 'User Profile | DemoStoke',
+    description: 'View rider profiles and their listed gear on DemoStoke.'
+  });
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);

--- a/src/pages/SearchResultsPage.tsx
+++ b/src/pages/SearchResultsPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import usePageMetadata from "@/hooks/usePageMetadata";
 import { useSearchParams } from "react-router-dom";
 import { searchEquipmentWithNLP, getEquipmentData } from "@/services/searchService";
 import { AISearchResult } from "@/services/equipment/aiSearchService";
@@ -14,6 +15,10 @@ import { useMockData } from "@/hooks/useMockData";
 import { useEquipmentWithDynamicDistance } from "@/hooks/useEquipmentWithDynamicDistance";
 
 const SearchResultsPage = () => {
+  usePageMetadata({
+    title: 'Search Results | DemoStoke',
+    description: 'Find gear near you with DemoStoke search.'
+  });
   const [searchParams, setSearchParams] = useSearchParams();
   const query = searchParams.get("q") || "";
   const [results, setResults] = useState<AISearchResult[]>([]);

--- a/src/pages/ShopPage.tsx
+++ b/src/pages/ShopPage.tsx
@@ -1,5 +1,6 @@
 
 import { useEffect } from "react";
+import usePageMetadata from "@/hooks/usePageMetadata";
 import { useParams, Link } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -59,6 +60,10 @@ const shops: { [key: string]: Shop; } = {
 };
 
 const ShopPage = () => {
+  usePageMetadata({
+    title: 'Shop | DemoStoke',
+    description: 'View shop details and available gear on DemoStoke.'
+  });
   const { shopId } = useParams<{ shopId: string; }>();
   const shop = shopId ? shops[shopId] : null;
 

--- a/src/pages/SignInPage.tsx
+++ b/src/pages/SignInPage.tsx
@@ -1,5 +1,6 @@
 
 import { useState } from "react";
+import usePageMetadata from "@/hooks/usePageMetadata";
 import { useNavigate, Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import {
@@ -17,6 +18,10 @@ import { MapPin } from "lucide-react";
 import HCaptcha from "@/components/HCaptcha";
 
 const SignInPage = () => {
+  usePageMetadata({
+    title: 'Sign In | DemoStoke',
+    description: 'Access your DemoStoke account.'
+  });
   const navigate = useNavigate();
   const { login } = useAuth();
 

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -1,5 +1,6 @@
 
 import { useState } from "react";
+import usePageMetadata from "@/hooks/usePageMetadata";
 import { useNavigate, Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import {
@@ -17,6 +18,10 @@ import { MapPin } from "lucide-react";
 import HCaptcha from "@/components/HCaptcha";
 
 const SignUpPage = () => {
+  usePageMetadata({
+    title: 'Sign Up | DemoStoke',
+    description: 'Create your DemoStoke account.'
+  });
   const navigate = useNavigate();
   const { signup, isLoading } = useAuth();
 

--- a/src/pages/UserProfilePage.tsx
+++ b/src/pages/UserProfilePage.tsx
@@ -1,5 +1,6 @@
 
 import { useEffect, useState } from "react";
+import usePageMetadata from "@/hooks/usePageMetadata";
 import { useNavigate } from "react-router-dom";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/helpers";
@@ -13,6 +14,10 @@ import { PasswordChangeSection } from "@/components/profile/PasswordChangeSectio
 import { HeroImageSection } from "@/components/profile/HeroImageSection";
 
 const UserProfilePage = () => {
+  usePageMetadata({
+    title: 'My Profile | DemoStoke',
+    description: 'Manage your DemoStoke profile settings.'
+  });
   const { user, isAuthenticated, isLoading } = useAuth();
   const navigate = useNavigate();
   const { toast } = useToast();


### PR DESCRIPTION
## Summary
- add `usePageMetadata` hook for updating `<head>` tags
- apply metadata to every page
- include JSON-LD schema for blog posts

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*
- `npm run build` *(fails: `vite` not found)*
- `npx tsc --noEmit` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_6864687c9a54832085e682a6c853e5b3