### PR TITLE
Fix map black screen in hybrid view

### DIFF
--- a/src/components/HybridView.tsx
+++ b/src/components/HybridView.tsx
@@ -73,9 +73,16 @@ const HybridView = ({ filteredEquipment, activeCategory, isLocationBased, userLo
     fetchMapboxToken();
   }, []);
 
-  // Initialize map
+  // Initialize or reinitialize the map
   useEffect(() => {
     if (!mapContainer.current || !mapboxToken) return;
+
+    if (map.current) {
+      map.current.remove();
+      map.current = null;
+    }
+
+    setIsMapLoaded(false);
 
     try {
       map.current = initializeMap(mapContainer.current, mapboxToken);
@@ -92,14 +99,7 @@ const HybridView = ({ filteredEquipment, activeCategory, isLocationBased, userLo
         map.current = null;
       }
     };
-  }, [mapboxToken]);
-
-  // Resize map when layout changes to keep pins visible
-  useEffect(() => {
-    if (map.current) {
-      map.current.resize();
-    }
-  }, [isMobile]);
+  }, [mapboxToken, isMobile]);
 
   const selectedEquipment = selectedEquipmentId
     ? mapEquipment.find(item => item.id === selectedEquipmentId)


### PR DESCRIPTION
## Summary
- reinitialize map when hybrid layout switches between mobile and desktop

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687324479af0832096b6baa30f86c515