### PR TITLE
Use equipment_images only for gear cards

### DIFF
--- a/src/components/EquipmentCard.tsx
+++ b/src/components/EquipmentCard.tsx
@@ -1,10 +1,15 @@
-
 import { Link } from "react-router-dom";
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { StarIcon, StoreIcon, UsersIcon, EditIcon } from "lucide-react";
-import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from "@/components/ui/carousel";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/components/ui/carousel";
 import { getCategoryDisplayName } from "@/helpers";
 import { Equipment } from "@/types";
 import { useAuth } from "@/contexts/auth";
@@ -16,9 +21,12 @@ interface EquipmentCardProps {
 
 const EquipmentCard = ({ equipment }: EquipmentCardProps) => {
   const { user } = useAuth();
-  
+
   // Debug logging
-  console.log(`Equipment ${equipment.name} subcategory:`, equipment.subcategory);
+  console.log(
+    `Equipment ${equipment.name} subcategory:`,
+    equipment.subcategory,
+  );
 
   // Determine if this is from a shop or private party based on owner
   const isShop = equipment.owner.shopId;
@@ -31,12 +39,9 @@ const EquipmentCard = ({ equipment }: EquipmentCardProps) => {
     ? `/shop/${equipment.owner.shopId}`
     : `/user-profile/${equipment.owner.id}`;
 
-  // Handle both single image_url and multiple images array - ensure we always have an array
-  const images = equipment.images && equipment.images.length > 0
-    ? equipment.images
-    : equipment.image_url
-      ? [equipment.image_url]
-      : [];
+  // Use images array from equipment_images table
+  const images =
+    equipment.images && equipment.images.length > 0 ? equipment.images : [];
 
   const hasMultipleImages = images.length > 1;
   const hasImages = images.length > 0;
@@ -76,17 +81,12 @@ const EquipmentCard = ({ equipment }: EquipmentCardProps) => {
 
         {/* Subcategory badge in upper left */}
         {equipment.subcategory && (
-          <Badge
-            className="absolute top-2 left-2 z-20 bg-white text-gray-900 border shadow-sm"
-          >
+          <Badge className="absolute top-2 left-2 z-20 bg-white text-gray-900 border shadow-sm">
             {equipment.subcategory}
           </Badge>
         )}
 
-        <Badge
-          className="absolute top-2 right-2 z-10"
-          variant="secondary"
-        >
+        <Badge className="absolute top-2 right-2 z-10" variant="secondary">
           {getCategoryDisplayName(equipment.category)}
         </Badge>
 
@@ -109,11 +109,17 @@ const EquipmentCard = ({ equipment }: EquipmentCardProps) => {
             <span>{equipment.rating}</span>
           </div>
         </div>
-        <p className="text-sm text-muted-foreground mb-3 line-clamp-2">{equipment.description}</p>
+        <p className="text-sm text-muted-foreground mb-3 line-clamp-2">
+          {equipment.description}
+        </p>
         <div className="flex items-center justify-between mb-2">
           <div>
-            <p className="text-sm font-medium">${equipment.price_per_day}/day</p>
-            <p className="text-xs text-muted-foreground">{equipment.location.address}</p>
+            <p className="text-sm font-medium">
+              ${equipment.price_per_day}/day
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {equipment.location.address}
+            </p>
           </div>
           <div className="flex items-center gap-1 text-xs text-muted-foreground">
             <DistanceDisplay equipment={equipment} showUnit={false} />

--- a/src/components/equipment-detail/AddOnSelection.tsx
+++ b/src/components/equipment-detail/AddOnSelection.tsx
@@ -1,4 +1,3 @@
-
 import React from "react";
 import { Card } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -13,7 +12,12 @@ interface AddOnSelectionProps {
   onAddOnToggle: (addOn: AddOn, checked: boolean) => void;
 }
 
-const AddOnSelection = ({ equipment, addOns, selectedAddOns, onAddOnToggle }: AddOnSelectionProps) => {
+const AddOnSelection = ({
+  equipment,
+  addOns,
+  selectedAddOns,
+  onAddOnToggle,
+}: AddOnSelectionProps) => {
   const formatCurrency = (amount: number): string => {
     return parseFloat(amount.toFixed(2)).toFixed(2);
   };
@@ -29,29 +33,40 @@ const AddOnSelection = ({ equipment, addOns, selectedAddOns, onAddOnToggle }: Ad
           <div className="w-16 h-16 overflow-hidden rounded-md mb-2">
             <AspectRatio ratio={1}>
               <img
-                src={equipment.image_url}
+                src={equipment.images?.[0]}
                 alt={equipment.name}
                 className="w-full h-full object-cover"
               />
             </AspectRatio>
           </div>
-          <span className="text-xs text-center font-medium">{equipment.name}</span>
+          <span className="text-xs text-center font-medium">
+            {equipment.name}
+          </span>
         </div>
 
         {/* Add-on items */}
         {addOns.map((addOn) => {
-          const isSelected = selectedAddOns.some(item => item.name === addOn.name);
+          const isSelected = selectedAddOns.some(
+            (item) => item.name === addOn.name,
+          );
 
           return (
-            <div key={addOn.name} className="relative flex flex-col items-center w-24">
+            <div
+              key={addOn.name}
+              className="relative flex flex-col items-center w-24"
+            >
               <div className="absolute -left-2 z-10">
                 <Checkbox
                   checked={isSelected}
-                  onCheckedChange={(checked) => onAddOnToggle(addOn, checked === true)}
+                  onCheckedChange={(checked) =>
+                    onAddOnToggle(addOn, checked === true)
+                  }
                   className="absolute"
                 />
               </div>
-              <div className={`w-16 h-16 overflow-hidden rounded-md mb-2 ${!isSelected ? 'opacity-50' : ''}`}>
+              <div
+                className={`w-16 h-16 overflow-hidden rounded-md mb-2 ${!isSelected ? "opacity-50" : ""}`}
+              >
                 <AspectRatio ratio={1}>
                   <img
                     src={addOn.imageUrl}
@@ -60,10 +75,14 @@ const AddOnSelection = ({ equipment, addOns, selectedAddOns, onAddOnToggle }: Ad
                   />
                 </AspectRatio>
               </div>
-              <span className={`text-xs text-center font-medium ${!isSelected ? 'text-gray-400' : ''}`}>
+              <span
+                className={`text-xs text-center font-medium ${!isSelected ? "text-gray-400" : ""}`}
+              >
                 {addOn.name}
               </span>
-              <span className="text-xs text-muted-foreground">${formatCurrency(addOn.price_per_day)}/day</span>
+              <span className="text-xs text-muted-foreground">
+                ${formatCurrency(addOn.price_per_day)}/day
+              </span>
             </div>
           );
         })}

--- a/src/components/equipment-detail/FrequentlyPairedTogether.tsx
+++ b/src/components/equipment-detail/FrequentlyPairedTogether.tsx
@@ -1,8 +1,13 @@
-
 import { useState } from "react";
 import { AddOn, calculateTotalPrice, getAddOnsForCategory } from "@/lib/addOns";
 import { Equipment } from "@/types";
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
 import { AspectRatio } from "@/components/ui/aspect-ratio";
@@ -18,17 +23,22 @@ const FrequentlyPairedTogether = ({
   equipment,
   onDemoRequest,
   selectedRange,
-  isDateSelected
+  isDateSelected,
 }: FrequentlyBoughtTogetherProps) => {
   const addOns = getAddOnsForCategory(equipment.category);
   const [selectedAddOns, setSelectedAddOns] = useState<AddOn[]>([...addOns]);
-  const totalPrice = calculateTotalPrice(equipment.price_per_day, selectedAddOns);
+  const totalPrice = calculateTotalPrice(
+    equipment.price_per_day,
+    selectedAddOns,
+  );
 
   const handleAddOnToggle = (addOn: AddOn, checked: boolean) => {
     if (checked) {
       setSelectedAddOns([...selectedAddOns, addOn]);
     } else {
-      setSelectedAddOns(selectedAddOns.filter(item => item.name !== addOn.name));
+      setSelectedAddOns(
+        selectedAddOns.filter((item) => item.name !== addOn.name),
+      );
     }
   };
 
@@ -47,29 +57,40 @@ const FrequentlyPairedTogether = ({
             <div className="w-16 h-16 overflow-hidden rounded-md mb-2">
               <AspectRatio ratio={1}>
                 <img
-                  src={equipment.image_url}
+                  src={equipment.images?.[0]}
                   alt={equipment.name}
                   className="w-full h-full object-cover"
                 />
               </AspectRatio>
             </div>
-            <span className="text-xs text-center font-medium">{equipment.name}</span>
+            <span className="text-xs text-center font-medium">
+              {equipment.name}
+            </span>
           </div>
 
           {/* Add-on items */}
           {addOns.map((addOn) => {
-            const isSelected = selectedAddOns.some(item => item.name === addOn.name);
+            const isSelected = selectedAddOns.some(
+              (item) => item.name === addOn.name,
+            );
 
             return (
-              <div key={addOn.name} className="relative flex flex-col items-center w-24">
+              <div
+                key={addOn.name}
+                className="relative flex flex-col items-center w-24"
+              >
                 <div className="absolute -left-2 z-10">
                   <Checkbox
                     checked={isSelected}
-                    onCheckedChange={(checked) => handleAddOnToggle(addOn, checked === true)}
+                    onCheckedChange={(checked) =>
+                      handleAddOnToggle(addOn, checked === true)
+                    }
                     className="absolute"
                   />
                 </div>
-                <div className={`w-16 h-16 overflow-hidden rounded-md mb-2 ${!isSelected ? 'opacity-50' : ''}`}>
+                <div
+                  className={`w-16 h-16 overflow-hidden rounded-md mb-2 ${!isSelected ? "opacity-50" : ""}`}
+                >
                   <AspectRatio ratio={1}>
                     <img
                       src={addOn.imageUrl}
@@ -78,10 +99,14 @@ const FrequentlyPairedTogether = ({
                     />
                   </AspectRatio>
                 </div>
-                <span className={`text-xs text-center font-medium ${!isSelected ? 'text-gray-400' : ''}`}>
+                <span
+                  className={`text-xs text-center font-medium ${!isSelected ? "text-gray-400" : ""}`}
+                >
                   {addOn.name}
                 </span>
-                <span className="text-xs text-muted-foreground">${addOn.price_per_day}/day</span>
+                <span className="text-xs text-muted-foreground">
+                  ${addOn.price_per_day}/day
+                </span>
               </div>
             );
           })}

--- a/src/components/equipment-detail/RelatedGear.tsx
+++ b/src/components/equipment-detail/RelatedGear.tsx
@@ -1,9 +1,14 @@
-
 import { Link } from "react-router-dom";
 import { StarIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from "@/components/ui/carousel";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/components/ui/carousel";
 import { Equipment } from "@/types";
 
 interface RelatedGearProps {
@@ -21,13 +26,16 @@ const RelatedGear = ({ relatedGear }: RelatedGearProps) => {
       <h4 className="text-lg font-semibold mb-4">Related Gear</h4>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {relatedGear.map((item) => {
-          // Handle both single image_url and multiple images array
-          const images = item.images || (item.image_url ? [item.image_url] : []);
+          // Use images array from equipment_images table
+          const images = item.images || [];
           const hasMultipleImages = images.length > 1;
           const hasImages = images.length > 0;
 
           return (
-            <Card key={item.id} className="overflow-hidden hover:shadow-md transition-shadow">
+            <Card
+              key={item.id}
+              className="overflow-hidden hover:shadow-md transition-shadow"
+            >
               <div className="flex h-24">
                 <div className="w-1/3 relative">
                   {hasImages ? (
@@ -49,7 +57,7 @@ const RelatedGear = ({ relatedGear }: RelatedGearProps) => {
                       </Carousel>
                     ) : (
                       <img
-                        src={images[0] || item.image_url}
+                        src={images[0]}
                         alt={item.name}
                         className="h-full w-full object-cover"
                       />
@@ -62,14 +70,18 @@ const RelatedGear = ({ relatedGear }: RelatedGearProps) => {
                 </div>
                 <div className="w-2/3 p-3 flex flex-col justify-between">
                   <div>
-                    <h5 className="font-medium text-sm mb-1 line-clamp-2">{item.name}</h5>
+                    <h5 className="font-medium text-sm mb-1 line-clamp-2">
+                      {item.name}
+                    </h5>
                     <div className="flex items-center text-xs mb-1">
                       <StarIcon className="h-3 w-3 text-yellow-500 fill-yellow-500 mr-1" />
                       <span>{item.rating}</span>
                     </div>
                   </div>
                   <div className="flex justify-between items-center">
-                    <span className="text-xs text-muted-foreground">${item.price_per_day}/day</span>
+                    <span className="text-xs text-muted-foreground">
+                      ${item.price_per_day}/day
+                    </span>
                     <Button size="sm" asChild className="text-xs h-6">
                       <Link to={`/equipment/${item.id}`}>View</Link>
                     </Button>

--- a/src/components/equipment-detail/SimilarEquipment.tsx
+++ b/src/components/equipment-detail/SimilarEquipment.tsx
@@ -1,9 +1,14 @@
-
 import { Link } from "react-router-dom";
 import { StarIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from "@/components/ui/carousel";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/components/ui/carousel";
 import { Equipment } from "@/types";
 
 interface SimilarEquipmentProps {
@@ -21,8 +26,8 @@ const SimilarEquipment = ({ similarEquipment }: SimilarEquipmentProps) => {
       <h3 className="font-medium mb-3">Similar Equipment</h3>
       <div className="space-y-4">
         {similarEquipment.map((item) => {
-          // Handle both single image_url and multiple images array
-          const images = item.images || (item.image_url ? [item.image_url] : []);
+          // Use images array from equipment_images table
+          const images = item.images || [];
           const hasMultipleImages = images.length > 1;
 
           return (
@@ -47,7 +52,7 @@ const SimilarEquipment = ({ similarEquipment }: SimilarEquipmentProps) => {
                     </Carousel>
                   ) : (
                     <img
-                      src={images[0] || item.image_url}
+                      src={images[0]}
                       alt={item.name}
                       className="h-full w-full object-cover"
                     />
@@ -55,14 +60,18 @@ const SimilarEquipment = ({ similarEquipment }: SimilarEquipmentProps) => {
                 </div>
                 <div className="w-2/3 p-3 flex flex-col justify-between">
                   <div>
-                    <h4 className="font-medium text-sm mb-1 truncate">{item.name}</h4>
+                    <h4 className="font-medium text-sm mb-1 truncate">
+                      {item.name}
+                    </h4>
                     <div className="flex items-center text-xs">
                       <StarIcon className="h-3 w-3 text-yellow-500 fill-yellow-500 mr-1" />
                       <span>{item.rating}</span>
                     </div>
                   </div>
                   <div className="flex justify-between items-center">
-                    <span className="text-xs text-muted-foreground">${item.price_per_day}/day</span>
+                    <span className="text-xs text-muted-foreground">
+                      ${item.price_per_day}/day
+                    </span>
                     <Button size="sm" asChild className="text-xs h-6">
                       <Link to={`/equipment/${item.id}`}>View</Link>
                     </Button>

--- a/src/components/profile/UserEquipmentGrid.tsx
+++ b/src/components/profile/UserEquipmentGrid.tsx
@@ -1,11 +1,16 @@
-
 import { Link } from "react-router-dom";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { StarIcon } from "lucide-react";
-import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from "@/components/ui/carousel";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/components/ui/carousel";
 
 import type { UserEquipment } from "@/types/equipment";
 
@@ -19,7 +24,12 @@ interface UserEquipmentGridProps {
   isMockUser?: boolean;
 }
 
-export const UserEquipmentGrid = ({ userEquipment, stats, isLoading, isMockUser }: UserEquipmentGridProps) => {
+export const UserEquipmentGrid = ({
+  userEquipment,
+  stats,
+  isLoading,
+  isMockUser,
+}: UserEquipmentGridProps) => {
   if (isLoading && !isMockUser) {
     return (
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -39,19 +49,17 @@ export const UserEquipmentGrid = ({ userEquipment, stats, isLoading, isMockUser 
 
   if (!userEquipment || userEquipment.length === 0) {
     return (
-      <p className="text-muted-foreground dark:text-white">No gear currently listed.</p>
+      <p className="text-muted-foreground dark:text-white">
+        No gear currently listed.
+      </p>
     );
   }
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
       {userEquipment.map((item: UserEquipment) => {
-        // Handle both single image_url and multiple images array - ensure we always have an array
-        const images = item.images && item.images.length > 0
-          ? item.images
-          : item.image_url
-            ? [item.image_url]
-            : [];
+        // Use images array from equipment_images table
+        const images = item.images && item.images.length > 0 ? item.images : [];
 
         const hasMultipleImages = images.length > 1;
         const hasImages = images.length > 0;
@@ -92,7 +100,9 @@ export const UserEquipmentGrid = ({ userEquipment, stats, isLoading, isMockUser 
             <CardContent className="p-4">
               <div className="flex justify-between items-start mb-2">
                 <h3 className="font-medium dark:text-white">{item.name}</h3>
-                <span className="font-medium text-primary">${item.price_per_day}/day</span>
+                <span className="font-medium text-primary">
+                  ${item.price_per_day}/day
+                </span>
               </div>
               <p className="text-xs text-muted-foreground line-clamp-2 mb-3">
                 {item.description}
@@ -101,10 +111,14 @@ export const UserEquipmentGrid = ({ userEquipment, stats, isLoading, isMockUser 
                 {stats && stats.totalReviews > 0 ? (
                   <div className="flex items-center text-xs">
                     <StarIcon className="h-3 w-3 text-yellow-500 fill-yellow-500 mr-1" />
-                    <span>{stats.averageRating} ({stats.totalReviews})</span>
+                    <span>
+                      {stats.averageRating} ({stats.totalReviews})
+                    </span>
                   </div>
                 ) : (
-                  <div className="text-xs text-muted-foreground">No reviews yet</div>
+                  <div className="text-xs text-muted-foreground">
+                    No reviews yet
+                  </div>
                 )}
                 <Button size="sm" asChild className="text-xs h-8">
                   <Link to={`/equipment/${item.id}`}>View Details</Link>

--- a/src/hooks/useEquipmentById.ts
+++ b/src/hooks/useEquipmentById.ts
@@ -5,29 +5,31 @@ import { fetchEquipmentImages } from "@/utils/multipleImageHandling";
 
 export const useEquipmentById = (id: string) => {
   return useQuery({
-    queryKey: ['equipment', id],
+    queryKey: ["equipment", id],
     queryFn: async (): Promise<Equipment | null> => {
       if (!id) {
-        throw new Error('Equipment ID is required');
+        throw new Error("Equipment ID is required");
       }
 
-      console.log('=== FETCHING EQUIPMENT BY ID ===');
-      console.log('Equipment ID:', id);
+      console.log("=== FETCHING EQUIPMENT BY ID ===");
+      console.log("Equipment ID:", id);
 
       const { data, error } = await supabase
-        .from('equipment')
-        .select(`
+        .from("equipment")
+        .select(
+          `
           *,
           profiles!equipment_user_id_fkey (
             name,
             avatar_url
           )
-        `)
-        .eq('id', id)
+        `,
+        )
+        .eq("id", id)
         .single();
 
       if (error) {
-        console.error('Error fetching equipment:', error);
+        console.error("Error fetching equipment:", error);
         throw error;
       }
 
@@ -36,22 +38,22 @@ export const useEquipmentById = (id: string) => {
       }
 
       // Log the raw data to see what we're getting from the database
-      console.log('Raw equipment data from database:', data);
-      console.log('Profile data:', data.profiles);
-      console.log('Damage deposit from database:', data.damage_deposit);
-      console.log('Primary image URL:', data.image_url);
-      console.log('Price per day:', data.price_per_day);
-      console.log('Price per hour:', data.price_per_hour);
-      console.log('Price per week:', data.price_per_week);
+      console.log("Raw equipment data from database:", data);
+      console.log("Profile data:", data.profiles);
+      console.log("Damage deposit from database:", data.damage_deposit);
+      console.log("Primary image URL:", data.image_url);
+      console.log("Price per day:", data.price_per_day);
+      console.log("Price per hour:", data.price_per_hour);
+      console.log("Price per week:", data.price_per_week);
 
       // Fetch additional images from equipment_images table
-      console.log('Fetching additional images for equipment ID:', data.id);
+      console.log("Fetching additional images for equipment ID:", data.id);
       const additionalImages = await fetchEquipmentImages(data.id);
-      console.log('Additional images fetched:', additionalImages);
+      console.log("Additional images fetched:", additionalImages);
 
-      // Create combined images array
-      const allImages = additionalImages.length > 0 ? additionalImages : (data.image_url ? [data.image_url] : []);
-      console.log('Final combined images array:', allImages);
+      // Use images from equipment_images table only
+      const allImages = additionalImages;
+      console.log("Images array:", allImages);
 
       // Convert to Equipment type with proper location mapping
       const equipment = {
@@ -59,19 +61,29 @@ export const useEquipmentById = (id: string) => {
         name: data.name,
         category: data.category,
         subcategory: data.subcategory,
-        description: data.description || '',
-        image_url: data.image_url || '',
+        description: data.description || "",
+        image_url: data.image_url || "",
         images: allImages,
         price_per_day: Number(data.price_per_day),
-        price_per_hour: data.price_per_hour !== null && data.price_per_hour !== undefined ? Number(data.price_per_hour) : undefined,
-        price_per_week: data.price_per_week !== null && data.price_per_week !== undefined ? Number(data.price_per_week) : undefined,
+        price_per_hour:
+          data.price_per_hour !== null && data.price_per_hour !== undefined
+            ? Number(data.price_per_hour)
+            : undefined,
+        price_per_week:
+          data.price_per_week !== null && data.price_per_week !== undefined
+            ? Number(data.price_per_week)
+            : undefined,
         rating: Number(data.rating || 0),
         review_count: data.review_count || 0,
-        damage_deposit: data.damage_deposit ? Number(data.damage_deposit) : undefined,
+        damage_deposit: data.damage_deposit
+          ? Number(data.damage_deposit)
+          : undefined,
         owner: {
           id: data.user_id,
-          name: data.profiles?.name || 'Owner',
-          imageUrl: data.profiles?.avatar_url || 'https://api.dicebear.com/6.x/avataaars/svg?seed=' + data.user_id,
+          name: data.profiles?.name || "Owner",
+          imageUrl:
+            data.profiles?.avatar_url ||
+            "https://api.dicebear.com/6.x/avataaars/svg?seed=" + data.user_id,
           rating: 4.8,
           reviewCount: 15,
           responseRate: 95,
@@ -79,28 +91,29 @@ export const useEquipmentById = (id: string) => {
         location: {
           lat: Number(data.location_lat || 0),
           lng: Number(data.location_lng || 0),
-          address: data.location_address || '', // Changed from zip to address
+          address: data.location_address || "", // Changed from zip to address
         },
         distance: 2.5,
         specifications: {
-          size: data.size || '',
-          weight: data.weight || '',
-          material: data.material || '',
-          suitable: data.suitable_skill_level || '',
+          size: data.size || "",
+          weight: data.weight || "",
+          material: data.material || "",
+          suitable: data.suitable_skill_level || "",
         },
         availability: {
-          available: data.status === 'available',
+          available: data.status === "available",
         },
         // Remove pricing_options dependency
         pricing_options: [],
-        status: data.status || 'available',
+        status: data.status || "available",
         created_at: data.created_at,
         updated_at: data.updated_at,
-        visible_on_map: data.visible_on_map !== undefined ? data.visible_on_map : true,
+        visible_on_map:
+          data.visible_on_map !== undefined ? data.visible_on_map : true,
       };
 
-      console.log('Mapped equipment object:', equipment);
-      console.log('=== END EQUIPMENT FETCH ===');
+      console.log("Mapped equipment object:", equipment);
+      console.log("=== END EQUIPMENT FETCH ===");
 
       return equipment;
     },

--- a/src/pages/EquipmentDetailPageDb.tsx
+++ b/src/pages/EquipmentDetailPageDb.tsx
@@ -1,4 +1,3 @@
-
 import { Card } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
@@ -14,7 +13,13 @@ import OwnerCard from "@/components/equipment-detail/OwnerCard";
 import SimilarEquipment from "@/components/equipment-detail/SimilarEquipment";
 import GearImageModal from "@/components/equipment-detail/GearImageModal";
 import ContactInfoModal from "@/components/equipment-detail/ContactInfoModal";
-import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from "@/components/ui/carousel";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/components/ui/carousel";
 import { getCategoryDisplayName } from "@/helpers";
 import { Equipment } from "@/types";
 import React, { useState } from "react";
@@ -44,12 +49,9 @@ const EquipmentDetailPageDb: React.FC<EquipmentDetailPageDbProps> = ({
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
   const [showContactModal, setShowContactModal] = useState(false);
 
-  // Handle both single image_url and multiple images array - ensure we always have an array
-  const images = equipment.images && equipment.images.length > 0
-    ? equipment.images
-    : equipment.image_url
-      ? [equipment.image_url]
-      : [];
+  // Use images array from equipment_images table
+  const images =
+    equipment.images && equipment.images.length > 0 ? equipment.images : [];
 
   const hasMultipleImages = images.length > 1;
   const hasImages = images.length > 0;
@@ -67,7 +69,10 @@ const EquipmentDetailPageDb: React.FC<EquipmentDetailPageDbProps> = ({
       <Breadcrumbs
         items={[
           { label: "Home", path: "/" },
-          { label: getCategoryDisplayName(equipment.category), path: `/explore?category=${equipment.category}` },
+          {
+            label: getCategoryDisplayName(equipment.category),
+            path: `/explore?category=${equipment.category}`,
+          },
           { label: equipment.name, path: `/equipment/${equipment.id}` },
         ]}
       />
@@ -94,7 +99,9 @@ const EquipmentDetailPageDb: React.FC<EquipmentDetailPageDbProps> = ({
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4 overflow-y-auto">
           <div className="bg-white dark:bg-zinc-900 rounded-lg max-w-3xl w-full max-h-[90vh] overflow-y-auto p-6">
             <div className="flex justify-between items-center mb-4">
-              <h2 className="text-2xl font-bold">{waiverCompleted ? "Edit" : "Complete"} Waiver</h2>
+              <h2 className="text-2xl font-bold">
+                {waiverCompleted ? "Edit" : "Complete"} Waiver
+              </h2>
               <Button
                 variant="outline"
                 onClick={() => setShowWaiver(false)}
@@ -200,7 +207,10 @@ const EquipmentDetailPageDb: React.FC<EquipmentDetailPageDbProps> = ({
         <div className="space-y-6">
           {/* Booking Card */}
           <Card className="p-6" ref={bookingCardRef}>
-            <h3 className="text-lg font-semibold mb-4">The ability to book here is coming soon. Please contact {equipment.owner.name}.</h3>
+            <h3 className="text-lg font-semibold mb-4">
+              The ability to book here is coming soon. Please contact{" "}
+              {equipment.owner.name}.
+            </h3>
             <button
               onClick={() => setShowContactModal(true)}
               className="text-primary

--- a/src/pages/EquipmentDetailPageMock.tsx
+++ b/src/pages/EquipmentDetailPageMock.tsx
@@ -1,4 +1,3 @@
-
 import { Card } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
@@ -13,7 +12,13 @@ import PolicyTab from "@/components/equipment-detail/PolicyTab";
 import OwnerCard from "@/components/equipment-detail/OwnerCard";
 import SimilarEquipment from "@/components/equipment-detail/SimilarEquipment";
 import GearImageModal from "@/components/equipment-detail/GearImageModal";
-import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from "@/components/ui/carousel";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/components/ui/carousel";
 import { getCategoryDisplayName } from "@/helpers";
 import { Equipment } from "@/types";
 import React, { useState } from "react";
@@ -42,12 +47,9 @@ const EquipmentDetailPageMock: React.FC<EquipmentDetailPageMockProps> = ({
   const [showImageModal, setShowImageModal] = useState(false);
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
 
-  // Handle both single image_url and multiple images array - ensure we always have an array
-  const images = equipment.images && equipment.images.length > 0
-    ? equipment.images
-    : equipment.image_url
-      ? [equipment.image_url]
-      : [];
+  // Use images array from equipment_images table
+  const images =
+    equipment.images && equipment.images.length > 0 ? equipment.images : [];
 
   const hasMultipleImages = images.length > 1;
   const hasImages = images.length > 0;
@@ -62,7 +64,10 @@ const EquipmentDetailPageMock: React.FC<EquipmentDetailPageMockProps> = ({
       <Breadcrumbs
         items={[
           { label: "Home", path: "/" },
-          { label: getCategoryDisplayName(equipment.category), path: `/explore?category=${equipment.category}` },
+          {
+            label: getCategoryDisplayName(equipment.category),
+            path: `/explore?category=${equipment.category}`,
+          },
           { label: equipment.name, path: `/equipment/${equipment.id}` },
         ]}
       />
@@ -81,7 +86,9 @@ const EquipmentDetailPageMock: React.FC<EquipmentDetailPageMockProps> = ({
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4 overflow-y-auto">
           <div className="bg-white dark:bg-zinc-900 rounded-lg max-w-3xl w-full max-h-[90vh] overflow-y-auto p-6">
             <div className="flex justify-between items-center mb-4">
-              <h2 className="text-2xl font-bold">{waiverCompleted ? "Edit" : "Complete"} Waiver</h2>
+              <h2 className="text-2xl font-bold">
+                {waiverCompleted ? "Edit" : "Complete"} Waiver
+              </h2>
               <Button
                 variant="outline"
                 onClick={() => setShowWaiver(false)}
@@ -108,7 +115,7 @@ const EquipmentDetailPageMock: React.FC<EquipmentDetailPageMockProps> = ({
                   <CarouselContent>
                     {images.map((imageUrl, index) => (
                       <CarouselItem key={index}>
-                        <div 
+                        <div
                           className="cursor-pointer hover:opacity-90 transition-opacity"
                           onClick={() => handleImageClick(index)}
                         >
@@ -125,7 +132,7 @@ const EquipmentDetailPageMock: React.FC<EquipmentDetailPageMockProps> = ({
                   <CarouselNext className="right-2" />
                 </Carousel>
               ) : (
-                <div 
+                <div
                   className="cursor-pointer hover:opacity-90 transition-opacity"
                   onClick={() => handleImageClick(0)}
                 >
@@ -168,7 +175,11 @@ const EquipmentDetailPageMock: React.FC<EquipmentDetailPageMockProps> = ({
               <LocationTab equipment={equipment} />
             </TabsContent>
             <TabsContent value="reviews">
-              <ReviewsTab equipmentId={equipment.id} rating={equipment.rating} reviewCount={equipment.review_count} />
+              <ReviewsTab
+                equipmentId={equipment.id}
+                rating={equipment.rating}
+                reviewCount={equipment.review_count}
+              />
             </TabsContent>
             <TabsContent value="policy">
               <PolicyTab />

--- a/src/pages/GearOwnerProfilePage.tsx
+++ b/src/pages/GearOwnerProfilePage.tsx
@@ -1,4 +1,3 @@
-
 import { useEffect } from "react";
 import usePageMetadata from "@/hooks/usePageMetadata";
 import { useParams } from "react-router-dom";
@@ -6,14 +5,20 @@ import { Link } from "react-router-dom";
 import { mockEquipment, ownerPersonas } from "@/lib/mockData";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { StarIcon, MapPinIcon, CalendarIcon, UsersIcon, GlobeIcon } from "lucide-react";
+import {
+  StarIcon,
+  MapPinIcon,
+  CalendarIcon,
+  UsersIcon,
+  GlobeIcon,
+} from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Separator } from "@/components/ui/separator";
 
 const GearOwnerProfilePage = () => {
   usePageMetadata({
-    title: 'Gear Owner Profile | DemoStoke',
-    description: 'View information about this gear owner on DemoStoke.'
+    title: "Gear Owner Profile | DemoStoke",
+    description: "View information about this gear owner on DemoStoke.",
   });
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -55,10 +60,16 @@ const GearOwnerProfilePage = () => {
               {/* Increased spacing with padding-top instead of margin-top */}
               <div className="pt-16">
                 <div className="flex justify-between items-start">
-                  <div className="max-w-[80%]"> {/* Constrain width to prevent overflow */}
-                    <h1 className="text-2xl font-bold truncate dark:text-white">{owner.name}</h1>
+                  <div className="max-w-[80%]">
+                    {" "}
+                    {/* Constrain width to prevent overflow */}
+                    <h1 className="text-2xl font-bold truncate dark:text-white">
+                      {owner.name}
+                    </h1>
                     {owner.personality && (
-                      <span className={`inline-block text-xs px-2 py-1 rounded-full mt-1 ${personalityBadgeColor}`}>
+                      <span
+                        className={`inline-block text-xs px-2 py-1 rounded-full mt-1 ${personalityBadgeColor}`}
+                      >
                         {owner.personality}
                       </span>
                     )}
@@ -89,9 +100,13 @@ const GearOwnerProfilePage = () => {
                   {owner.website && (
                     <div className="flex items-center">
                       <GlobeIcon className="h-4 w-4 text-slate-500 mr-2 flex-shrink-0" />
-                      <a 
-                        href={owner.website.startsWith('http') ? owner.website : `https://${owner.website}`}
-                        target="_blank" 
+                      <a
+                        href={
+                          owner.website.startsWith("http")
+                            ? owner.website
+                            : `https://${owner.website}`
+                        }
+                        target="_blank"
                         rel="noopener noreferrer"
                         className="text-sm hover:text-primary underline truncate"
                       >
@@ -110,7 +125,8 @@ const GearOwnerProfilePage = () => {
           <Card>
             <CardContent className="p-6">
               <div className="whitespace-pre-line text-sm text-muted-foreground leading-relaxed">
-                {owner.bio || `Hi, I'm ${owner.name.split(" ")[0]}! I love sharing my gear with others and helping them enjoy their adventures. Feel free to reach out if you have any questions!`}
+                {owner.bio ||
+                  `Hi, I'm ${owner.name.split(" ")[0]}! I love sharing my gear with others and helping them enjoy their adventures. Feel free to reach out if you have any questions!`}
               </div>
             </CardContent>
           </Card>
@@ -120,16 +136,20 @@ const GearOwnerProfilePage = () => {
       <Separator className="my-8" />
 
       <div>
-        <h2 className="text-xl font-medium mb-6 dark:text-white">Available Gear</h2>
+        <h2 className="text-xl font-medium mb-6 dark:text-white">
+          Available Gear
+        </h2>
         {ownerEquipment.length === 0 ? (
-          <p className="text-muted-foreground dark:text-white">No gear currently listed.</p>
+          <p className="text-muted-foreground dark:text-white">
+            No gear currently listed.
+          </p>
         ) : (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
             {ownerEquipment.map((item) => (
               <Card key={item.id} className="overflow-hidden">
                 <div className="h-48 overflow-hidden">
                   <img
-                    src={item.image_url}
+                    src={item.images?.[0]}
                     alt={item.name}
                     className="h-full w-full object-cover"
                   />
@@ -137,7 +157,9 @@ const GearOwnerProfilePage = () => {
                 <CardContent className="p-4">
                   <div className="flex justify-between items-start mb-2">
                     <h3 className="font-medium dark:text-white">{item.name}</h3>
-                    <span className="font-medium text-primary">${item.price_per_day}/day</span>
+                    <span className="font-medium text-primary">
+                      ${item.price_per_day}/day
+                    </span>
                   </div>
                   <p className="text-xs text-muted-foreground line-clamp-2 mb-3">
                     {item.description}
@@ -145,9 +167,16 @@ const GearOwnerProfilePage = () => {
                   <div className="flex items-center justify-between mt-2">
                     <div className="flex items-center text-xs">
                       <StarIcon className="h-3 w-3 text-yellow-500 fill-yellow-500 mr-1" />
-                      <span>{item.rating} ({item.review_count})</span>
+                      <span>
+                        {item.rating} ({item.review_count})
+                      </span>
                     </div>
-                    <Button variant="outline" size="sm" asChild className="text-xs h-8">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      asChild
+                      className="text-xs h-8"
+                    >
                       <Link to={`/equipment/${item.id}`}>View Details</Link>
                     </Button>
                   </div>

--- a/src/pages/MyEquipmentPage.tsx
+++ b/src/pages/MyEquipmentPage.tsx
@@ -21,18 +21,28 @@ import {
   DollarSign,
   BarChart3,
 } from "lucide-react";
-import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from "@/components/ui/carousel";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/components/ui/carousel";
 import { Link, useNavigate } from "react-router-dom";
 import { useToast } from "@/hooks/use-toast";
-import { useUserEquipment, useDeleteEquipment, useUpdateEquipmentVisibility } from "@/hooks/useUserEquipment";
+import {
+  useUserEquipment,
+  useDeleteEquipment,
+  useUpdateEquipmentVisibility,
+} from "@/hooks/useUserEquipment";
 import usePageMetadata from "@/hooks/usePageMetadata";
 import { useAuth } from "@/helpers";
 import type { UserEquipment } from "@/types/equipment";
 
 const MyEquipmentPage = () => {
   usePageMetadata({
-    title: 'My Equipment | DemoStoke',
-    description: 'Manage your equipment listings on DemoStoke.'
+    title: "My Equipment | DemoStoke",
+    description: "Manage your equipment listings on DemoStoke.",
   });
 
   const navigate = useNavigate();
@@ -47,7 +57,11 @@ const MyEquipmentPage = () => {
   const updateVisibilityMutation = useUpdateEquipmentVisibility();
 
   const handleDelete = async (equipmentId: string, equipmentName: string) => {
-    if (window.confirm(`Are you sure you want to delete "${equipmentName}"? This action cannot be undone.`)) {
+    if (
+      window.confirm(
+        `Are you sure you want to delete "${equipmentName}"? This action cannot be undone.`,
+      )
+    ) {
       try {
         await deleteEquipmentMutation.mutateAsync(equipmentId);
         toast({
@@ -55,7 +69,7 @@ const MyEquipmentPage = () => {
           description: `${equipmentName} has been successfully deleted.`,
         });
       } catch (error) {
-        console.error('Delete error:', error);
+        console.error("Delete error:", error);
         toast({
           title: "Error",
           description: "Failed to delete equipment. Please try again.",
@@ -65,19 +79,23 @@ const MyEquipmentPage = () => {
     }
   };
 
-  const handleVisibilityToggle = async (equipmentId: string, currentVisibility: boolean, equipmentName: string) => {
+  const handleVisibilityToggle = async (
+    equipmentId: string,
+    currentVisibility: boolean,
+    equipmentName: string,
+  ) => {
     try {
       await updateVisibilityMutation.mutateAsync({
         equipmentId,
-        visible: !currentVisibility
+        visible: !currentVisibility,
       });
 
       toast({
         title: "Visibility Updated",
-        description: `${equipmentName} is now ${!currentVisibility ? 'visible' : 'hidden'} on the map.`,
+        description: `${equipmentName} is now ${!currentVisibility ? "visible" : "hidden"} on the map.`,
       });
     } catch (error) {
-      console.error('Visibility toggle error:', error);
+      console.error("Visibility toggle error:", error);
       toast({
         title: "Error",
         description: "Failed to update visibility. Please try again.",
@@ -91,18 +109,18 @@ const MyEquipmentPage = () => {
       name: equipmentItem.name,
       category: equipmentItem.category,
       description: equipmentItem.description,
-      location_address: equipmentItem.location?.address || '', // Changed from zip to address
-      size: equipmentItem.specifications?.size || '',
-      weight: equipmentItem.specifications?.weight || '',
-      material: equipmentItem.specifications?.material || '',
-      suitable_skill_level: equipmentItem.specifications?.suitable || '',
+      location_address: equipmentItem.location?.address || "", // Changed from zip to address
+      size: equipmentItem.specifications?.size || "",
+      weight: equipmentItem.specifications?.weight || "",
+      material: equipmentItem.specifications?.material || "",
+      suitable_skill_level: equipmentItem.specifications?.suitable || "",
       price_per_day: equipmentItem.price_per_day,
       damage_deposit: equipmentItem.damage_deposit || 0,
-      image_url: equipmentItem.image_url
+      image_url: equipmentItem.image_url,
     };
 
-    sessionStorage.setItem('duplicateGearData', JSON.stringify(duplicateData));
-    navigate('/list-your-gear/add-gear-form');
+    sessionStorage.setItem("duplicateGearData", JSON.stringify(duplicateData));
+    navigate("/list-your-gear/add-gear-form");
   };
 
   if (!user) {
@@ -162,18 +180,24 @@ const MyEquipmentPage = () => {
     );
   }
 
-  const filteredEquipment = equipment?.filter(item => {
-    const matchesSearch = item.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      item.category.toLowerCase().includes(searchTerm.toLowerCase());
-    const matchesCategory = selectedCategory === "all" || item.category === selectedCategory;
-    const matchesVisibility = visibilityFilter === "all" ||
-      (visibilityFilter === "visible" && item.visible_on_map) ||
-      (visibilityFilter === "hidden" && !item.visible_on_map);
+  const filteredEquipment =
+    equipment?.filter((item) => {
+      const matchesSearch =
+        item.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        item.category.toLowerCase().includes(searchTerm.toLowerCase());
+      const matchesCategory =
+        selectedCategory === "all" || item.category === selectedCategory;
+      const matchesVisibility =
+        visibilityFilter === "all" ||
+        (visibilityFilter === "visible" && item.visible_on_map) ||
+        (visibilityFilter === "hidden" && !item.visible_on_map);
 
-    return matchesSearch && matchesCategory && matchesVisibility;
-  }) || [];
+      return matchesSearch && matchesCategory && matchesVisibility;
+    }) || [];
 
-  const categories = [...new Set(equipment?.map(item => item.category) || [])];
+  const categories = [
+    ...new Set(equipment?.map((item) => item.category) || []),
+  ];
 
   return (
     <div className="container mx-auto px-4 py-8">
@@ -218,7 +242,7 @@ const MyEquipmentPage = () => {
                 className="px-3 py-2 border border-input bg-background rounded-md text-sm"
               >
                 <option value="all">All Categories</option>
-                {categories.map(category => (
+                {categories.map((category) => (
                   <option key={category} value={category}>
                     {category.charAt(0).toUpperCase() + category.slice(1)}
                   </option>
@@ -244,8 +268,7 @@ const MyEquipmentPage = () => {
               <p className="text-muted-foreground mb-6">
                 {equipment?.length === 0
                   ? "You haven't added any equipment yet. Start by adding your first item!"
-                  : "No equipment matches your current filters."
-                }
+                  : "No equipment matches your current filters."}
               </p>
               {equipment?.length === 0 && (
                 <Button asChild>
@@ -259,23 +282,26 @@ const MyEquipmentPage = () => {
           ) : (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {filteredEquipment.map((item) => {
-                // Handle both single image_url and multiple images array - ensure we always have an array
-                const images = item.images && item.images.length > 0
-                  ? item.images
-                  : item.image_url
-                    ? [item.image_url]
-                    : [];
+                // Use images array from equipment_images table
+                const images =
+                  item.images && item.images.length > 0 ? item.images : [];
 
                 const hasMultipleImages = images.length > 1;
                 const hasImages = images.length > 0;
 
                 return (
-                  <Card key={item.id} className="group hover:shadow-lg transition-shadow">
+                  <Card
+                    key={item.id}
+                    className="group hover:shadow-lg transition-shadow"
+                  >
                     <CardHeader className="pb-2">
                       <div className="aspect-square relative overflow-hidden rounded-md mb-4">
                         {hasImages ? (
                           hasMultipleImages ? (
-                            <Carousel className="w-full h-full" opts={{ loop: true }}>
+                            <Carousel
+                              className="w-full h-full"
+                              opts={{ loop: true }}
+                            >
                               <CarouselContent>
                                 {images.map((imageUrl, index) => (
                                   <CarouselItem key={index}>
@@ -299,11 +325,20 @@ const MyEquipmentPage = () => {
                           )
                         ) : (
                           <div className="w-full h-full bg-gray-200 flex items-center justify-center">
-                            <span className="text-gray-500">No image available</span>
+                            <span className="text-gray-500">
+                              No image available
+                            </span>
                           </div>
                         )}
                         <div className="absolute top-2 right-2 flex gap-1">
-                          <Badge variant={item.status === 'available' ? 'default' : 'secondary'} className="text-xs">
+                          <Badge
+                            variant={
+                              item.status === "available"
+                                ? "default"
+                                : "secondary"
+                            }
+                            className="text-xs"
+                          >
                             {item.status}
                           </Badge>
                           {!item.visible_on_map && (
@@ -317,7 +352,9 @@ const MyEquipmentPage = () => {
 
                       <div className="space-y-1">
                         <Link to={`/equipment/${item.id}`}>
-                          <CardTitle className="text-lg line-clamp-1 hover:text-primary transition-colors">{item.name}</CardTitle>
+                          <CardTitle className="text-lg line-clamp-1 hover:text-primary transition-colors">
+                            {item.name}
+                          </CardTitle>
                         </Link>
                         <div className="flex items-center justify-between text-sm text-muted-foreground">
                           <span className="capitalize">{item.category}</span>
@@ -343,7 +380,9 @@ const MyEquipmentPage = () => {
                         {/* Location */}
                         <div className="flex items-center gap-1 text-sm text-muted-foreground">
                           <MapPin className="h-3 w-3" />
-                          <span className="line-clamp-1">{item.location.address}</span>
+                          <span className="line-clamp-1">
+                            {item.location.address}
+                          </span>
                         </div>
 
                         {/* Actions */}
@@ -353,7 +392,13 @@ const MyEquipmentPage = () => {
                             <Button
                               variant="ghost"
                               size="sm"
-                              onClick={() => handleVisibilityToggle(item.id, item.visible_on_map, item.name)}
+                              onClick={() =>
+                                handleVisibilityToggle(
+                                  item.id,
+                                  item.visible_on_map,
+                                  item.name,
+                                )
+                              }
                               disabled={updateVisibilityMutation.isPending}
                             >
                               {item.visible_on_map ? (
@@ -372,11 +417,7 @@ const MyEquipmentPage = () => {
                              <Copy className="h-4 w-4" />
                            </Button> */}
 
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              asChild
-                            >
+                            <Button variant="ghost" size="sm" asChild>
                               <Link to={`/edit-gear/${item.id}`}>
                                 <Edit className="h-4 w-4" />
                               </Link>
@@ -411,7 +452,8 @@ const MyEquipmentPage = () => {
           <div className="py-6">
             <h3 className="text-lg font-semibold mb-4">Analytics Dashboard</h3>
             <p className="text-muted-foreground">
-              Here you can view detailed analytics about your equipment listings.
+              Here you can view detailed analytics about your equipment
+              listings.
             </p>
             <Separator className="my-4" />
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -424,7 +466,9 @@ const MyEquipmentPage = () => {
                 </CardHeader>
                 <CardContent>
                   <p className="text-2xl font-bold">0</p>
-                  <p className="text-sm text-muted-foreground">No data available</p>
+                  <p className="text-sm text-muted-foreground">
+                    No data available
+                  </p>
                 </CardContent>
               </Card>
 
@@ -437,7 +481,9 @@ const MyEquipmentPage = () => {
                 </CardHeader>
                 <CardContent>
                   <p className="text-2xl font-bold">0</p>
-                  <p className="text-sm text-muted-foreground">No data available</p>
+                  <p className="text-sm text-muted-foreground">
+                    No data available
+                  </p>
                 </CardContent>
               </Card>
 
@@ -450,13 +496,14 @@ const MyEquipmentPage = () => {
                 </CardHeader>
                 <CardContent>
                   <p className="text-2xl font-bold">$0</p>
-                  <p className="text-sm text-muted-foreground">No data available</p>
+                  <p className="text-sm text-muted-foreground">
+                    No data available
+                  </p>
                 </CardContent>
               </Card>
             </div>
           </div>
         </TabsContent>
-
       </Tabs>
     </div>
   );

--- a/src/services/equipment/equipmentConverter.ts
+++ b/src/services/equipment/equipmentConverter.ts
@@ -1,39 +1,47 @@
-
 import type { Equipment } from "@/types";
 
-export const convertDbEquipmentToFrontend = (dbEquipment: Record<string, unknown>): Equipment => {
-  // Handle images array - prioritize all_images if available, fallback to images, then image_url
+export const convertDbEquipmentToFrontend = (
+  dbEquipment: Record<string, unknown>,
+): Equipment => {
+  // Handle images array - prioritize all_images if available, fallback to images only
   let imagesArray: string[] = [];
-  
+
   if (dbEquipment.all_images && Array.isArray(dbEquipment.all_images)) {
     imagesArray = dbEquipment.all_images;
   } else if (dbEquipment.images && Array.isArray(dbEquipment.images)) {
     imagesArray = dbEquipment.images;
-  } else if (dbEquipment.image_url) {
-    imagesArray = [dbEquipment.image_url as string];
   }
 
   // Ensure we have at least one image for the image_url field
-  const primaryImageUrl = imagesArray.length > 0 ? imagesArray[0] : '';
+  const primaryImageUrl = imagesArray.length > 0 ? imagesArray[0] : "";
 
   return {
     id: dbEquipment.id as string,
     name: dbEquipment.name as string,
     category: dbEquipment.category as string,
     subcategory: dbEquipment.subcategory as string,
-    description: (dbEquipment.description as string) || '',
+    description: (dbEquipment.description as string) || "",
     image_url: primaryImageUrl,
     images: imagesArray, // This will now include all images for carousel functionality
     price_per_day: Number(dbEquipment.price_per_day as number),
-    price_per_hour: dbEquipment.price_per_hour ? Number(dbEquipment.price_per_hour as number) : undefined,
-    price_per_week: dbEquipment.price_per_week ? Number(dbEquipment.price_per_week as number) : undefined,
+    price_per_hour: dbEquipment.price_per_hour
+      ? Number(dbEquipment.price_per_hour as number)
+      : undefined,
+    price_per_week: dbEquipment.price_per_week
+      ? Number(dbEquipment.price_per_week as number)
+      : undefined,
     rating: Number((dbEquipment.rating as number) || 0),
     review_count: (dbEquipment.review_count as number) || 0,
-    damage_deposit: dbEquipment.damage_deposit ? Number(dbEquipment.damage_deposit) : undefined,
+    damage_deposit: dbEquipment.damage_deposit
+      ? Number(dbEquipment.damage_deposit)
+      : undefined,
     owner: {
       id: dbEquipment.user_id as string,
-      name: (dbEquipment.profiles as any)?.name || 'Owner',
-      imageUrl: (dbEquipment.profiles as any)?.avatar_url || 'https://api.dicebear.com/6.x/avataaars/svg?seed=' + dbEquipment.user_id,
+      name: (dbEquipment.profiles as any)?.name || "Owner",
+      imageUrl:
+        (dbEquipment.profiles as any)?.avatar_url ||
+        "https://api.dicebear.com/6.x/avataaars/svg?seed=" +
+          dbEquipment.user_id,
       rating: 4.8,
       reviewCount: 15,
       responseRate: 95,
@@ -41,27 +49,32 @@ export const convertDbEquipmentToFrontend = (dbEquipment: Record<string, unknown
     location: {
       lat: Number((dbEquipment.location_lat as number) || 0),
       lng: Number((dbEquipment.location_lng as number) || 0),
-      address: (dbEquipment.location_address as string) || '', // Changed from zip to address
+      address: (dbEquipment.location_address as string) || "", // Changed from zip to address
     },
     distance: 2.5,
     specifications: {
-      size: (dbEquipment.size as string) || '',
-      weight: (dbEquipment.weight as string) || '',
-      material: (dbEquipment.material as string) || '',
-      suitable: (dbEquipment.suitable_skill_level as string) || '',
+      size: (dbEquipment.size as string) || "",
+      weight: (dbEquipment.weight as string) || "",
+      material: (dbEquipment.material as string) || "",
+      suitable: (dbEquipment.suitable_skill_level as string) || "",
     },
     availability: {
-      available: (dbEquipment.status as string) === 'available',
+      available: (dbEquipment.status as string) === "available",
     },
     pricing_options: [],
-    status: (dbEquipment.status as string) || 'available',
+    status: (dbEquipment.status as string) || "available",
     created_at: dbEquipment.created_at as string,
     updated_at: dbEquipment.updated_at as string,
-    visible_on_map: (dbEquipment.visible_on_map as boolean) !== undefined ? (dbEquipment.visible_on_map as boolean) : true,
+    visible_on_map:
+      (dbEquipment.visible_on_map as boolean) !== undefined
+        ? (dbEquipment.visible_on_map as boolean)
+        : true,
   };
 };
 
 // Export the function with the expected name for backward compatibility
-export const convertSupabaseToEquipment = async (dbEquipment: Record<string, unknown>): Promise<Equipment> => {
+export const convertSupabaseToEquipment = async (
+  dbEquipment: Record<string, unknown>,
+): Promise<Equipment> => {
   return convertDbEquipmentToFrontend(dbEquipment);
 };


### PR DESCRIPTION
## Summary
- fetch only `equipment_images` for all gear data
- drop fallback to `image_url` in card and detail components
- ensure profile pages and explore cards use `equipment_images` array

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686cb5bb3acc83209a98a6137bd9f9db