### PR TITLE
Improve tag-based related gear

### DIFF
--- a/src/hooks/useRelatedGear.ts
+++ b/src/hooks/useRelatedGear.ts
@@ -1,72 +1,65 @@
 import { useQuery } from "@tanstack/react-query";
 import { Equipment } from "@/types";
-import { searchEquipmentWithNLP } from "@/services/searchService";
+import { getEquipmentData } from "@/services/equipment/equipmentDataService";
 
-export const useRelatedGear = (tags: Array<string>) => {
+// Fetch gear related to the provided tags. If a tag matches an equipment
+// category (e.g. "surfboards" or "mountain bikes"), gear from that category is
+// prioritized. Otherwise, tags are matched against gear names. If no gear is
+// found from tags, a final fallback filters by the blog post category.
+export const useRelatedGear = (tags: Array<string>, category?: string) => {
   return useQuery({
-    queryKey: ['relatedGear', tags],
+    queryKey: ["relatedGear", tags, category],
     queryFn: async (): Promise<Equipment[]> => {
-      if (!tags) return [];
+      if ((!tags || tags.length === 0) && !category) return [];
 
-      console.log(`🔍 Searching for gear related to blog post: "${tags}"`);
-
-      // Extract key terms from the blog title for better search
-      const searchQuery = extractSearchTerms(tags.join(" "));
-      console.log(`🔍 Extracted search terms: "${searchQuery}"`);
+      console.log(
+        `🔍 Searching for gear related to tags: "${tags.join(", ")}"`
+      );
 
       try {
-        // Use the existing AI-enhanced search
-        const results = await searchEquipmentWithNLP(searchQuery);
+        const allEquipment = await getEquipmentData();
 
-        // Convert AISearchResult[] to Equipment[] and limit to 2 items
-        const equipment = results.map(result => ({
-          id: result.id,
-          name: result.name,
-          category: result.category,
-          description: result.description,
-          price_per_day: result.price_per_day,
-          rating: result.rating,
-          review_count: result.review_count || 0,
-          image_url: result.image_url,
-          images: result.images,
-          owner: result.owner,
-          location: result.location,
-          distance: 0, // Default distance for related gear
-          specifications: result.specifications,
-          availability: {
-            available: true, // Default to available for related gear display
-            nextAvailableDate: undefined
-          },
-          pricing_options: [] // Default empty array for pricing options
-        })).slice(0, 4);
+        const tagsLower = tags.map((t) => t.toLowerCase());
+        const tagSlugs = tagsLower.map((t) => t.replace(/\s+/g, "-"));
 
-        console.log(`✅ Found ${equipment.length} related gear items`);
-        return equipment;
+        const categoryMatches: Equipment[] = [];
+        const nameMatches: Equipment[] = [];
+
+        for (const item of allEquipment) {
+          const itemCategory = item.category.toLowerCase();
+          const nameLower = item.name.toLowerCase();
+
+          const isCategoryMatch = tagSlugs.some((tag) => tag === itemCategory);
+          if (isCategoryMatch) {
+            categoryMatches.push(item);
+            continue;
+          }
+
+          const hasTagInName = tagsLower.some((tag) => nameLower.includes(tag));
+          if (hasTagInName) {
+            nameMatches.push(item);
+          }
+        }
+
+        let related = [...categoryMatches, ...nameMatches];
+
+        if (related.length === 0 && category) {
+          const categorySlug = category.toLowerCase().replace(/\s+/g, "-");
+          related = allEquipment.filter(
+            (item) => item.category.toLowerCase() === categorySlug
+          );
+        }
+
+        related = related.slice(0, 4);
+
+        console.log(`✅ Found ${related.length} related gear items`);
+        return related;
       } catch (error) {
         console.error('❌ Error searching for related gear:', error);
         return [];
       }
     },
-    enabled: !!tags,
+    enabled: tags.length > 0 || !!category,
     staleTime: 1000 * 60 * 10, // Cache for 10 minutes
   });
-};
-
-// Extract meaningful search terms from tags
-const extractSearchTerms = (tag: string): string => {
-  // Convert to lowercase and remove common words
-  const commonWords = [
-    'the', 'a', 'an', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for', 'of', 'with', 'by',
-    'review', 'guide', 'tips', 'how', 'best', 'top', 'ultimate', 'complete', 'beginner',
-    'advanced', 'pro', 'vs', 'versus', '2024', '2023', 'new', 'latest'
-  ];
-
-  // Split title into words and filter out common words
-  const words = tag.toLowerCase()
-    .replace(/[^\w\s-]/g, ' ') // Replace punctuation except hyphens with spaces
-    .split(/\s+/)
-    .filter(word => word.length > 2 && !commonWords.includes(word));
-
-  // Join the meaningful words back together
-  return words.join(' '); // Limit to first 5 meaningful words
 };

--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -33,8 +33,11 @@ const BlogPostPage = () => {
       : undefined
   });
 
-  // Fetch related gear based on the blog post title
-  const { data: relatedGear, isLoading: isLoadingRelatedGear } = useRelatedGear(post?.tags || []);
+  // Fetch related gear based on post tags with a category fallback
+  const {
+    data: relatedGear,
+    isLoading: isLoadingRelatedGear,
+  } = useRelatedGear(post?.tags || [], post?.category);
 
   console.log("Post ID:", slug);
 


### PR DESCRIPTION
## Summary
- update related gear hook to use category if tag search finds no matches
- update BlogPostPage to pass post category for fallback

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ac67592bc832082892329e97a2675