### PR TITLE
Add location parsing to search services

### DIFF
--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -1,12 +1,18 @@
 
-import { Equipment } from "@/types";
 import { getEquipmentData } from "./equipment/equipmentDataService";
 import { searchWithAI, fallbackSearch, AISearchResult } from "./equipment/aiSearchService";
 import { getUseAISearchSetting } from "./equipment/appSettingsService";
+import { parseQueryForLocation } from "@/utils/queryParsing";
+import { isValidCoordinate, calculateDistance } from "@/utils/distanceCalculation";
 
 // AI-enhanced search function with location support
-export const searchEquipmentWithNLP = async (query: string, userLocation?: { lat: number; lng: number }): Promise<AISearchResult[]> => {
+export const searchEquipmentWithNLP = async (
+  query: string,
+  userLocation?: { lat: number; lng: number }
+): Promise<AISearchResult[]> => {
   console.log(`🔍 Starting AI-enhanced search for query: "${query}"`);
+
+  const { baseQuery, location, nearMe } = parseQueryForLocation(query);
 
   const useAISearch = await getUseAISearchSetting();
   
@@ -19,17 +25,57 @@ export const searchEquipmentWithNLP = async (query: string, userLocation?: { lat
     return [];
   }
   
+  let results: AISearchResult[];
+
   if (!useAISearch) {
     console.log('🤖 AI search disabled - using fallback search');
-    const results = fallbackSearch(query, equipmentData);
-    console.log(`✅ Fallback search completed. Found ${results.length} results`);
-    return results;
+    results = fallbackSearch(baseQuery, equipmentData);
+  } else {
+    // Use AI-powered search with cleaned query
+    results = await searchWithAI(baseQuery, equipmentData, userLocation);
   }
 
-  // Use AI-powered search with location
-  const results = await searchWithAI(query, equipmentData, userLocation);
-  console.log(`✅ AI search completed. Found ${results.length} results`);
-  
+  console.log(`✅ Search completed. Found ${results.length} results`);
+
+  // Filter by explicit location after "in"
+  if (location) {
+    const locLower = location.toLowerCase();
+    const locationSynonyms: Record<string, string[]> = {
+      hawaii: ['hi'],
+      california: ['ca'],
+      'new york': ['ny'],
+      colorado: ['co'],
+      oregon: ['or'],
+      washington: ['wa']
+    };
+
+    const locTerms = [locLower, ...(locationSynonyms[locLower] || [])];
+
+    results = results.filter(item => {
+      const address = item.location?.address?.toLowerCase() || '';
+      return locTerms.some(term => address.includes(term));
+    });
+  }
+
+  // If no explicit location or "near me", sort by distance when possible
+  if (!location && !nearMe && isValidCoordinate(userLocation?.lat, userLocation?.lng)) {
+    results = [...results].sort((a, b) => {
+      const distA = calculateDistance(
+        userLocation!.lat,
+        userLocation!.lng,
+        a.location.lat,
+        a.location.lng
+      );
+      const distB = calculateDistance(
+        userLocation!.lat,
+        userLocation!.lng,
+        b.location.lat,
+        b.location.lng
+      );
+      return distA - distB;
+    });
+  }
+
   return results;
 };
 

--- a/src/utils/queryParsing.ts
+++ b/src/utils/queryParsing.ts
@@ -1,0 +1,29 @@
+export interface ParsedQuery {
+  baseQuery: string;
+  location?: string;
+  nearMe: boolean;
+}
+
+export const parseQueryForLocation = (query: string): ParsedQuery => {
+  const lower = query.toLowerCase();
+  const nearMe = lower.includes('near me');
+
+  // Extract part after " in " if present
+  const inMatch = query.match(/\bin\s+([^]+)/i);
+  let location: string | undefined;
+  let baseQuery = query;
+  if (inMatch) {
+    location = inMatch[1].trim();
+    baseQuery = query.slice(0, inMatch.index).trim();
+  }
+
+  if (nearMe) {
+    baseQuery = baseQuery.replace(/near me/ig, '').trim();
+  }
+
+  return {
+    baseQuery: baseQuery.trim(),
+    location,
+    nearMe,
+  };
+};


### PR DESCRIPTION
## Summary
- parse search queries to extract location info
- filter AI and fallback search results using location fragments
- sort by distance when no explicit location is provided
- default sort by distance if query has no location in Search Results page
- gather browser location whenever needed

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a125187008320af770fb04c772ec3