### PR TITLE
fix: sidebar close button

### DIFF
--- a/src/components/blog/BlogFilterSidebar.tsx
+++ b/src/components/blog/BlogFilterSidebar.tsx
@@ -49,7 +49,6 @@ export function BlogFilterSidebar({
   const previousIsMobileRef = useRef(isMobile);
 
   const closeSidebar = () => {
-    setOpen(false);
     setOpenMobile(false);
   };
 
@@ -183,7 +182,7 @@ export function BlogFilterSidebar({
         <div className="fixed bottom-0 left-0 p-6 bg-sidebar border-t space-y-2 z-10" style={{ width: 'var(--sidebar-width, 320px)' }}>
           {isMobile && (
             <Button onClick={closeSidebar} className="w-full">
-              Go
+              Close
             </Button>
           )}
           <Button variant="outline" onClick={clearSearch} className="w-full">


### PR DESCRIPTION
## Summary
- ensure mobile sidebar close button only affects mobile state so desktop view remains open
- rename sidebar action button to "Close" for clarity

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot read properties of undefined (reading 'allowShortCircuit'))*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_688ee182d5548320b77c0bb52669874e