### PR TITLE
Fix signup permission issue for user_roles

### DIFF
--- a/supabase/migrations/20250715080000-ea44a57c-e683-4cdc-970f-d705ae9948e4.sql
+++ b/supabase/migrations/20250715080000-ea44a57c-e683-4cdc-970f-d705ae9948e4.sql
@@ -1,0 +1,6 @@
+-- Allow regular signups to succeed by permitting users to insert their own default role
+CREATE POLICY "Users can assign themselves default role" ON public.user_roles
+FOR INSERT
+WITH CHECK (
+  auth.uid() = user_id AND role = 'user'
+);


### PR DESCRIPTION
## Summary
- allow non-admin signups to insert the default `user` role

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68747bf4db2c8320be26f58d640b6f5c