### PR TITLE
Add admin blog generator and tooltips

### DIFF
--- a/src/components/EquipmentCard.tsx
+++ b/src/components/EquipmentCard.tsx
@@ -15,6 +15,11 @@ import { Equipment } from "@/types";
 import { useAuth } from "@/contexts/auth";
 import { slugify } from "@/utils/slugify";
 import DistanceDisplay from "./DistanceDisplay";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
 
 interface EquipmentCardProps {
   equipment: Equipment;
@@ -110,9 +115,16 @@ const EquipmentCard = ({ equipment }: EquipmentCardProps) => {
             <span>{equipment.rating}</span>
           </div>
         </div>
-        <p className="text-sm text-muted-foreground mb-3 line-clamp-2">
-          {equipment.description}
-        </p>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <p className="text-sm text-muted-foreground mb-3 line-clamp-2">
+              {equipment.description}
+            </p>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" align="start" className="max-w-[500px]">
+            {equipment.description}
+          </TooltipContent>
+        </Tooltip>
         <div className="flex items-center justify-between mb-2">
           <div>
             <p className="text-sm font-medium">

--- a/src/components/admin/BlogPostGeneratorSection.tsx
+++ b/src/components/admin/BlogPostGeneratorSection.tsx
@@ -1,0 +1,179 @@
+import { useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { Calendar } from "@/components/ui/calendar";
+import { useToast } from "@/hooks/use-toast";
+import { blogPosts } from "@/lib/blog";
+import { slugify } from "@/utils/slugify";
+import { format } from "date-fns";
+import { CalendarIcon, Sparkles, Loader2 } from "lucide-react";
+import { generateBlogPost } from "@/services/blog/generateBlogPost";
+
+const BlogPostGeneratorSection = () => {
+  const { toast } = useToast();
+  const categories = Array.from(new Set(blogPosts.map((p) => p.category)));
+
+  const [prompt, setPrompt] = useState("");
+  const [category, setCategory] = useState<string>(categories[0] || "");
+  const [author, setAuthor] = useState("");
+  const [tags, setTags] = useState("");
+  const [thumbnail, setThumbnail] = useState("");
+  const [heroImage, setHeroImage] = useState("");
+  const [youtubeUrl, setYoutubeUrl] = useState("");
+  const [useYoutubeThumb, setUseYoutubeThumb] = useState(false);
+  const [useYoutubeHero, setUseYoutubeHero] = useState(false);
+  const [publishedDate, setPublishedDate] = useState<Date | undefined>(undefined);
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  const isFormValid =
+    prompt.trim() &&
+    category &&
+    author.trim() &&
+    tags.trim() &&
+    thumbnail.trim() &&
+    heroImage.trim() &&
+    publishedDate;
+
+  const handleGenerate = async () => {
+    if (!prompt.trim() || !author.trim()) {
+      toast({
+        title: "Missing Fields",
+        description: "Prompt and author are required.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setIsGenerating(true);
+    const authorId = slugify(author);
+    const result = await generateBlogPost({
+      prompt,
+      category,
+      author,
+      authorId,
+      tags: tags.split(",").map((t) => t.trim()).filter(Boolean),
+      thumbnail,
+      heroImage,
+      youtubeUrl,
+      useYoutubeThumbnail: useYoutubeThumb,
+      useYoutubeHero,
+      publishedAt: (publishedDate ?? new Date()).toISOString(),
+    });
+    setIsGenerating(false);
+
+    if (result) {
+      toast({ title: "Blog Post Generated", description: "Check your CMS for the new post." });
+    } else {
+      toast({ title: "Error", description: "Failed to generate blog post.", variant: "destructive" });
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Generate Blog Post</CardTitle>
+        <CardDescription>Create a new blog post using AI-generated content.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="prompt">
+            Prompt <span className="text-red-500">*</span>
+          </Label>
+          <Textarea
+            id="prompt"
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            rows={4}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="category">
+            Category <span className="text-red-500">*</span>
+          </Label>
+          <Select value={category} onValueChange={setCategory}>
+            <SelectTrigger id="category">
+              <SelectValue placeholder="Select category" />
+            </SelectTrigger>
+            <SelectContent>
+              {categories.map((cat) => (
+                <SelectItem key={cat} value={cat}>
+                  {cat}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="author">
+            Author Name <span className="text-red-500">*</span>
+          </Label>
+          <Input id="author" value={author} onChange={(e) => setAuthor(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="tags">
+            Tags (comma separated) <span className="text-red-500">*</span>
+          </Label>
+          <Input id="tags" value={tags} onChange={(e) => setTags(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="thumb">
+            Thumbnail Image URL <span className="text-red-500">*</span>
+          </Label>
+          <Input id="thumb" value={thumbnail} onChange={(e) => setThumbnail(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="hero">
+            Hero Image URL <span className="text-red-500">*</span>
+          </Label>
+          <Input id="hero" value={heroImage} onChange={(e) => setHeroImage(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="youtube">YouTube Video URL</Label>
+          <Input id="youtube" value={youtubeUrl} onChange={(e) => setYoutubeUrl(e.target.value)} />
+        </div>
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2">
+            <Checkbox id="use-thumb" checked={useYoutubeThumb} onCheckedChange={(c) => setUseYoutubeThumb(!!c)} />
+            <Label htmlFor="use-thumb">Use YouTube thumbnail</Label>
+          </div>
+          <div className="flex items-center gap-2">
+            <Checkbox id="use-hero" checked={useYoutubeHero} onCheckedChange={(c) => setUseYoutubeHero(!!c)} />
+            <Label htmlFor="use-hero">Use YouTube hero image</Label>
+          </div>
+        </div>
+        <div className="space-y-2">
+          <Label>
+            Published Date <span className="text-red-500">*</span>
+          </Label>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="outline" className="justify-start text-left font-normal w-full sm:w-auto">
+                <CalendarIcon className="mr-2 h-4 w-4" />
+                {publishedDate ? format(publishedDate, "PPP") : <span>Pick a date</span>}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-auto p-0">
+              <Calendar mode="single" selected={publishedDate} onSelect={setPublishedDate} className="pointer-events-auto" />
+            </PopoverContent>
+          </Popover>
+        </div>
+        <Button
+          onClick={handleGenerate}
+          disabled={isGenerating || !isFormValid}
+          className="flex items-center gap-2"
+        >
+          {isGenerating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
+          {isGenerating ? "Generating..." : "Generate Blog Post"}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default BlogPostGeneratorSection;

--- a/src/components/gear-form/GearBasicInfo.tsx
+++ b/src/components/gear-form/GearBasicInfo.tsx
@@ -3,7 +3,7 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Sparkles } from "lucide-react";
 import { useState } from "react";
 import { useToast } from "@/hooks/use-toast";
 import { generateGearDescription } from "@/services/equipment/descriptionAIService";
@@ -119,10 +119,13 @@ const GearBasicInfo = ({
           {isGenerating ? (
             <>
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              Generating...
+              Loading...
             </>
           ) : (
-            <>Generate Description</>
+            <>
+              <Sparkles className="mr-2 h-4 w-4" />
+              Generate Description
+            </>
           )}
         </Button>
       </div>

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -5,6 +5,7 @@ import UserManagementSection from "@/components/admin/UserManagementSection";
 import ManualUserCreationSection from "@/components/admin/ManualUserCreationSection";
 import ImageUploadSection from "@/components/admin/ImageUploadSection";
 import VideoUploadSection from "@/components/admin/VideoUploadSection";
+import BlogPostGeneratorSection from "@/components/admin/BlogPostGeneratorSection";
 import DataDisplaySettings from "@/components/admin/DataDisplaySettings";
 import GlobalSearchSettings from "@/components/admin/GlobalSearchSettings";
 import GeocodingRecoverySection from "@/components/admin/GeocodingRecoverySection";
@@ -57,6 +58,7 @@ const AdminPage = () => {
         </TabsContent>
 
         <TabsContent value="content" className="space-y-6">
+          <BlogPostGeneratorSection />
           <ImageUploadSection />
           <VideoUploadSection />
         </TabsContent>

--- a/src/pages/MyEquipmentPage.tsx
+++ b/src/pages/MyEquipmentPage.tsx
@@ -11,6 +11,11 @@ import { slugify } from "@/utils/slugify";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
+import {
   Eye,
   EyeOff,
   Plus,
@@ -381,6 +386,17 @@ const MyEquipmentPage = () => {
                             {item.location.address}
                           </span>
                         </div>
+
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <p className="text-sm text-muted-foreground line-clamp-2">
+                              {item.description}
+                            </p>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom" align="start" className="max-w-[500px]">
+                            {item.description}
+                          </TooltipContent>
+                        </Tooltip>
 
                         {/* Actions */}
                         <Separator />

--- a/src/services/blog/generateBlogPost.ts
+++ b/src/services/blog/generateBlogPost.ts
@@ -1,0 +1,37 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { BlogPost } from "@/lib/blog";
+
+export interface GenerateBlogPostParams {
+  prompt: string;
+  category: string;
+  author: string;
+  authorId: string;
+  tags: string[];
+  thumbnail: string;
+  heroImage: string;
+  youtubeUrl: string;
+  useYoutubeThumbnail: boolean;
+  useYoutubeHero: boolean;
+  publishedAt: string;
+}
+
+export const generateBlogPost = async (
+  params: GenerateBlogPostParams,
+): Promise<BlogPost | null> => {
+  try {
+    const { data, error } = await supabase.functions.invoke(
+      "generate-blog-post",
+      { body: params },
+    );
+
+    if (error) {
+      console.error("Supabase function error:", error);
+      return null;
+    }
+
+    return (data as any)?.post ?? null;
+  } catch (err) {
+    console.error("Error generating blog post:", err);
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary
- add sparkles icon to the gear description generator
- show description tooltips on equipment cards
- display gear description with tooltip on My Gear page
- add blog post generation tools to the admin panel
- support generating blog posts via Supabase function
- disable blog post generation until all fields are filled
- mark required admin fields with a red asterisk
- move the blog generator section to the top of the Content tab

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6877b525780c8320858bb52fd69752ea