### PR TITLE
Fix role references

### DIFF
--- a/src/hooks/useProfileImageHandlers.ts
+++ b/src/hooks/useProfileImageHandlers.ts
@@ -55,7 +55,7 @@ export const useProfileImageHandlers = ({
       // First, get the current profile data to preserve existing values
       const { data: currentProfile, error: fetchError } = await supabase
         .from('profiles')
-        .select('role, name')
+        .select('name')
         .eq('id', user.id)
         .single();
 
@@ -77,11 +77,10 @@ export const useProfileImageHandlers = ({
       // Update the avatar_url in the database while preserving existing role and name
       const { error } = await supabase
         .from('profiles')
-        .upsert({ 
+        .upsert({
           id: user.id,
           avatar_url: imageUrl,
-          name: currentProfile?.name || user.name || '',
-          role: currentProfile?.role || 'private-party' // Preserve existing role
+          name: currentProfile?.name || user.name || ''
         }, {
           onConflict: 'id'
         });
@@ -117,17 +116,16 @@ export const useProfileImageHandlers = ({
       // Update database with fallback avatar, preserving existing data
       const { data: currentProfile } = await supabase
         .from('profiles')
-        .select('role, name')
+        .select('name')
         .eq('id', user.id)
         .single();
 
       await supabase
         .from('profiles')
-        .upsert({ 
+        .upsert({
           id: user.id,
           avatar_url: fallbackAvatar,
-          name: currentProfile?.name || user.name || '',
-          role: currentProfile?.role || 'private-party' // Preserve existing role
+          name: currentProfile?.name || user.name || ''
         }, {
           onConflict: 'id'
         });
@@ -145,7 +143,7 @@ export const useProfileImageHandlers = ({
       // First, get the current profile data to preserve existing values
       const { data: currentProfile, error: fetchError } = await supabase
         .from('profiles')
-        .select('role, name')
+        .select('name')
         .eq('id', user.id)
         .single();
 
@@ -164,11 +162,10 @@ export const useProfileImageHandlers = ({
       // Update the avatar_url in the database while preserving existing role and name
       const { error } = await supabase
         .from('profiles')
-        .upsert({ 
+        .upsert({
           id: user.id,
           avatar_url: fallbackAvatar,
-          name: currentProfile?.name || user.name || '',
-          role: currentProfile?.role || 'private-party' // Preserve existing role
+          name: currentProfile?.name || user.name || ''
         }, {
           onConflict: 'id'
         });

--- a/src/hooks/useProfileQuery.ts
+++ b/src/hooks/useProfileQuery.ts
@@ -18,7 +18,7 @@ export const useProfileQuery = () => {
 
       const { data: profileData, error } = await supabase
         .from('profiles')
-        .select('name, role, avatar_url, hero_image_url, phone, address, about, website, location_lat, location_lng')
+        .select('name, avatar_url, hero_image_url, phone, address, about, website, location_lat, location_lng')
         .eq('id', user.id)
         .single();
 
@@ -27,7 +27,7 @@ export const useProfileQuery = () => {
         return {
           name: user.name || "",
           email: currentEmail,
-          role: "private-party",
+          role: "user",
           phone: "",
           address: "",
           location_lat: null,
@@ -40,13 +40,19 @@ export const useProfileQuery = () => {
       }
 
       // Use avatar_url for profile image, fallback to dicebear if not set
+      const { data: roleRow } = await supabase
+        .from('user_roles')
+        .select('role')
+        .eq('user_id', user.id)
+        .single();
+
       const avatarUrl = profileData.avatar_url || generateDicebearAvatar(user.id);
       console.log('Setting profile image from avatar_url:', avatarUrl);
 
       return {
         name: profileData.name || "",
         email: currentEmail, // Use the current email from auth
-        role: profileData.role || "private-party",
+        role: roleRow?.role || "user",
         phone: profileData.phone || "",
         address: profileData.address || "",
         location_lat: profileData.location_lat,
@@ -65,7 +71,7 @@ export const useProfileQuery = () => {
       return {
         name: user.name || "",
         email: currentEmail,
-        role: "private-party",
+        role: "user",
         phone: "",
         address: "",
         location_lat: null,

--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -6,7 +6,6 @@ interface UserProfile {
   id: string;
   name: string;
   avatar_url: string | null;
-  role: string;
   about: string | null;
   phone: string | null;
   address: string | null;

--- a/src/hooks/useUserProfileBySlug.ts
+++ b/src/hooks/useUserProfileBySlug.ts
@@ -6,7 +6,6 @@ interface UserProfile {
   id: string;
   name: string;
   avatar_url: string | null;
-  role: string;
   about: string | null;
   phone: string | null;
   address: string | null;

--- a/src/hooks/user-creation/useUserCreationSubmission.ts
+++ b/src/hooks/user-creation/useUserCreationSubmission.ts
@@ -100,7 +100,6 @@ export const useUserCreationSubmission = () => {
       // Step 5: Create or update the profile with form data (including geocoded coordinates)
       const profileData = {
         name: formData.name,
-        role: formData.role,
         website: formData.website || null,
         phone: formData.phone || null,
         address: formData.address || null,
@@ -170,7 +169,7 @@ export const useUserCreationSubmission = () => {
       // Step 7: Final verification
       const { data: finalProfile } = await supabase
         .from('profiles')
-        .select('name, role, phone, address, website, location_lat, location_lng')
+        .select('name, phone, address, website, location_lat, location_lng')
         .eq('id', authData.user.id)
         .single();
 


### PR DESCRIPTION
## Summary
- fetch roles from `user_roles` instead of the removed `profiles.role`
- stop persisting role in profile image handlers
- update profile queries to use `user_roles`
- drop `role` field from user profile hooks
- remove role field from new profile creation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687352a939788320ac64cc830291da2b