### PR TITLE
Filter Similar Equipment by distance

### DIFF
--- a/src/hooks/useSimilarEquipment.ts
+++ b/src/hooks/useSimilarEquipment.ts
@@ -2,21 +2,48 @@
 import { useQuery } from "@tanstack/react-query";
 import { Equipment } from "@/types";
 import { getEquipmentData } from "@/services/equipment/equipmentDataService";
+import { calculateDistance, isValidCoordinate } from "@/utils/distanceCalculation";
 
-export const useSimilarEquipment = (category: string, excludeId: string) => {
+export const useSimilarEquipment = (
+  category: string,
+  excludeId: string,
+  lat?: number,
+  lng?: number
+) => {
   return useQuery({
-    queryKey: ['similarEquipment', category, excludeId],
+    queryKey: ['similarEquipment', category, excludeId, lat, lng],
     queryFn: async (): Promise<Equipment[]> => {
-      console.log(`🔍 Fetching similar equipment for category: ${category}, excluding ID: ${excludeId}`);
-      
+      console.log(
+        `🔍 Fetching similar equipment for category: ${category}, excluding ID: ${excludeId}`
+      );
+
       // Get all equipment data based on app settings (mock or real)
       const allEquipment = await getEquipmentData();
-      
-      // Filter by category and exclude current item
-      const similarEquipment = allEquipment
-        .filter(item => item.category === category && item.id !== excludeId)
-        .slice(0, 3); // Limit to 3 items for the sidebar
-      
+
+      // Filter by category and exclude current item first
+      let similarEquipment = allEquipment.filter(
+        (item) => item.category === category && item.id !== excludeId
+      );
+
+      // If we have valid coordinates for the current item, further filter by distance
+      if (isValidCoordinate(lat, lng)) {
+        similarEquipment = similarEquipment.filter((item) => {
+          if (!isValidCoordinate(item.location?.lat, item.location?.lng)) {
+            return false;
+          }
+          const distance = calculateDistance(
+            lat as number,
+            lng as number,
+            item.location!.lat,
+            item.location!.lng
+          );
+          return distance <= 50; // only include equipment within 50 miles
+        });
+      }
+
+      // Limit to 3 items for the sidebar
+      similarEquipment = similarEquipment.slice(0, 3);
+
       console.log(`✅ Found ${similarEquipment.length} similar equipment items`);
       return similarEquipment;
     },

--- a/src/pages/EquipmentDetailPage.tsx
+++ b/src/pages/EquipmentDetailPage.tsx
@@ -122,7 +122,9 @@ const EquipmentDetailPage = () => {
   const currentEquipment = equipmentForDisplayDb || equipmentForDisplayMock;
   const { data: similarEquipmentFromDb, isLoading: similarLoading } = useSimilarEquipment(
     currentEquipment?.category || '',
-    currentEquipment?.id || ''
+    currentEquipment?.id || '',
+    currentEquipment?.location?.lat,
+    currentEquipment?.location?.lng
   );
 
   // Use real similar equipment data, fallback to empty array


### PR DESCRIPTION
## Summary
- filter `useSimilarEquipment` results by radius of 50 miles
- pass equipment location to `useSimilarEquipment`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68669f832c78832092a65b75e13c169a