### PR TITLE
Add user preference for AI search

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -38,7 +38,8 @@ const HeroSection = () => {
   const handleSearch = (e?: React.FormEvent) => {
     if (e) e.preventDefault();
     if (searchQuery.trim()) {
-      navigate(`/search?q=${encodeURIComponent(searchQuery.trim())}`);
+      const search = new URLSearchParams({ q: searchQuery.trim() }).toString();
+      navigate(`/search?${search}`);
     }
   };
 

--- a/src/components/SearchDialog.tsx
+++ b/src/components/SearchDialog.tsx
@@ -35,8 +35,9 @@ const SearchDialog = ({ isOpen, onClose }: SearchDialogProps) => {
     setIsLoading(true);
 
     try {
-      // Perform the search
-      navigate(`/search?q=${encodeURIComponent(query)}`);
+      // Perform the search using consistent query param formatting
+      const search = new URLSearchParams({ q: query }).toString();
+      navigate(`/search?${search}`);
       onClose();
     } catch (error) {
       console.error("Search error:", error);

--- a/src/components/admin/GlobalSearchSettings.tsx
+++ b/src/components/admin/GlobalSearchSettings.tsx
@@ -1,0 +1,71 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { useSearchPreference, useUpdateSearchPreference } from "@/hooks/useSearchPreference";
+import { useToast } from "@/hooks/use-toast";
+import { useEffect, useState } from "react";
+
+const GlobalSearchSettings = () => {
+  const { data: preference } = useSearchPreference();
+  const updatePreference = useUpdateSearchPreference();
+  const { toast } = useToast();
+
+  const [enabled, setEnabled] = useState(true);
+
+  useEffect(() => {
+    if (preference) {
+      setEnabled(preference.use_ai_search);
+    }
+  }, [preference]);
+
+  const handleToggle = async (checked: boolean) => {
+    try {
+      setEnabled(checked);
+      await updatePreference.mutateAsync(checked);
+      toast({
+        title: "Settings Updated",
+        description: `AI search is now ${checked ? 'enabled' : 'disabled'} for all users.`,
+      });
+    } catch (error) {
+      console.error('Error updating settings:', error);
+      toast({
+        title: "Error",
+        description: "Failed to update settings. Please try again.",
+        variant: "destructive"
+      });
+      // revert toggle on error
+      setEnabled(prev => !prev);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Global Search Settings</CardTitle>
+        <CardDescription>
+          Control the search engine used throughout the application
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5">
+            <Label htmlFor="ai-search-toggle" className="text-base">
+              Use AI Search
+            </Label>
+            <div className="text-sm text-muted-foreground">
+              Toggle GPT-powered search on or off
+            </div>
+          </div>
+          <Switch
+            id="ai-search-toggle"
+            checked={enabled}
+            onCheckedChange={handleToggle}
+            disabled={updatePreference.isPending}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default GlobalSearchSettings;

--- a/src/hooks/useAppSettings.ts
+++ b/src/hooks/useAppSettings.ts
@@ -11,23 +11,28 @@ export const useAppSettings = () => {
       const { data, error } = await supabase
         .from('app_settings')
         .select('setting_key, setting_value')
-        .eq('setting_key', 'show_mock_data');
+        .in('setting_key', ['show_mock_data', 'use_ai_search']);
 
       if (error) {
         console.error('❌ Error fetching app settings:', error);
         console.log('🔄 Using default fallback values');
-        return { 
-          show_mock_data: true
+        return {
+          show_mock_data: true,
+          use_ai_search: true
         };
       }
 
       const settings = {
-        show_mock_data: true // default
+        show_mock_data: true, // default
+        use_ai_search: true
       };
 
       data?.forEach(setting => {
         if (setting.setting_key === 'show_mock_data') {
           settings.show_mock_data = setting.setting_value === true;
+        }
+        if (setting.setting_key === 'use_ai_search') {
+          settings.use_ai_search = setting.setting_value === true;
         }
       });
       
@@ -44,24 +49,36 @@ export const useUpdateAppSettings = () => {
   const { isAdmin } = useIsAdmin();
 
   return useMutation({
-    mutationFn: async (settings: { showMockData?: boolean }) => {
+    mutationFn: async (settings: { showMockData?: boolean; useAISearch?: boolean }) => {
       if (!isAdmin) {
         throw new Error('Only admins can update app settings');
       }
 
       console.log('🔧 Admin updating app settings:', settings);
 
-      const updates = [];
+      const updates = [] as Promise<any>[];
 
       if (settings.showMockData !== undefined) {
         updates.push(
           supabase
             .from('app_settings')
-            .update({ 
+            .update({
               setting_value: settings.showMockData,
               updated_at: new Date().toISOString()
             })
             .eq('setting_key', 'show_mock_data')
+        );
+      }
+
+      if (settings.useAISearch !== undefined) {
+        updates.push(
+          supabase
+            .from('app_settings')
+            .update({
+              setting_value: settings.useAISearch,
+              updated_at: new Date().toISOString()
+            })
+            .eq('setting_key', 'use_ai_search')
         );
       }
 

--- a/src/hooks/useSearchPreference.ts
+++ b/src/hooks/useSearchPreference.ts
@@ -1,0 +1,22 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getUseAISearchPreference, setUseAISearchPreference } from "@/services/userPreferencesService";
+
+export const useSearchPreference = () => {
+  return useQuery({
+    queryKey: ["aiSearchPreference"],
+    queryFn: async () => ({ use_ai_search: await getUseAISearchPreference() }),
+    staleTime: 30 * 1000,
+  });
+};
+
+export const useUpdateSearchPreference = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (value: boolean) => {
+      await setUseAISearchPreference(value);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["aiSearchPreference"] });
+    },
+  });
+};

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -369,6 +369,7 @@ export type Database = {
           created_at: string | null
           id: string
           show_mock_data: boolean | null
+          use_ai_search: boolean | null
           updated_at: string | null
           user_id: string | null
         }
@@ -376,6 +377,7 @@ export type Database = {
           created_at?: string | null
           id?: string
           show_mock_data?: boolean | null
+          use_ai_search?: boolean | null
           updated_at?: string | null
           user_id?: string | null
         }
@@ -383,6 +385,7 @@ export type Database = {
           created_at?: string | null
           id?: string
           show_mock_data?: boolean | null
+          use_ai_search?: boolean | null
           updated_at?: string | null
           user_id?: string | null
         }

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -6,6 +6,7 @@ import ManualUserCreationSection from "@/components/admin/ManualUserCreationSect
 import ImageUploadSection from "@/components/admin/ImageUploadSection";
 import VideoUploadSection from "@/components/admin/VideoUploadSection";
 import DataDisplaySettings from "@/components/admin/DataDisplaySettings";
+import GlobalSearchSettings from "@/components/admin/GlobalSearchSettings";
 import GeocodingRecoverySection from "@/components/admin/GeocodingRecoverySection";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -60,6 +61,7 @@ const AdminPage = () => {
         </TabsContent>
 
         <TabsContent value="settings" className="space-y-6">
+          <GlobalSearchSettings />
           <DataDisplaySettings />
         </TabsContent>
 

--- a/src/services/equipment/aiSearchService.ts
+++ b/src/services/equipment/aiSearchService.ts
@@ -71,7 +71,7 @@ export const searchWithAI = async (query: string, equipmentData: Equipment[], us
 };
 
 // Fallback to the original search logic if AI fails
-const fallbackSearch = (query: string, equipmentData: Equipment[]): AISearchResult[] => {
+export const fallbackSearch = (query: string, equipmentData: Equipment[]): AISearchResult[] => {
   console.log('🔄 Using fallback search logic');
 
   const lowerQuery = query.toLowerCase();

--- a/src/services/equipment/appSettingsService.ts
+++ b/src/services/equipment/appSettingsService.ts
@@ -26,3 +26,29 @@ export const getShowMockDataSetting = async (): Promise<boolean> => {
     return true; // Default to mock data if error
   }
 };
+
+// Get global app setting for AI search usage
+export const getUseAISearchSetting = async (): Promise<boolean> => {
+  try {
+    console.log('🔍 Checking global app setting for use_ai_search...');
+    const { data, error } = await supabase
+      .from('app_settings')
+      .select('setting_value')
+      .eq('setting_key', 'use_ai_search')
+      .single();
+
+    if (error) {
+      console.error('❌ Error fetching app setting:', error);
+      console.log('🔄 Defaulting to AI search due to error');
+      return true;
+    }
+
+    const useAI = data?.setting_value === true;
+    console.log('✅ Global app setting use_ai_search:', useAI);
+    return useAI;
+  } catch (error) {
+    console.error('❌ Exception fetching app setting:', error);
+    console.log('🔄 Defaulting to AI search due to exception');
+    return true;
+  }
+};

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -1,11 +1,14 @@
 
 import { Equipment } from "@/types";
 import { getEquipmentData } from "./equipment/equipmentDataService";
-import { searchWithAI, AISearchResult } from "./equipment/aiSearchService";
+import { searchWithAI, fallbackSearch, AISearchResult } from "./equipment/aiSearchService";
+import { getUseAISearchPreference } from "./userPreferencesService";
 
 // AI-enhanced search function with location support
 export const searchEquipmentWithNLP = async (query: string, userLocation?: { lat: number; lng: number }): Promise<AISearchResult[]> => {
   console.log(`🔍 Starting AI-enhanced search for query: "${query}"`);
+
+  const useAISearch = await getUseAISearchPreference();
   
   // Get the appropriate dataset based on global setting
   const equipmentData = await getEquipmentData();
@@ -16,6 +19,13 @@ export const searchEquipmentWithNLP = async (query: string, userLocation?: { lat
     return [];
   }
   
+  if (!useAISearch) {
+    console.log('🤖 AI search disabled - using fallback search');
+    const results = fallbackSearch(query, equipmentData);
+    console.log(`✅ Fallback search completed. Found ${results.length} results`);
+    return results;
+  }
+
   // Use AI-powered search with location
   const results = await searchWithAI(query, equipmentData, userLocation);
   console.log(`✅ AI search completed. Found ${results.length} results`);

--- a/src/services/userPreferencesService.ts
+++ b/src/services/userPreferencesService.ts
@@ -1,0 +1,49 @@
+import { supabase } from "@/integrations/supabase/client";
+
+// Fetch the AI search preference for the current user
+export const getUseAISearchPreference = async (): Promise<boolean> => {
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    const userId = user?.id;
+    if (!userId) {
+      return true; // default when not logged in
+    }
+
+    const { data, error } = await supabase
+      .from('user_preferences')
+      .select('use_ai_search')
+      .eq('user_id', userId)
+      .single();
+
+    if (error) {
+      console.error('❌ Error fetching user preference:', error);
+      return true;
+    }
+
+    return data?.use_ai_search ?? true;
+  } catch (error) {
+    console.error('❌ Exception fetching user preference:', error);
+    return true;
+  }
+};
+
+// Update or insert the AI search preference for the current user
+export const setUseAISearchPreference = async (useAI: boolean): Promise<void> => {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user?.id) {
+    throw new Error('User not authenticated');
+  }
+
+  const { error } = await supabase
+    .from('user_preferences')
+    .upsert({
+      user_id: user.id,
+      use_ai_search: useAI,
+      updated_at: new Date().toISOString()
+    }, { onConflict: 'user_id' });
+
+  if (error) {
+    console.error('❌ Error updating user preference:', error);
+    throw error;
+  }
+};

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -66,6 +66,7 @@ export interface Database {
           id: string;
           user_id: string;
           show_mock_data: boolean;
+          use_ai_search: boolean;
           created_at: string;
           updated_at: string;
         };
@@ -73,6 +74,7 @@ export interface Database {
           id?: string;
           user_id: string;
           show_mock_data?: boolean;
+          use_ai_search?: boolean;
           created_at?: string;
           updated_at?: string;
         };
@@ -80,6 +82,7 @@ export interface Database {
           id?: string;
           user_id?: string;
           show_mock_data?: boolean;
+          use_ai_search?: boolean;
           created_at?: string;
           updated_at?: string;
         };

--- a/supabase/migrations/20250705160000-b557c102-adc6-4f36-9fe4-f1ed4db02737.sql
+++ b/supabase/migrations/20250705160000-b557c102-adc6-4f36-9fe4-f1ed4db02737.sql
@@ -1,0 +1,3 @@
+-- Add default setting for AI search
+INSERT INTO public.app_settings (setting_key, setting_value)
+VALUES ('use_ai_search', 'true'::jsonb);

--- a/supabase/migrations/20250705161000-add-use-ai-search-to-user-preferences.sql
+++ b/supabase/migrations/20250705161000-add-use-ai-search-to-user-preferences.sql
@@ -1,0 +1,6 @@
+-- Add column for AI search preference
+ALTER TABLE public.user_preferences
+ADD COLUMN IF NOT EXISTS use_ai_search boolean NOT NULL DEFAULT true;
+
+-- Initialize existing rows with default value
+UPDATE public.user_preferences SET use_ai_search = true WHERE use_ai_search IS NULL;


### PR DESCRIPTION
## Summary
- persist AI search toggle per user
- fetch and update preference via new hooks
- check preference in search service
- update Supabase types and migration
- standardize search URL formatting with `URLSearchParams`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686925cc018883208bdb5b79938a0ca0