### PR TITLE
Add tooltip to copy description modal

### DIFF
--- a/src/components/gear-form/SimilarGearDescriptionCopy.tsx
+++ b/src/components/gear-form/SimilarGearDescriptionCopy.tsx
@@ -290,7 +290,11 @@ const SimilarGearDescriptionCopy = ({
                               {truncateDescription(gear.description)}
                             </p>
                           </TooltipTrigger>
-                          <TooltipContent side="bottom" align="start" className="max-w-[500px]">
+                          <TooltipContent
+                            side="top"
+                            align="end"
+                            className="max-w-[500px]"
+                          >
                             {gear.description}
                           </TooltipContent>
                         </Tooltip>


### PR DESCRIPTION
## Summary
- add tooltip imports
- show full description via tooltip in SimilarGearDescriptionCopy

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_6877de552b548320832747d71b71f07a