### PR TITLE
Fix duplicate images in gear carousels

### DIFF
--- a/src/services/equipment/equipmentDataService.ts
+++ b/src/services/equipment/equipmentDataService.ts
@@ -4,70 +4,22 @@ import { Equipment } from "@/types";
 import { convertSupabaseToEquipment } from "./equipmentConverter";
 import { fetchEquipmentImages } from "@/utils/multipleImageHandling";
 
-// Smart deduplication that handles same content with different URLs (original vs WebP)
+// Deduplicate image URLs, ignoring any query parameters
 const deduplicateImages = (imageUrls: string[]): string[] => {
   const seen = new Set<string>();
-  const result: string[] = [];
-  
+  const unique: string[] = [];
+
   for (const url of imageUrls) {
-    // Extract meaningful parts of the URL for comparison
-    // This handles cases where the same image exists as original and WebP converted versions
-    const urlParts = url.split('/');
-    const fileName = urlParts[urlParts.length - 1];
-    
-    // Create a key based on the base filename (without extension) and equipment ID
-    // This will match both original and converted versions of the same image
-    const baseFileName = fileName.replace(/\.(jpg|jpeg|png|webp)$/i, '');
-    const equipmentIdMatch = url.match(/equipment(?:_images)?\/([^\/]+)/);
-    const equipmentId = equipmentIdMatch ? equipmentIdMatch[1] : '';
-    
-    // Create a composite key that identifies the same image regardless of format
-    const imageKey = `${equipmentId}-${baseFileName}`;
-    
-    // For WebP images, also check if there's a timestamp-based pattern that might indicate conversion
-    let isDuplicate = false;
-    
-    // Check if this image is a duplicate based on our smart logic
-    for (const seenKey of seen) {
-      // If we have the same equipment ID and similar base filename, it's likely a duplicate
-      if (seenKey.startsWith(equipmentId) && imageKey.startsWith(equipmentId)) {
-        // Additional check: if one URL contains 'webp-images' and another doesn't,
-        // and they have similar timestamps or patterns, they're likely the same image
-        const isCurrentWebP = url.includes('/webp-images/');
-        const seenUrl = result.find(u => {
-          const seenParts = u.split('/');
-          const seenFileName = seenParts[seenParts.length - 1];
-          const seenBaseFileName = seenFileName.replace(/\.(jpg|jpeg|png|webp)$/i, '');
-          return seenKey.includes(seenBaseFileName);
-        });
-        
-        if (seenUrl) {
-          const isSeenWebP = seenUrl.includes('/webp-images/');
-          
-          // If one is WebP and the other isn't, they might be the same image
-          if (isCurrentWebP !== isSeenWebP) {
-            // Prefer the WebP version (better compression)
-            if (isCurrentWebP) {
-              // Replace the non-WebP version with the WebP version
-              const indexToReplace = result.findIndex(u => u === seenUrl);
-              if (indexToReplace !== -1) {
-                result[indexToReplace] = url;
-              }
-            }
-            isDuplicate = true;
-            break;
-          }
-        }
-      }
-    }
-    
-    if (!isDuplicate && !seen.has(imageKey)) {
-      seen.add(imageKey);
-      result.push(url);
+    // Normalize by removing query string so transformed URLs are treated equally
+    const normalized = url.split('?')[0];
+
+    if (!seen.has(normalized)) {
+      seen.add(normalized);
+      unique.push(url);
     }
   }
-  
-  return result;
+
+  return unique;
 };
 
 export const fetchEquipmentFromSupabase = async (): Promise<Equipment[]> => {


### PR DESCRIPTION
## Summary
- clean up carousel image list creation by deduplicating URLs in `equipmentDataService`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686caf6674bc83209539d5c20d1b246d