### PR TITLE
Fix display role for public profiles

### DIFF
--- a/src/hooks/useUserProfileBySlug.ts
+++ b/src/hooks/useUserProfileBySlug.ts
@@ -55,8 +55,7 @@ export const useUserProfileBySlug = (slug: string) => {
       if (roleError || !roleRow) {
         try {
           const { data: fnData, error: fnError } = await supabase.functions.invoke(
-            'get-user-display-role',
-            { body: { user_id: data.id } }
+            `get-user-display-role?user_id=${data.id}`
           );
           if (!fnError && (fnData as any)?.display_role) {
             displayRole = (fnData as any).display_role as string;


### PR DESCRIPTION
## Summary
- ensure RealUserProfilePage retrieves display role via Supabase functions when unauthenticated

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_687d22f80f94832084cef8280f0cb3fe