### PR TITLE
Fix hydration warning

### DIFF
--- a/src/entry-client.tsx
+++ b/src/entry-client.tsx
@@ -1,12 +1,27 @@
 
 import React from 'react';
-import { hydrateRoot } from 'react-dom/client';
+import { hydrateRoot, createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
 
-hydrateRoot(document.getElementById('root')!,
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>
-);
+const container = document.getElementById('root')!;
+
+// Hydrate when server rendered markup is present. In development the app is
+// often served without SSR, leaving the container empty. Trying to hydrate an
+// empty container triggers React's mismatch warning, so fall back to a normal
+// client render in that case.
+if (container.hasChildNodes()) {
+  hydrateRoot(
+    container,
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>,
+  );
+} else {
+  createRoot(container).render(
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>,
+  );
+}


### PR DESCRIPTION
## Summary
- avoid calling hydrateRoot in dev when there's no SSR output

## Testing
- `npm run type-check`
- `npm run lint` *(fails: Cannot find package '@eslint/js' because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68855e6ae8f0832096f4a81d8b32ce67