### PR TITLE
Fix duplicate key warning on blog pages

### DIFF
--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -382,9 +382,9 @@ const BlogPage = () => {
                     </div>
                   </div>
                   <div className="flex flex-wrap gap-1 mt-3">
-                    {post.tags.map((tag) => (
-                      <Link key={tag} to={`/blog?search=${encodeURIComponent(tag)}`}>
-                        <Badge variant="outline" className="text-xs hover:text-primary hover:border-primary hover:bg-transparent transition-colors cursor-pointer">
+                    {Array.from(new Set(post.tags)).map((tag) => (
+                      <Link key={tag} to={`/blog?search=${encodeURIComponent(tag)}`}> 
+                        <Badge variant="outline" className="text-xs hover:text-primary hover:border-primary hover:bg-transparent transition-colors cursor-pointer"> 
                           {tag}
                         </Badge>
                       </Link>

--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -222,9 +222,9 @@ const BlogPostPage = () => {
             <div className="mb-8">
               <h4 className="text-lg font-semibold mb-3">Tags</h4>
               <div className="flex flex-wrap gap-2">
-                {post.tags.map((tag) => (
-                  <Link key={tag} to={`/blog?search=${encodeURIComponent(tag)}`}>
-                    <Badge variant="outline" className="hover:text-primary hover:border-primary hover:bg-transparent transition-colors cursor-pointer">
+                {Array.from(new Set(post.tags)).map((tag) => (
+                  <Link key={tag} to={`/blog?search=${encodeURIComponent(tag)}`}> 
+                    <Badge variant="outline" className="hover:text-primary hover:border-primary hover:bg-transparent transition-colors cursor-pointer"> 
                       {tag}
                     </Badge>
                   </Link>


### PR DESCRIPTION
## Summary
- dedupe blog post tags before rendering them

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_687bbd465c0c832083b5a374f7f784ba