### PR TITLE
Add Guides category and pop-up surf guide

### DIFF
--- a/src/lib/blog/guidesPosts.ts
+++ b/src/lib/blog/guidesPosts.ts
@@ -1,0 +1,49 @@
+import { BlogPost } from './types';
+
+export const guidesPosts: BlogPost[] = [
+  {
+    id: 'how-to-pop-up-on-a-surfboard',
+    title: 'How to Pop Up on a Surfboard: Step-by-Step Guide',
+    excerpt: 'Master the pop-up technique with this detailed walkthrough so you can get to your feet quickly and confidently.',
+    content: `The pop-up is the moment where paddling ends and surfing begins. Done correctly, it launches you from laying down to riding with balance and control.
+
+    "The pop-up is a quick transition from prone to standing. Arch your back, press your hands flat on the deck, and in one swift movement bring your feet underneath you to land in surf stance" ([SurferToday](https://www.surfertoday.com/surfing/how-to-pop-up-on-a-surfboard)).
+
+**Preparation**
+
+- Start with your board pointed toward the beach and paddle hard to match the wave's speed.
+- Keep your eyes forward and your body centered over the board.
+
+**Hand Placement**
+
+- Place your palms flat on the board beside your chest, fingers spread for stability.
+- Keep your elbows tucked in to maximize power.
+
+**The Pop-Up Motion**
+
+- Push your upper body up as though doing a quick push-up.
+- In the same motion, slide or jump your feet under your body.
+- Land with knees bent and your feet roughly shoulder-width apart.
+
+**Stance and Balance**
+
+- Keep your back knee bent and your front foot angled slightly toward the nose.
+- Stay low with your weight centered to maintain control as the board accelerates.
+
+**Common Mistakes**
+
+- Looking down at your feet instead of ahead down the line.
+- Trying to stand in stages instead of one swift movement.
+- Placing your hands too far forward, causing the board to stall.
+
+Practice the pop-up on land before heading into the water, and remember that fluidity comes with repetition. With time, you’ll move from wobbly first attempts to confident takeoffs on any wave.`,
+    category: 'guides',
+    publishedAt: '2025-07-10',
+    readTime: 5,
+    heroImage: 'https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=1200&q=80',
+    thumbnail: 'https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=800&q=80',
+    tags: ['guides', 'surfing', 'pop up', 'technique', 'beginner'],
+    author: 'Generative AI',
+    authorId: 'generative-ai'
+  }
+];

--- a/src/lib/blog/index.ts
+++ b/src/lib/blog/index.ts
@@ -5,6 +5,7 @@ import { surfboardsPosts } from './surfboardsPosts';
 import { mountainBikesPosts } from './mountainBikesPosts';
 import { gearReviewsPosts } from './gearReviewsPosts';
 import { storiesThatStokePosts } from './storiesThatStokePosts';
+import { guidesPosts } from './guidesPosts';
 
 export type { BlogPost };
 
@@ -14,5 +15,6 @@ export const blogPosts: BlogPost[] = [
   ...surfboardsPosts,
   ...mountainBikesPosts,
   ...gearReviewsPosts,
-  ...storiesThatStokePosts
+  ...storiesThatStokePosts,
+  ...guidesPosts
 ].sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime());

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -48,7 +48,8 @@ const BlogPage = () => {
     { label: "Skis", value: "skis" },
     { label: "Surfboards", value: "surfboards" },
     { label: "Mountain Bikes", value: "mountain bikes" },
-    { label: "Stories That Stoke", value: "stories that stoke" }
+    { label: "Stories That Stoke", value: "stories that stoke" },
+    { label: "Guides", value: "guides" }
   ];
 
   const handleSearch = async (query?: string, filter?: string) => {
@@ -133,7 +134,8 @@ const BlogPage = () => {
       skis: "bg-lime-300 text-gray-900 hover:bg-lime-400",
       surfboards: "bg-lime-300 text-gray-900 hover:bg-lime-400",
       "mountain bikes": "bg-lime-300 text-gray-900 hover:bg-lime-400",
-      "stories that stoke": "bg-fuchsia-500 text-gray-900 hover:bg-fuchsia-600"
+      "stories that stoke": "bg-fuchsia-500 text-gray-900 hover:bg-fuchsia-600",
+      guides: "bg-sky-500 text-white hover:bg-sky-600"
     };
     return colors[category as keyof typeof colors] || "bg-gray-100 text-gray-800 hover:bg-gray-200";
   };

--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -84,7 +84,8 @@ const BlogPostPage = () => {
       skis: "bg-lime-300 text-gray-900 hover:bg-lime-400",
       surfboards: "bg-lime-300 text-gray-900 hover:bg-lime-400",
       "mountain bikes": "bg-lime-300 text-gray-900 hover:bg-lime-400",
-      "stories that stoke": "bg-fuchsia-500 text-gray-900 hover:bg-fuchsia-600"
+      "stories that stoke": "bg-fuchsia-500 text-gray-900 hover:bg-fuchsia-600",
+      guides: "bg-sky-500 text-white hover:bg-sky-600"
     };
     return colors[category as keyof typeof colors] || "bg-gray-100 text-gray-800 hover:bg-gray-200";
   };


### PR DESCRIPTION
## Summary
- add Guides category to blog filters
- style Guides with a sky color in blog pages
- include Guides category in blog post index
- write a new post about how to pop up on a surfboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68655c6f6bc8832089036b0ea02e0c4d