### PR TITLE
Stack gear header buttons on mobile for authorized users

### DIFF
--- a/src/components/equipment-detail/EquipmentHeader.tsx
+++ b/src/components/equipment-detail/EquipmentHeader.tsx
@@ -6,18 +6,27 @@ import PriceDisplay from "./PriceDisplay";
 import DistanceDisplay from "@/components/DistanceDisplay";
 import { Link } from "react-router-dom";
 import { slugify } from "@/utils/slugify";
+import { cn } from "@/lib/utils";
 
 interface EquipmentHeaderProps {
   equipment: Equipment;
+  stackOnMobile?: boolean;
 }
 
-const EquipmentHeader = ({ equipment }: EquipmentHeaderProps) => {
+const EquipmentHeader = ({ equipment, stackOnMobile = false }: EquipmentHeaderProps) => {
 
   // Create tracking data for analytics
   const trackingData = `${equipment.owner.name} - ${equipment.name}`;
 
   return (
-    <div className="flex justify-between items-start mb-4">
+    <div
+      className={cn(
+        "mb-4",
+        stackOnMobile
+          ? "flex flex-col md:flex-row md:justify-between md:items-start"
+          : "flex justify-between items-start"
+      )}
+    >
       <div className="flex-1">
         <div className="flex items-center gap-4 mb-2">
           <h1 className="text-3xl font-bold">{equipment.name}</h1>
@@ -68,7 +77,9 @@ const EquipmentHeader = ({ equipment }: EquipmentHeaderProps) => {
           </div>
         </div>
       </div>
-      <PriceDisplay equipment={equipment} equipmentHeader />
+      <div className={stackOnMobile ? "mt-4 md:mt-0" : ""}>
+        <PriceDisplay equipment={equipment} equipmentHeader />
+      </div>
     </div>
   );
 };

--- a/src/pages/EquipmentDetailPageDb.tsx
+++ b/src/pages/EquipmentDetailPageDb.tsx
@@ -230,12 +230,18 @@ const EquipmentDetailPageDb: React.FC<EquipmentDetailPageDbProps> = ({
           </div>
           {/* Equipment Info */}
           <div>
-            <div className="flex justify-between items-start mb-4">
+            <div
+              className={`mb-4 ${
+                canEdit
+                  ? "flex flex-col md:flex-row md:justify-between md:items-start"
+                  : "flex justify-between items-start"
+              }`}
+            >
               <div className="flex-1">
-                <EquipmentHeader equipment={equipment} />
+                <EquipmentHeader equipment={equipment} stackOnMobile={canEdit} />
               </div>
               {canEdit && (
-                <div className="flex gap-2 flex-col ml-4">
+                <div className="flex gap-2 flex-col mt-4 md:mt-0 md:ml-4">
                   <Button
                     variant="outline"
                     size="sm"


### PR DESCRIPTION
## Summary
- stack gear title, price, and edit/delete/hide controls vertically on mobile when user can manage gear
- preserve existing layout for guests and desktop screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: TypeError loading rule '@typescript-eslint/no-unused-expressions')*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6890f093e79c8320afac4e32e0b12445