### PR TITLE
Improve unique gear matching

### DIFF
--- a/src/hooks/useRelatedGear.ts
+++ b/src/hooks/useRelatedGear.ts
@@ -50,6 +50,15 @@ export const useRelatedGear = (tags: Array<string>, category?: string) => {
           );
         }
 
+        // Deduplicate by item name
+        const seenNames = new Set<string>();
+        related = related.filter((item) => {
+          if (seenNames.has(item.name)) return false;
+          seenNames.add(item.name);
+          return true;
+        });
+
+        // Limit to 4 items
         related = related.slice(0, 4);
 
         console.log(`✅ Found ${related.length} related gear items`);

--- a/src/pages/EquipmentDetailPage.tsx
+++ b/src/pages/EquipmentDetailPage.tsx
@@ -97,6 +97,7 @@ const EquipmentDetailPage = () => {
   const { data: similarEquipmentFromDb, isLoading: similarLoading } = useSimilarEquipment(
     currentEquipment?.category || '',
     currentEquipment?.id || '',
+    currentEquipment?.name || '',
     currentEquipment?.location?.lat,
     currentEquipment?.location?.lng
   );


### PR DESCRIPTION
## Summary
- remove duplicate names from related gear suggestions
- exclude current item and deduplicate similar gear results
- pass equipment name when loading similar gear

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687814e0dc308320842e03781e738004