### PR TITLE
Fix homepage gear images

### DIFF
--- a/src/hooks/useRecentEquipment.ts
+++ b/src/hooks/useRecentEquipment.ts
@@ -54,12 +54,17 @@ export const useRecentEquipment = () => {
 
         // Convert equipment details
         const { convertSupabaseToEquipment } = await import('@/services/equipment/equipmentConverter');
-        
+        const { fetchEquipmentImages } = await import('@/utils/multipleImageHandling');
+
         const equipmentPromises = equipmentData.map(async (item) => {
+          const galleryImages = await fetchEquipmentImages(item.id);
+          const allImages = Array.from(new Set([item.image_url, ...galleryImages].filter(Boolean)));
+
           const flatItem = {
             ...item,
             profile_name: item.profiles?.name,
-            profile_avatar_url: item.profiles?.avatar_url
+            profile_avatar_url: item.profiles?.avatar_url,
+            all_images: allImages,
           };
           return await convertSupabaseToEquipment(flatItem);
         });

--- a/src/hooks/useTrendingEquipment.ts
+++ b/src/hooks/useTrendingEquipment.ts
@@ -69,12 +69,18 @@ export const useTrendingEquipment = () => {
 
         // Convert and sort equipment to maintain trending order
         const { convertSupabaseToEquipment } = await import('@/services/equipment/equipmentConverter');
-        
+        const { fetchEquipmentImages } = await import('@/utils/multipleImageHandling');
+
         const equipmentPromises = equipmentDetails.map(async (item) => {
+          // Fetch any gallery images and combine with the primary image
+          const galleryImages = await fetchEquipmentImages(item.id);
+          const allImages = Array.from(new Set([item.image_url, ...galleryImages].filter(Boolean)));
+
           const flatItem = {
             ...item,
             profile_name: item.profiles?.name,
-            profile_avatar_url: item.profiles?.avatar_url
+            profile_avatar_url: item.profiles?.avatar_url,
+            all_images: allImages,
           };
           return await convertSupabaseToEquipment(flatItem);
         });

--- a/src/services/equipment/equipmentConverter.ts
+++ b/src/services/equipment/equipmentConverter.ts
@@ -3,17 +3,25 @@ import type { Equipment } from "@/types";
 export const convertDbEquipmentToFrontend = (
   dbEquipment: Record<string, unknown>,
 ): Equipment => {
-  // Handle images array - prioritize all_images if available, fallback to images only
+  // Handle images array - prioritize all_images if available, then images, and
+  // finally fall back to the single image_url field if provided. This ensures
+  // cards always have at least one image for the carousel component.
   let imagesArray: string[] = [];
 
   if (dbEquipment.all_images && Array.isArray(dbEquipment.all_images)) {
-    imagesArray = dbEquipment.all_images;
+    imagesArray = dbEquipment.all_images as string[];
   } else if (dbEquipment.images && Array.isArray(dbEquipment.images)) {
-    imagesArray = dbEquipment.images;
+    imagesArray = dbEquipment.images as string[];
+  } else if (typeof dbEquipment.image_url === "string" && dbEquipment.image_url) {
+    imagesArray = [dbEquipment.image_url];
   }
 
-  // Ensure we have at least one image for the image_url field
-  const primaryImageUrl = imagesArray.length > 0 ? imagesArray[0] : "";
+  // Determine the primary image URL, falling back to the image_url field when
+  // no images array exists
+  const primaryImageUrl =
+    imagesArray.length > 0
+      ? imagesArray[0]
+      : (typeof dbEquipment.image_url === "string" ? dbEquipment.image_url : "");
 
   return {
     id: dbEquipment.id as string,


### PR DESCRIPTION
## Summary
- ensure equipment converter uses `image_url` when no image array is available
- add gallery image fetch for trending and recent equipment hooks

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da9a1f79c8320866c5907b0bbe350