### PR TITLE
Update gear URLs to use category and title slugs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,7 +73,7 @@ const App = () => {
                     <Route path="blog/:slug" element={<BlogPostPage />} />
                     <Route path="contact-us" element={<ContactPage />} />
                     <Route path="explore" element={<ExplorePage />} />
-                    <Route path="equipment/:id" element={<EquipmentDetailPage />} />
+                    <Route path=":category/:slug" element={<EquipmentDetailPage />} />
                     <Route path="list-your-gear" element={<ListGearPage />} />
                     <Route path="list-your-gear/add-gear-form" element={<AddGearForm />} />
                     <Route path="list-your-gear/lightspeed-pos" element={<LightspeedPOSPage />} />

--- a/src/components/EquipmentCard.tsx
+++ b/src/components/EquipmentCard.tsx
@@ -13,6 +13,7 @@ import {
 import { getCategoryDisplayName } from "@/helpers";
 import { Equipment } from "@/types";
 import { useAuth } from "@/contexts/auth";
+import { slugify } from "@/utils/slugify";
 import DistanceDisplay from "./DistanceDisplay";
 
 interface EquipmentCardProps {
@@ -140,7 +141,7 @@ const EquipmentCard = ({ equipment }: EquipmentCardProps) => {
 
       <CardFooter className="p-4 pt-0 flex justify-between">
         <Button asChild size="sm">
-          <Link to={`/equipment/${equipment.id}`}>View Details</Link>
+          <Link to={`/${equipment.category}/${slugify(equipment.name)}`}>View Details</Link>
         </Button>
         {isOwner && (
           <Button asChild size="sm" variant="outline">

--- a/src/components/equipment-detail/RelatedGear.tsx
+++ b/src/components/equipment-detail/RelatedGear.tsx
@@ -10,6 +10,7 @@ import {
   CarouselPrevious,
 } from "@/components/ui/carousel";
 import { Equipment } from "@/types";
+import { slugify } from "@/utils/slugify";
 
 interface RelatedGearProps {
   relatedGear: Equipment[];
@@ -83,7 +84,7 @@ const RelatedGear = ({ relatedGear }: RelatedGearProps) => {
                       ${item.price_per_day}/day
                     </span>
                     <Button size="sm" asChild className="text-xs h-6">
-                      <Link to={`/equipment/${item.id}`}>View</Link>
+                      <Link to={`/${item.category}/${slugify(item.name)}`}>View</Link>
                     </Button>
                   </div>
                 </div>

--- a/src/components/equipment-detail/SimilarEquipment.tsx
+++ b/src/components/equipment-detail/SimilarEquipment.tsx
@@ -10,6 +10,7 @@ import {
   CarouselPrevious,
 } from "@/components/ui/carousel";
 import { Equipment } from "@/types";
+import { slugify } from "@/utils/slugify";
 
 interface SimilarEquipmentProps {
   similarEquipment: Equipment[];
@@ -73,7 +74,7 @@ const SimilarEquipment = ({ similarEquipment }: SimilarEquipmentProps) => {
                       ${item.price_per_day}/day
                     </span>
                     <Button size="sm" asChild className="text-xs h-6">
-                      <Link to={`/equipment/${item.id}`}>View</Link>
+                      <Link to={`/${item.category}/${slugify(item.name)}`}>View</Link>
                     </Button>
                   </div>
                 </div>

--- a/src/components/profile/UserEquipmentGrid.tsx
+++ b/src/components/profile/UserEquipmentGrid.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/carousel";
 
 import type { UserEquipment } from "@/types/equipment";
+import { slugify } from "@/utils/slugify";
 
 interface UserEquipmentGridProps {
   userEquipment: UserEquipment[] | undefined;
@@ -121,7 +122,7 @@ export const UserEquipmentGrid = ({
                   </div>
                 )}
                 <Button size="sm" asChild className="text-xs h-8">
-                  <Link to={`/equipment/${item.id}`}>View Details</Link>
+                  <Link to={`/${item.category}/${slugify(item.name)}`}>View Details</Link>
                 </Button>
               </div>
             </CardContent>

--- a/src/hooks/gear-form/useEditGearFormSubmission.ts
+++ b/src/hooks/gear-form/useEditGearFormSubmission.ts
@@ -10,6 +10,7 @@ import { useEditGearFormValidation } from "./useEditGearFormValidation";
 import { useEditGearImageHandling } from "./useEditGearImageHandling";
 import { useEditGearLocationHandling } from "./useEditGearLocationHandling";
 import { useEditGearDatabaseUpdate } from "./useEditGearDatabaseUpdate";
+import { slugify } from "@/utils/slugify";
 
 interface UseEditGearFormSubmissionProps {
   equipment: UserEquipment | null | undefined;
@@ -136,7 +137,7 @@ export const useEditGearFormSubmission = ({
         description: `${gearName} has been successfully updated.`,
       });
 
-      navigate(`/equipment/${equipment!.id}`);
+      navigate(`/${equipment!.category}/${slugify(equipment!.name)}`);
 
     } catch (error) {
       console.error('=== FORM SUBMISSION ERROR ===');
@@ -161,7 +162,7 @@ export const useEditGearFormSubmission = ({
   };
 
   const handleCancel = () => {
-    navigate(`/equipment/${equipment!.id}`);
+    navigate(`/${equipment!.category}/${slugify(equipment!.name)}`);
   };
 
   return {

--- a/src/hooks/gear-form/useMultipleEditGearFormSubmission.ts
+++ b/src/hooks/gear-form/useMultipleEditGearFormSubmission.ts
@@ -8,6 +8,7 @@ import { useEditGearFormValidation } from "./useEditGearFormValidation";
 import { useEditGearLocationHandling } from "./useEditGearLocationHandling";
 import { useEditGearDatabaseUpdate } from "./useEditGearDatabaseUpdate";
 import { uploadMultipleGearImages, updateEquipmentImages } from "@/utils/multipleImageHandling";
+import { slugify } from "@/utils/slugify";
 import type { FormData } from "./types";
 
 interface UseMultipleEditGearFormSubmissionProps {
@@ -171,7 +172,7 @@ export const useMultipleEditGearFormSubmission = ({
         description: `${gearName} has been successfully updated.`,
       });
 
-      navigate(`/equipment/${equipment!.id}`);
+      navigate(`/${equipment!.category}/${slugify(equipment!.name)}`);
 
     } catch (error) {
       console.error('=== FORM SUBMISSION ERROR ===');
@@ -196,7 +197,7 @@ export const useMultipleEditGearFormSubmission = ({
   };
 
   const handleCancel = () => {
-    navigate(`/equipment/${equipment!.id}`);
+    navigate(`/${equipment!.category}/${slugify(equipment!.name)}`);
   };
 
   return {

--- a/src/hooks/useEquipmentBySlug.ts
+++ b/src/hooks/useEquipmentBySlug.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { Equipment } from "@/types";
+import { getEquipmentData } from "@/services/equipment/equipmentDataService";
+import { slugify } from "@/utils/slugify";
+
+export const useEquipmentBySlug = (category: string, slug: string) => {
+  return useQuery({
+    queryKey: ["equipment", category, slug],
+    queryFn: async (): Promise<Equipment | null> => {
+      if (!category || !slug) {
+        throw new Error("Category and slug are required");
+      }
+      const data = await getEquipmentData();
+      const item = data.find(
+        (e) => e.category === category && slugify(e.name) === slug,
+      );
+      return item || null;
+    },
+  });
+};

--- a/src/pages/EquipmentDetailPageDb.tsx
+++ b/src/pages/EquipmentDetailPageDb.tsx
@@ -13,6 +13,7 @@ import OwnerCard from "@/components/equipment-detail/OwnerCard";
 import SimilarEquipment from "@/components/equipment-detail/SimilarEquipment";
 import GearImageModal from "@/components/equipment-detail/GearImageModal";
 import ContactInfoModal from "@/components/equipment-detail/ContactInfoModal";
+import { slugify } from "@/utils/slugify";
 import {
   Carousel,
   CarouselContent,
@@ -82,7 +83,7 @@ const EquipmentDetailPageDb: React.FC<EquipmentDetailPageDbProps> = ({
             label: getCategoryDisplayName(equipment.category),
             path: `/explore?category=${equipment.category}`,
           },
-          { label: equipment.name, path: `/equipment/${equipment.id}` },
+          { label: equipment.name, path: `/${equipment.category}/${slugify(equipment.name)}` },
         ]}
       />
 

--- a/src/pages/EquipmentDetailPageMock.tsx
+++ b/src/pages/EquipmentDetailPageMock.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/carousel";
 import { getCategoryDisplayName } from "@/helpers";
 import { Equipment } from "@/types";
+import { slugify } from "@/utils/slugify";
 import React, { useState } from "react";
 
 interface EquipmentDetailPageMockProps {
@@ -68,7 +69,7 @@ const EquipmentDetailPageMock: React.FC<EquipmentDetailPageMockProps> = ({
             label: getCategoryDisplayName(equipment.category),
             path: `/explore?category=${equipment.category}`,
           },
-          { label: equipment.name, path: `/equipment/${equipment.id}` },
+          { label: equipment.name, path: `/${equipment.category}/${slugify(equipment.name)}` },
         ]}
       />
 

--- a/src/pages/GearOwnerProfilePage.tsx
+++ b/src/pages/GearOwnerProfilePage.tsx
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom";
 import { mockEquipment, ownerPersonas } from "@/lib/mockData";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { slugify } from "@/utils/slugify";
 import {
   StarIcon,
   MapPinIcon,
@@ -177,7 +178,7 @@ const GearOwnerProfilePage = () => {
                       asChild
                       className="text-xs h-8"
                     >
-                      <Link to={`/equipment/${item.id}`}>View Details</Link>
+                      <Link to={`/${item.category}/${slugify(item.name)}`}>View Details</Link>
                     </Button>
                   </div>
                 </CardContent>

--- a/src/pages/LightspeedPOSPage.tsx
+++ b/src/pages/LightspeedPOSPage.tsx
@@ -16,6 +16,7 @@ import { useAuth } from "@/helpers";
 import { useUserEquipment, useUpdateEquipmentVisibility } from "@/hooks/useUserEquipment";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
+import { slugify } from "@/utils/slugify";
 import { fetchMockLightspeedInventory, ingestLightspeedInventory } from "@/services/lightspeed/lightspeedService";
 
 const LightspeedPOSPage = () => {
@@ -66,8 +67,8 @@ const LightspeedPOSPage = () => {
     });
   };
 
-  const handleViewDetails = (id: string) => {
-    navigate(`/equipment/${id}`);
+  const handleViewDetails = (id: string, name: string, category: string) => {
+    navigate(`/${category}/${slugify(name)}`);
   };
 
   const totalPages = Math.ceil(inventory.length / itemsPerPage) || 1;
@@ -353,7 +354,7 @@ const LightspeedPOSPage = () => {
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                       {paginatedItems.map(item => (
                         <Card key={item.id} className="overflow-hidden">
-                          <div className="relative h-32 cursor-pointer" onClick={() => handleViewDetails(item.id)}>
+                          <div className="relative h-32 cursor-pointer" onClick={() => handleViewDetails(item.id, item.name, item.category)}>
                             <img src={item.image_url} alt={item.name} className="w-full h-full object-cover" />
                             <div className="absolute top-2 right-2 bg-background/80 backdrop-blur-sm p-1.5 rounded-md">
                               {item.visible_on_map ? (
@@ -363,7 +364,7 @@ const LightspeedPOSPage = () => {
                               )}
                             </div>
                           </div>
-                          <CardHeader className="p-4 cursor-pointer" onClick={() => handleViewDetails(item.id)}>
+                          <CardHeader className="p-4 cursor-pointer" onClick={() => handleViewDetails(item.id, item.name, item.category)}>
                             <CardTitle className="text-base line-clamp-1">{item.name}</CardTitle>
                             <CardDescription>${item.price_per_day}/day</CardDescription>
                           </CardHeader>

--- a/src/pages/MyEquipmentPage.tsx
+++ b/src/pages/MyEquipmentPage.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Separator } from "@/components/ui/separator";
+import { slugify } from "@/utils/slugify";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
@@ -351,7 +352,7 @@ const MyEquipmentPage = () => {
                       </div>
 
                       <div className="space-y-1">
-                        <Link to={`/equipment/${item.id}`}>
+                        <Link to={`/${item.category}/${slugify(item.name)}`}>
                           <CardTitle className="text-lg line-clamp-1 hover:text-primary transition-colors">
                             {item.name}
                           </CardTitle>
@@ -434,7 +435,7 @@ const MyEquipmentPage = () => {
                           </div>
 
                           <Button size="sm" asChild>
-                            <Link to={`/equipment/${item.id}`}>
+                            <Link to={`/${item.category}/${slugify(item.name)}`}>
                               View Details
                             </Link>
                           </Button>

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -1,5 +1,6 @@
 
 import mapboxgl from 'mapbox-gl';
+import { slugify } from '@/utils/slugify';
 
 export const getCategoryColor = (category: string): string => {
   switch (category.toLowerCase()) {
@@ -104,7 +105,7 @@ export const createPopupContent = (item: {
       <p class="text-sm mt-1">$${item.price_per_day}/day</p>
       <button
         class="mt-2 px-2 py-1 bg-blue-500 text-white text-sm rounded hover:bg-blue-600"
-        onclick="window.location.href='/equipment/${item.id}'"
+        onclick="window.location.href='/${item.category}/${slugify(item.name)}'"
       >
         View Details
       </button>

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,0 +1,6 @@
+export const slugify = (text: string): string => {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+};


### PR DESCRIPTION
## Summary
- add `slugify` utility and `useEquipmentBySlug` hook
- change gear detail route to `/:category/:slug`
- update components and pages to generate SEO-friendly gear links
- adjust map popups and form navigation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68702352aba08320b0f7e36a5a11653a