### PR TITLE
Update Vite config for SSR

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,25 +1,50 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react-swc";
-import path from "path";
-import { componentTagger } from "lovable-tagger";
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react-swc';
+import path from 'path';
+import { componentTagger } from 'lovable-tagger';
 
-// https://vitejs.dev/config/
-export default defineConfig(({ mode }) => {
-  // Check if running on localhost
-  const isLocalhost = process.env.HOSTNAME === "localhost" || process.env.NODE_ENV === "development";
+export default defineConfig(({ command, mode, ssrBuild }) => {
+  const isLocalhost =
+    process.env.HOSTNAME === 'localhost' ||
+    process.env.NODE_ENV === 'development';
 
+  // ✅ SSR BUILD
+  if (ssrBuild) {
+    return {
+      plugins: [react()],
+      resolve: {
+        alias: {
+          '@': path.resolve(__dirname, './src'),
+        },
+      },
+      build: {
+        outDir: 'dist/server',
+        ssr: 'src/entry-server.tsx',
+        rollupOptions: {
+          input: 'src/entry-server.tsx',
+        },
+      },
+    };
+  }
+
+  // ✅ CLIENT BUILD
   return {
     server: {
-      host: "::",
-      port: isLocalhost ? 4050 : 8080, // Use port 4050 for localhost, 8080 otherwise
+      host: '::',
+      port: isLocalhost ? 4050 : 8080,
     },
-    plugins: [
-      react(),
-      mode === "development" && componentTagger(),
-    ].filter(Boolean),
+    plugins: [react(), mode === 'development' && componentTagger()].filter(
+      Boolean,
+    ),
     resolve: {
       alias: {
-        "@": path.resolve(__dirname, "./src"),
+        '@': path.resolve(__dirname, './src'),
+      },
+    },
+    build: {
+      outDir: 'dist/client',
+      rollupOptions: {
+        input: path.resolve(__dirname, 'index.html'),
       },
     },
   };


### PR DESCRIPTION
## Summary
- support SSR build output and client build output in `vite.config.ts`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871941c86b883208a3a84b7b9130b22