### PR TITLE
Remove container classes for full-width sections

### DIFF
--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -75,7 +75,7 @@ const FilterBar = ({
 
   return (
     <div className="border-b sticky top-16 z-30 bg-background pb-2">
-      <div className="container px-4 md:px-6 py-4">
+      <div className="px-4 md:px-6 py-4">
         {/* Mobile layout */}
         <div className="flex flex-col gap-2 lg:hidden">
           <div className="flex gap-2 w-full">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 const Footer = () => {
   return (
     <footer className="bg-background border-t mb-10 lg:mb-0">
-      <div className="container px-4 md:px-6 py-8 md:py-12">
+      <div className="px-4 md:px-6 py-8 md:py-12">
         <div className="flex flex-col md:flex-row justify-between">
           <div className="mb-8 md:mb-0">
             <div className="flex items-center gap-2 mb-4">

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -15,7 +15,7 @@ const Navbar = () => {
   return (
     <>
       <header className="sticky top-0 z-40 w-full bg-background/80 backdrop-blur-sm">
-        <div className="container flex h-20 items-center justify-between px-4 md:px-6">
+        <div className="flex h-20 items-center justify-between px-4 md:px-6">
           <div className="flex items-center gap-2">
             <NavbarLogo />
             <ThemeSwitcher />


### PR DESCRIPTION
## Summary
- remove `.container` class from navbar for full width
- remove `.container` class from filter bar
- remove `.container` class from footer

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_688a22f050c08320a00f419328cd9341