### PR TITLE
Switch user profiles to slug URLs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,7 +83,7 @@ const App = () => {
                     <Route path="analytics" element={<AnalyticsPage />} />
                     <Route path="bookings" element={<BookingsPage />} />
                     <Route path="admin" element={<AdminPage />} />
-                    <Route path="user-profile/:id" element={<RealUserProfilePage />} />
+                    <Route path="user-profile/:slug" element={<RealUserProfilePage />} />
                     <Route path="owner/:id" element={<GearOwnerProfilePage />} />
                     <Route path="shop/:shopId" element={<ShopPage />} />
                     <Route path="private-party/:partyId" element={<PrivatePartyPage />} />

--- a/src/components/EquipmentCard.tsx
+++ b/src/components/EquipmentCard.tsx
@@ -38,7 +38,7 @@ const EquipmentCard = ({ equipment }: EquipmentCardProps) => {
 
   const ownerLinkPath = isShop
     ? `/shop/${equipment.owner.shopId}`
-    : `/user-profile/${equipment.owner.id}`;
+    : `/user-profile/${slugify(equipment.owner.name)}`;
 
   // Use images array from equipment_images table
   const images =

--- a/src/components/equipment-detail/OwnerCard.tsx
+++ b/src/components/equipment-detail/OwnerCard.tsx
@@ -6,6 +6,7 @@ import { StarIcon, MessageSquare } from "lucide-react";
 import { useUserProfile } from "@/hooks/useUserProfile";
 import { useUserStats } from "@/hooks/useUserStats";
 import { GearOwner } from "@/types";
+import { slugify } from "@/utils/slugify";
 import ContactInfoModal from "./ContactInfoModal";
 import { useState } from "react";
 
@@ -22,7 +23,7 @@ const OwnerCard = ({ owner, trackingData }: OwnerCardProps) => {
   // Determine the correct profile link - use real user profile for DB users
   const profileLinkPath = owner.shopId
     ? `/shop/${owner.shopId}`
-    : `/user-profile/${owner.id}`;
+    : `/user-profile/${slugify(owner.name)}`;
 
   // Use real data if available, fallback to mock data
   const displayName = profile?.name || owner.name;

--- a/src/components/profile/ProfileImageSection.tsx
+++ b/src/components/profile/ProfileImageSection.tsx
@@ -3,6 +3,7 @@ import { useRef } from "react";
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { User, Upload, Trash2, Eye } from "lucide-react";
+import { slugify } from "@/utils/slugify";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -118,7 +119,7 @@ export const ProfileImageSection = ({
           </AlertDialog>
           {userId && (
             <Button type="button" size="sm" asChild>
-              <Link to={`/user-profile/${userId}`}>
+              <Link to={`/user-profile/${slugify(name)}`}>
                 <Eye className="h-4 w-4 mr-2" />
                 View Profile
               </Link>

--- a/src/hooks/useMockUserProfileBySlug.ts
+++ b/src/hooks/useMockUserProfileBySlug.ts
@@ -1,0 +1,25 @@
+import { useMockData } from './useMockData';
+import { slugify } from '@/utils/slugify';
+import type { UserProfile } from '@/types';
+
+export const useMockUserProfileBySlug = (slug: string): UserProfile | null => {
+  const { owners } = useMockData();
+
+  const mockOwner = owners.find(owner => slugify(owner.name) === slug);
+
+  if (!mockOwner) {
+    return null;
+  }
+
+  return {
+    id: mockOwner.id,
+    name: mockOwner.name,
+    email: `${mockOwner.id}@mock.email`,
+    avatar_url: mockOwner.imageUrl,
+    role: 'private-party',
+    about: `Hi, I'm ${mockOwner.name}! ${mockOwner.personality || 'I love sharing my gear with others and helping them enjoy their adventures.'}`,
+    member_since: '2020-01-01T00:00:00.000Z',
+    created_at: '2020-01-01T00:00:00.000Z',
+    hero_image_url: null,
+  };
+};

--- a/src/hooks/useUserProfileBySlug.ts
+++ b/src/hooks/useUserProfileBySlug.ts
@@ -1,0 +1,45 @@
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { unslugify } from "@/utils/slugify";
+
+interface UserProfile {
+  id: string;
+  name: string;
+  avatar_url: string | null;
+  role: string;
+  about: string | null;
+  phone: string | null;
+  address: string | null;
+  location_lat: number | null;
+  location_lng: number | null;
+  member_since: string;
+  created_at: string;
+  website: string | null;
+}
+
+export const useUserProfileBySlug = (slug: string) => {
+  return useQuery({
+    queryKey: ['userProfile', slug],
+    queryFn: async (): Promise<UserProfile | null> => {
+      if (!slug) {
+        throw new Error('Slug is required');
+      }
+
+      const name = unslugify(slug);
+
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('*')
+        .ilike('name', name)
+        .single();
+
+      if (error) {
+        console.error('Error fetching user profile by slug:', error);
+        throw error;
+      }
+
+      return data;
+    },
+    enabled: !!slug,
+  });
+};

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Search, Clock, User, Calendar } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { blogPosts, BlogPost } from "@/lib/blog";
+import { slugify } from "@/utils/slugify";
 import { searchBlogPostsWithNLP } from "@/services/blogSearchService";
 import { useUserRole } from "@/hooks/useUserRole";
 import { toast } from "@/hooks/use-toast";
@@ -348,7 +349,7 @@ const BlogPage = () => {
                     <div className="flex items-center">
                       <User className="h-3 w-3 mr-1" />
                       <Link
-                        to={post.authorId !== 'generative-ai' ? `/user-profile/${post.authorId}` : '#'}
+                        to={post.authorId !== 'generative-ai' ? `/user-profile/${slugify(post.author)}` : '#'}
                         className="hover:text-primary transition-colors"
                       >
                         {post.author}

--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import Breadcrumbs from "@/components/Breadcrumbs";
 import { Clock, User, Calendar, Share2, ArrowUp } from "lucide-react";
 import { blogPosts } from "@/lib/blog";
+import { slugify } from "@/utils/slugify";
 import { useEffect, useState } from "react";
 import { useRelatedGear } from "@/hooks/useRelatedGear";
 import RelatedGear from "@/components/equipment-detail/RelatedGear";
@@ -147,7 +148,7 @@ const BlogPostPage = () => {
                   <div className="flex items-center">
                     <User className="h-4 w-4 mr-1" />
                     <Link
-                      to={post.authorId !== 'generative-ai' ? `/user-profile/${post.authorId}` : '#'}
+                      to={post.authorId !== 'generative-ai' ? `/user-profile/${slugify(post.author)}` : '#'}
                       className="hover:text-primary transition-colors"
                     >
                       {post.author}

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -99,7 +99,7 @@ export const createPopupContent = (item: {
     <div>
       <h3 class="text-base font-medium">${item.name}</h3>
       <p class="text-sm text-gray-500">
-        <a href="/user-profile/${item.ownerId}" class="underline underline-offset-2 hover:text-blue-600">${item.ownerName}</a>
+        <a href="/user-profile/${slugify(item.ownerName)}" class="underline underline-offset-2 hover:text-blue-600">${item.ownerName}</a>
       </p>
       <p class="text-sm text-gray-500">${item.category}</p>
       <p class="text-sm mt-1">$${item.price_per_day}/day</p>
@@ -122,7 +122,7 @@ export const createUserLocationPopupContent = (user: { id: string; name: string;
       <p class="text-sm mt-1">${user.address}</p>
       <button
         class="mt-2 px-2 py-1 bg-blue-500 text-white text-sm rounded hover:bg-blue-600"
-        onclick="window.location.href='/user-profile/${user.id}'"
+        onclick="window.location.href='/user-profile/${slugify(user.name)}'"
       >
         View Profile
       </button>

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -4,3 +4,7 @@ export const slugify = (text: string): string => {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
 };
+
+export const unslugify = (slug: string): string => {
+  return slug.replace(/-/g, ' ');
+};


### PR DESCRIPTION
## Summary
- add `unslugify` helper
- look up user profiles by slug
- link to profile pages using slugified names
- update routes and profile page to use slug param

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68702da0b1888320b1f52ac6a30ab05d