### PR TITLE
Add breadcrumbs to blog post page

### DIFF
--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -107,7 +107,9 @@ const BlogPostPage = () => {
           <article>
             {/* Article Header */}
             <header className="mb-8">
-              <div className="flex items-center justify-between mb-4">
+              <div
+                className="flex flex-col items-start gap-2 mb-4 lg:flex-row lg:items-center lg:justify-between"
+              >
                 <Breadcrumbs
                   items={[
                     { label: "Blog", path: "/blog" },


### PR DESCRIPTION
## Summary
- remove the Back to Blog overlay button from BlogPostPage
- introduce Breadcrumbs on BlogPostPage matching gear detail style
- position breadcrumbs opposite the category badge and date

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686a959a2cd483209f3ea6cbfacc27fa