### PR TITLE
refactor: move blog filters into sidebar

### DIFF
--- a/src/components/blog/BlogFilterSidebar.tsx
+++ b/src/components/blog/BlogFilterSidebar.tsx
@@ -1,0 +1,178 @@
+import { Search, SortAsc, SortDesc } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { SidebarContent, SidebarHeader, useSidebar } from "@/components/ui/sidebar";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+
+interface FilterOption {
+  label: string;
+  value: string;
+}
+
+interface DateOption {
+  label: string;
+  value: string;
+}
+
+interface BlogFilterSidebarProps {
+  searchQuery: string;
+  setSearchQuery: (value: string) => void;
+  sortBy: "latest" | "oldest";
+  setSortBy: (value: "latest" | "oldest") => void;
+  selectedFilter: string;
+  applyFilter: (filter: string) => void;
+  selectedDateFilter: string;
+  setSelectedDateFilter: (value: string) => void;
+  getDateOptions: () => DateOption[];
+  clearSearch: () => void;
+  filters: FilterOption[];
+}
+
+export function BlogFilterSidebar({
+  searchQuery,
+  setSearchQuery,
+  sortBy,
+  setSortBy,
+  selectedFilter,
+  applyFilter,
+  selectedDateFilter,
+  setSelectedDateFilter,
+  getDateOptions,
+  clearSearch,
+  filters,
+}: BlogFilterSidebarProps) {
+  const { setOpen, setOpenMobile } = useSidebar();
+
+  const closeSidebar = () => {
+    setOpen(false);
+    setOpenMobile(false);
+  };
+
+  const hasActiveFilters =
+    !!searchQuery ||
+    !!selectedFilter ||
+    !!selectedDateFilter ||
+    sortBy !== "latest";
+
+  return (
+    <>
+      <SidebarHeader className="p-6">
+        <h2 className="text-lg font-semibold">Search & Filter Posts</h2>
+      </SidebarHeader>
+      <SidebarContent className="p-6">
+        <div className="space-y-6 pb-6">
+          <div>
+            <label className="text-sm font-medium mb-2 block">Search</label>
+            <div className="relative">
+              <Input
+                type="text"
+                placeholder="Search blog posts..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-10"
+              />
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 transform text-gray-500" />
+            </div>
+          </div>
+
+          <div>
+            <label className="text-sm font-medium mb-2 block">Sort by Date</label>
+            <div className="grid grid-cols-2 gap-2">
+              <Button
+                variant={sortBy === "latest" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setSortBy("latest")}
+                className="gap-2"
+              >
+                <SortDesc className="h-3 w-3" />
+                Latest
+              </Button>
+              <Button
+                variant={sortBy === "oldest" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setSortBy("oldest")}
+                className="gap-2"
+              >
+                <SortAsc className="h-3 w-3" />
+                Oldest
+              </Button>
+            </div>
+          </div>
+
+          <Accordion type="multiple" defaultValue={["category", "date"]} className="w-full space-y-0">
+            <AccordionItem value="category" className="border-none">
+              <AccordionTrigger className="text-sm font-medium py-3">
+                Category
+              </AccordionTrigger>
+              <AccordionContent>
+                <div className="grid grid-cols-1 gap-2 pt-2">
+                  <Button
+                    variant={selectedFilter === "" ? "default" : "outline"}
+                    size="sm"
+                    onClick={() => applyFilter("")}
+                    className="justify-start"
+                  >
+                    All Posts
+                  </Button>
+                  {filters.map((filter) => (
+                    <Button
+                      key={filter.value}
+                      variant={selectedFilter === filter.value ? "default" : "outline"}
+                      size="sm"
+                      onClick={() => applyFilter(filter.value)}
+                      className="justify-start"
+                    >
+                      {filter.label}
+                    </Button>
+                  ))}
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="date" className="border-none">
+              <AccordionTrigger className="text-sm font-medium py-3">
+                Filter by Month/Year
+              </AccordionTrigger>
+              <AccordionContent>
+                <div className="grid grid-cols-1 gap-1 max-h-40 overflow-y-auto pt-2">
+                  <Button
+                    variant={selectedDateFilter === "" ? "default" : "outline"}
+                    size="sm"
+                    onClick={() => setSelectedDateFilter("")}
+                    className="justify-start text-xs"
+                  >
+                    All Dates
+                  </Button>
+                  {getDateOptions().map((dateOption) => (
+                    <Button
+                      key={dateOption.value}
+                      variant={selectedDateFilter === dateOption.value ? "default" : "outline"}
+                      size="sm"
+                      onClick={() => setSelectedDateFilter(dateOption.value)}
+                      className="justify-start text-xs"
+                    >
+                      {dateOption.label}
+                    </Button>
+                  ))}
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+
+          {hasActiveFilters && (
+            <div className="space-y-2">
+              <Button onClick={closeSidebar} className="w-full">
+                Go
+              </Button>
+              <Button variant="outline" onClick={clearSearch} className="w-full">
+                Clear All Filters
+              </Button>
+            </div>
+          )}
+        </div>
+      </SidebarContent>
+    </>
+  );
+}
+
+export default BlogFilterSidebar;

--- a/src/components/blog/BlogFilterSidebar.tsx
+++ b/src/components/blog/BlogFilterSidebar.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { SidebarContent, SidebarHeader, useSidebar } from "@/components/ui/sidebar";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import { cn } from "@/lib/utils";
 
 interface FilterOption {
   label: string;
@@ -59,8 +60,8 @@ export function BlogFilterSidebar({
       <SidebarHeader className="p-6">
         <h2 className="text-lg font-semibold">Search & Filter Posts</h2>
       </SidebarHeader>
-      <SidebarContent className="p-6">
-        <div className="space-y-6 pb-6">
+      <SidebarContent className="p-6 pb-32">
+        <div className="space-y-6">
           <div>
             <label className="text-sm font-medium mb-2 block">Search</label>
             <div className="relative">
@@ -79,19 +80,19 @@ export function BlogFilterSidebar({
             <label className="text-sm font-medium mb-2 block">Sort by Date</label>
             <div className="grid grid-cols-2 gap-2">
               <Button
-                variant={sortBy === "latest" ? "default" : "outline"}
+                variant="outline"
                 size="sm"
                 onClick={() => setSortBy("latest")}
-                className="gap-2"
+                className={cn("gap-2", sortBy === "latest" && "border-white text-white")}
               >
                 <SortDesc className="h-3 w-3" />
                 Latest
               </Button>
               <Button
-                variant={sortBy === "oldest" ? "default" : "outline"}
+                variant="outline"
                 size="sm"
                 onClick={() => setSortBy("oldest")}
-                className="gap-2"
+                className={cn("gap-2", sortBy === "oldest" && "border-white text-white")}
               >
                 <SortAsc className="h-3 w-3" />
                 Oldest
@@ -107,20 +108,20 @@ export function BlogFilterSidebar({
               <AccordionContent>
                 <div className="grid grid-cols-1 gap-2 pt-2">
                   <Button
-                    variant={selectedFilter === "" ? "default" : "outline"}
+                    variant="outline"
                     size="sm"
                     onClick={() => applyFilter("")}
-                    className="justify-start"
+                    className={cn("justify-start", selectedFilter === "" && "border-white text-white")}
                   >
                     All Posts
                   </Button>
                   {filters.map((filter) => (
                     <Button
                       key={filter.value}
-                      variant={selectedFilter === filter.value ? "default" : "outline"}
+                      variant="outline"
                       size="sm"
                       onClick={() => applyFilter(filter.value)}
-                      className="justify-start"
+                      className={cn("justify-start", selectedFilter === filter.value && "border-white text-white")}
                     >
                       {filter.label}
                     </Button>
@@ -136,20 +137,20 @@ export function BlogFilterSidebar({
               <AccordionContent>
                 <div className="grid grid-cols-1 gap-1 max-h-40 overflow-y-auto pt-2">
                   <Button
-                    variant={selectedDateFilter === "" ? "default" : "outline"}
+                    variant="outline"
                     size="sm"
                     onClick={() => setSelectedDateFilter("")}
-                    className="justify-start text-xs"
+                    className={cn("justify-start text-xs", selectedDateFilter === "" && "border-white text-white")}
                   >
                     All Dates
                   </Button>
                   {getDateOptions().map((dateOption) => (
                     <Button
                       key={dateOption.value}
-                      variant={selectedDateFilter === dateOption.value ? "default" : "outline"}
+                      variant="outline"
                       size="sm"
                       onClick={() => setSelectedDateFilter(dateOption.value)}
-                      className="justify-start text-xs"
+                      className={cn("justify-start text-xs", selectedDateFilter === dateOption.value && "border-white text-white")}
                     >
                       {dateOption.label}
                     </Button>
@@ -159,18 +160,18 @@ export function BlogFilterSidebar({
             </AccordionItem>
           </Accordion>
 
-          {hasActiveFilters && (
-            <div className="space-y-2">
-              <Button onClick={closeSidebar} className="w-full">
-                Go
-              </Button>
-              <Button variant="outline" onClick={clearSearch} className="w-full">
-                Clear All Filters
-              </Button>
-            </div>
-          )}
         </div>
       </SidebarContent>
+      {hasActiveFilters && (
+        <div className="space-y-2 fixed bottom-0 left-0 w-[--sidebar-width] p-6 bg-sidebar">
+          <Button onClick={closeSidebar} className="w-full">
+            Go
+          </Button>
+          <Button variant="outline" onClick={clearSearch} className="w-full">
+            Clear All Filters
+          </Button>
+        </div>
+      )}
     </>
   );
 }

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -12,7 +12,7 @@ import {
   SidebarProvider,
   useSidebar,
 } from "@/components/ui/sidebar";
-import BlogFilterSidebar from "@/components/blog/BlogFilterSidebar.tsx";
+import BlogFilterSidebar from "@/components/blog/BlogFilterSidebar";
 import { BlogPost } from "@/lib/blog";
 import { blogService } from "@/services/blogService";
 import { slugify } from "@/utils/slugify";
@@ -294,7 +294,7 @@ const BlogPageInner = () => {
               Discover tips, techniques, and stories from the world of outdoor gear
             </p>
 
-            <div className="flex justify-center">
+            <div className="flex justify-center md:hidden">
               <Button size="lg" className="gap-2" onClick={toggleSidebar}>
                 <Filter className="h-4 w-4" />
                 Search & Filter
@@ -422,7 +422,7 @@ const BlogPageInner = () => {
 };
 
 const BlogPage = () => (
-  <SidebarProvider defaultOpen={false} style={{ "--sidebar-width": "20rem" }}>
+  <SidebarProvider style={{ "--sidebar-width": "20rem" }}>
     <BlogPageInner />
   </SidebarProvider>
 );

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -3,12 +3,16 @@ import usePageMetadata from "@/hooks/usePageMetadata";
 import { Link, useSearchParams, useNavigate } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Search, Clock, User, Calendar, Filter, SortAsc, SortDesc } from "lucide-react";
+import { Clock, User, Calendar, Filter } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import {
+  Sidebar,
+  SidebarInset,
+  SidebarProvider,
+  useSidebar,
+} from "@/components/ui/sidebar";
+import BlogFilterSidebar from "@/components/blog/BlogFilterSidebar";
 import { BlogPost } from "@/lib/blog";
 import { blogService } from "@/services/blogService";
 import { slugify } from "@/utils/slugify";
@@ -17,7 +21,7 @@ import { useUserRole } from "@/hooks/useUserRole";
 import { toast } from "@/hooks/use-toast";
 import { featuredPostsService } from "@/services/featuredPostsService";
 
-const BlogPage = () => {
+const BlogPageInner = () => {
   usePageMetadata({
     title: 'DemoStoke Blog',
     description: 'Tips, gear reviews and stories from the DemoStoke community.'
@@ -35,9 +39,9 @@ const BlogPage = () => {
   const [featuredPosts, setFeaturedPosts] = useState<string[]>([]);
   const [sortBy, setSortBy] = useState<'latest' | 'oldest'>('latest');
   const [selectedDateFilter, setSelectedDateFilter] = useState<string>("");
-  const [isSheetOpen, setIsSheetOpen] = useState(false);
   const { data: userRole } = useUserRole();
   const isAdmin = userRole === 'admin';
+  const { toggleSidebar } = useSidebar();
 
   // Load all posts and featured posts on mount
   useEffect(() => {
@@ -261,7 +265,24 @@ const BlogPage = () => {
   };
 
   return (
-    <div className="min-h-screen">
+    <>
+      <Sidebar>
+        <BlogFilterSidebar
+          searchQuery={searchQuery}
+          setSearchQuery={setSearchQuery}
+          sortBy={sortBy}
+          setSortBy={setSortBy}
+          selectedFilter={selectedFilter}
+          applyFilter={applyFilter}
+          selectedDateFilter={selectedDateFilter}
+          setSelectedDateFilter={setSelectedDateFilter}
+          getDateOptions={getDateOptions}
+          clearSearch={clearSearch}
+          filters={filters}
+        />
+      </Sidebar>
+      <SidebarInset>
+        <div className="min-h-screen">
       {/* Hero Section */}
       <div className="py-16 text-gray-900 dark:text-white">
         <div className="container mx-auto px-4">
@@ -273,145 +294,11 @@ const BlogPage = () => {
               Discover tips, techniques, and stories from the world of outdoor gear
             </p>
 
-            {/* Search and Filter Sheet */}
             <div className="flex justify-center">
-              <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
-                <SheetTrigger asChild>
-                  <Button size="lg" className="gap-2">
-                    <Filter className="h-4 w-4" />
-                    Search & Filter
-                  </Button>
-                </SheetTrigger>
-                <SheetContent className="w-full sm:max-w-md overflow-y-auto">
-                  <SheetHeader>
-                    <SheetTitle>Search & Filter Posts</SheetTitle>
-                  </SheetHeader>
-                  
-                  <div className="space-y-6 mt-6 pb-6">
-                    {/* Search Bar */}
-                    <div>
-                      <label className="text-sm font-medium mb-2 block">Search</label>
-                      <div className="relative">
-                        <Input
-                          type="text"
-                          placeholder="Search blog posts..."
-                          value={searchQuery}
-                          onChange={(e) => setSearchQuery(e.target.value)}
-                          className="pl-10"
-                        />
-                        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-500" />
-                      </div>
-                    </div>
-
-                    {/* Sort Options */}
-                    <div>
-                      <label className="text-sm font-medium mb-2 block">Sort by Date</label>
-                      <div className="grid grid-cols-2 gap-2">
-                        <Button
-                          variant={sortBy === 'latest' ? "default" : "outline"}
-                          size="sm"
-                          onClick={() => setSortBy('latest')}
-                          className="gap-2"
-                        >
-                          <SortDesc className="h-3 w-3" />
-                          Latest
-                        </Button>
-                        <Button
-                          variant={sortBy === 'oldest' ? "default" : "outline"}
-                          size="sm"
-                          onClick={() => setSortBy('oldest')}
-                          className="gap-2"
-                        >
-                          <SortAsc className="h-3 w-3" />
-                          Oldest
-                        </Button>
-                      </div>
-                    </div>
-
-                    {/* Accordion for multi-row sections */}
-                    <Accordion type="multiple" defaultValue={["category", "date"]} className="w-full space-y-0">
-                      {/* Category Filter */}
-                      <AccordionItem value="category" className="border-none">
-                        <AccordionTrigger className="text-sm font-medium py-3">
-                          Category
-                        </AccordionTrigger>
-                        <AccordionContent>
-                          <div className="grid grid-cols-1 gap-2 pt-2">
-                            <Button
-                              variant={selectedFilter === "" ? "default" : "outline"}
-                              size="sm"
-                              onClick={() => applyFilter("")}
-                              className="justify-start"
-                            >
-                              All Posts
-                            </Button>
-                            {filters.map((filter) => (
-                              <Button
-                                key={filter.value}
-                                variant={selectedFilter === filter.value ? "default" : "outline"}
-                                size="sm"
-                                onClick={() => applyFilter(filter.value)}
-                                className="justify-start"
-                              >
-                                {filter.label}
-                              </Button>
-                            ))}
-                          </div>
-                        </AccordionContent>
-                      </AccordionItem>
-
-                      {/* Date Filter */}
-                      <AccordionItem value="date" className="border-none">
-                        <AccordionTrigger className="text-sm font-medium py-3">
-                          Filter by Month/Year
-                        </AccordionTrigger>
-                        <AccordionContent>
-                          <div className="grid grid-cols-1 gap-1 max-h-40 overflow-y-auto pt-2">
-                            <Button
-                              variant={selectedDateFilter === "" ? "default" : "outline"}
-                              size="sm"
-                              onClick={() => setSelectedDateFilter("")}
-                              className="justify-start text-xs"
-                            >
-                              All Dates
-                            </Button>
-                            {getDateOptions().map((dateOption) => (
-                              <Button
-                                key={dateOption.value}
-                                variant={selectedDateFilter === dateOption.value ? "default" : "outline"}
-                                size="sm"
-                                onClick={() => setSelectedDateFilter(dateOption.value)}
-                                className="justify-start text-xs"
-                              >
-                                {dateOption.label}
-                              </Button>
-                            ))}
-                          </div>
-                        </AccordionContent>
-                      </AccordionItem>
-                    </Accordion>
-
-                    {/* Go and Clear All buttons */}
-                    {(searchQuery || selectedFilter || selectedDateFilter || sortBy !== 'latest') && (
-                      <div className="space-y-2">
-                        <Button
-                          onClick={() => setIsSheetOpen(false)}
-                          className="w-full"
-                        >
-                          Go
-                        </Button>
-                        <Button
-                          variant="outline"
-                          onClick={clearSearch}
-                          className="w-full"
-                        >
-                          Clear All Filters
-                        </Button>
-                      </div>
-                    )}
-                  </div>
-                </SheetContent>
-              </Sheet>
+              <Button size="lg" className="gap-2" onClick={toggleSidebar}>
+                <Filter className="h-4 w-4" />
+                Search & Filter
+              </Button>
             </div>
           </div>
         </div>
@@ -529,7 +416,15 @@ const BlogPage = () => {
         )}
       </div>
     </div>
+  </SidebarInset>
+  </>
   );
 };
+
+const BlogPage = () => (
+  <SidebarProvider defaultOpen={false} style={{ "--sidebar-width": "20rem" }}>
+    <BlogPageInner />
+  </SidebarProvider>
+);
 
 export default BlogPage;

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -12,7 +12,7 @@ import {
   SidebarProvider,
   useSidebar,
 } from "@/components/ui/sidebar";
-import BlogFilterSidebar from "@/components/blog/BlogFilterSidebar";
+import BlogFilterSidebar from "@/components/blog/BlogFilterSidebar.tsx";
 import { BlogPost } from "@/lib/blog";
 import { blogService } from "@/services/blogService";
 import { slugify } from "@/utils/slugify";


### PR DESCRIPTION
## Summary
- replace blog filter sheet with sidebar and toggle button
- add BlogFilterSidebar component for search, sorting, and filter controls

## Testing
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_688ea23489248320a06223febf140bae