### PR TITLE
Fix mountain bike category mapping

### DIFF
--- a/src/utils/equipmentDataPreparation.ts
+++ b/src/utils/equipmentDataPreparation.ts
@@ -1,4 +1,6 @@
 
+import { mapGearTypeToCategory } from "@/utils/gearTypeMapping";
+
 interface PrepareEquipmentDataParams {
   userId?: string;
   gearName: string;
@@ -38,7 +40,7 @@ export const prepareEquipmentData = ({
 
   const equipmentData: Record<string, unknown> = {
     name: gearName,
-    category: gearType,
+    category: mapGearTypeToCategory(gearType),
     description: description,
     image_url: finalImageUrl,
     location_address: address, // Changed from location_zip to location_address


### PR DESCRIPTION
## Summary
- map mountain bikes to the plural category when saving gear

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686dadf4ebf08320a95b31a365a8d14d