### PR TITLE
Add slugified event URLs and map links for demo events

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev:ssr": "node server/index.js",
     "build:client": "vite build",
     "build:server": "vite build --ssr src/entry-server.tsx --outDir dist/server",
-    "build": "npm run build:client && npm run build:server",
+    "build": "npm run generate-sitemap && npm run build:client && npm run build:server",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "type-check": "tsc --noEmit",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,6 +1,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import { format } from 'date-fns';
 
 const SUPABASE_URL = process.env.VITE_SUPABASE_URL;
 const SUPABASE_KEY = process.env.VITE_SUPABASE_ANON_KEY;
@@ -46,6 +47,32 @@ async function fetchEquipment() {
   }));
 }
 
+function slugify(text) {
+  return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+function generateEventSlug(event) {
+  const titlePart = slugify(event.title);
+  const datePart = event.event_date ? format(new Date(event.event_date + 'T00:00:00'), 'MM-dd-yyyy') : 'tbd';
+  const timePart = event.event_time ? event.event_time.replace(':', '') : 'tbd';
+  return `${titlePart}-${datePart}-${timePart}`;
+}
+
+async function fetchDemoEvents() {
+  if (!supabase) return [];
+  const { data, error } = await supabase
+    .from('demo_calendar')
+    .select('title, event_date, event_time, updated_at');
+  if (error) {
+    console.error('Error fetching demo events:', error);
+    return [];
+  }
+  return (data || []).map(ev => ({
+    loc: `${baseUrl}/demo-calendar/event/${generateEventSlug(ev)}`,
+    lastmod: ev.updated_at ? new Date(ev.updated_at).toISOString() : undefined,
+  }));
+}
+
 async function generate() {
   await initSupabase();
   const staticUrls = [
@@ -69,8 +96,12 @@ async function generate() {
     '/demo-calendar',
   ].map(p => ({ loc: `${baseUrl}${p}` }));
 
-  const [blogUrls, equipmentUrls] = await Promise.all([fetchBlogPosts(), fetchEquipment()]);
-  const urls = [...staticUrls, ...blogUrls, ...equipmentUrls];
+  const [blogUrls, equipmentUrls, demoEventUrls] = await Promise.all([
+    fetchBlogPosts(),
+    fetchEquipment(),
+    fetchDemoEvents()
+  ]);
+  const urls = [...staticUrls, ...blogUrls, ...equipmentUrls, ...demoEventUrls];
 
   const xmlLines = [
     '<?xml version="1.0" encoding="UTF-8"?>',

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -8,6 +8,11 @@ const SUPABASE_KEY = process.env.VITE_SUPABASE_ANON_KEY;
 
 let supabase;
 async function initSupabase() {
+  if (!SUPABASE_URL || !SUPABASE_KEY) {
+    console.warn('Supabase credentials are not set; dynamic routes will be skipped.');
+    supabase = null;
+    return;
+  }
   try {
     const { createClient } = await import('@supabase/supabase-js');
     supabase = createClient(SUPABASE_URL, SUPABASE_KEY);

--- a/src/components/AppRoutes.tsx
+++ b/src/components/AppRoutes.tsx
@@ -66,6 +66,7 @@ const AppRoutes = () => {
           <Route path="private-party/:partyId" element={<PrivatePartyPage />} />
           <Route path="search" element={<SearchResultsPage />} />
           <Route path="demo-calendar" element={<DemoCalendarPage />} />
+          <Route path="demo-calendar/event/:eventSlug" element={<DemoCalendarPage />} />
           <Route path="*" element={<NotFoundPage />} />
         </Route>
     </Routes>

--- a/src/components/demo-calendar/CalendarGrid.tsx
+++ b/src/components/demo-calendar/CalendarGrid.tsx
@@ -1,12 +1,10 @@
 
-import { useState } from "react";
-import { startOfMonth, endOfMonth, eachDayOfInterval, isSameDay, parseISO, startOfWeek, endOfWeek } from "date-fns";
+import { startOfMonth, endOfMonth, eachDayOfInterval, isSameDay, startOfWeek, endOfWeek } from "date-fns";
 import { DemoEvent, CategoryFilter } from "@/types/demo-calendar";
 import CalendarHeader from "./CalendarHeader";
 import CalendarDaysHeader from "./CalendarDaysHeader";
 import CalendarDay from "./CalendarDay";
 import TBDEventsSection from "./TBDEventsSection";
-import EventModal from "./EventModal";
 import { useIsMobile } from "@/hooks/use-mobile";
 
 interface CalendarGridProps {
@@ -21,6 +19,7 @@ interface CalendarGridProps {
   onChangeView: (mode: 'calendar' | 'list') => void;
   onEditEvent: (event: DemoEvent) => void;
   onDeleteEvent: (eventId: string) => void;
+  onEventClick: (event: DemoEvent) => void;
   isDeleting?: boolean;
   isAdmin: boolean;
   isLoadingRole: boolean;
@@ -44,14 +43,12 @@ const CalendarGrid = ({
   onChangeView,
   onEditEvent,
   onDeleteEvent,
+  onEventClick,
   isDeleting,
   isAdmin,
   isLoadingRole
 }: CalendarGridProps) => {
   const isMobile = useIsMobile();
-  const [selectedEvent, setSelectedEvent] = useState<DemoEvent | null>(null);
-
-
   const monthStart = startOfMonth(currentDate);
   const monthEnd = endOfMonth(currentDate);
   
@@ -86,24 +83,6 @@ const CalendarGrid = ({
   // Get events without dates (TBD events)
   const tbdEvents = filteredEvents.filter(event => !event.event_date);
 
-  const handleEventClick = (event: DemoEvent) => {
-    setSelectedEvent(event);
-  };
-
-  const handleCloseModal = () => {
-    setSelectedEvent(null);
-  };
-
-  const handleEditFromModal = (event: DemoEvent) => {
-    setSelectedEvent(null);
-    onEditEvent(event);
-  };
-
-  const handleDeleteFromModal = (eventId: string) => {
-    setSelectedEvent(null);
-    onDeleteEvent(eventId);
-  };
-
   return (
     <div className="bg-card rounded-lg shadow-sm border">
       <CalendarHeader
@@ -134,7 +113,7 @@ const CalendarGrid = ({
               categoryFilters={categoryFilters}
               onEditEvent={onEditEvent}
               onDeleteEvent={onDeleteEvent}
-              onEventClick={handleEventClick}
+              onEventClick={onEventClick}
               isDeleting={isDeleting}
               isAdmin={isAdmin}
             />
@@ -147,18 +126,7 @@ const CalendarGrid = ({
         categoryFilters={categoryFilters}
         onEditEvent={onEditEvent}
         onDeleteEvent={onDeleteEvent}
-        onEventClick={handleEventClick}
-        isDeleting={isDeleting}
-        isAdmin={isAdmin}
-      />
-
-      {/* Event Modal */}
-      <EventModal
-        event={selectedEvent}
-        categoryColors={categoryFilters}
-        onClose={handleCloseModal}
-        onEdit={handleEditFromModal}
-        onDelete={handleDeleteFromModal}
+        onEventClick={onEventClick}
         isDeleting={isDeleting}
         isAdmin={isAdmin}
       />

--- a/src/components/demo-calendar/CalendarList.tsx
+++ b/src/components/demo-calendar/CalendarList.tsx
@@ -1,9 +1,7 @@
-import { useState } from "react";
 import { format, startOfMonth, endOfMonth, eachDayOfInterval, isSameDay } from "date-fns";
 import { DemoEvent, CategoryFilter } from "@/types/demo-calendar";
 import CalendarHeader from "./CalendarHeader";
 import TBDEventsSection from "./TBDEventsSection";
-import EventModal from "./EventModal";
 import EventListItem from "./EventListItem";
 
 interface CalendarListProps {
@@ -18,6 +16,7 @@ interface CalendarListProps {
   onChangeView: (mode: 'calendar' | 'list') => void;
   onEditEvent: (event: DemoEvent) => void;
   onDeleteEvent: (eventId: string) => void;
+  onEventClick: (event: DemoEvent) => void;
   isDeleting?: boolean;
   isAdmin: boolean;
   isLoadingRole: boolean;
@@ -39,12 +38,11 @@ const CalendarList = ({
   onChangeView,
   onEditEvent,
   onDeleteEvent,
+  onEventClick,
   isDeleting,
   isAdmin,
   isLoadingRole
 }: CalendarListProps) => {
-  const [selectedEvent, setSelectedEvent] = useState<DemoEvent | null>(null);
-
   const monthStart = startOfMonth(currentDate);
   const monthEnd = endOfMonth(currentDate);
 
@@ -69,24 +67,6 @@ const CalendarList = ({
     });
     return { day, events: dayEvents };
   }).filter(group => group.events.length > 0);
-
-  const handleEventClick = (event: DemoEvent) => {
-    setSelectedEvent(event);
-  };
-
-  const handleCloseModal = () => {
-    setSelectedEvent(null);
-  };
-
-  const handleEditFromModal = (event: DemoEvent) => {
-    setSelectedEvent(null);
-    onEditEvent(event);
-  };
-
-  const handleDeleteFromModal = (eventId: string) => {
-    setSelectedEvent(null);
-    onDeleteEvent(eventId);
-  };
 
   return (
     <div className="bg-card rounded-lg shadow-sm border">
@@ -116,7 +96,7 @@ const CalendarList = ({
                   categoryColors={categoryFilters}
                   onEdit={onEditEvent}
                   onDelete={onDeleteEvent}
-                  onEventClick={handleEventClick}
+                  onEventClick={onEventClick}
                   isDeleting={isDeleting}
                   isAdmin={isAdmin}
                 />
@@ -134,17 +114,7 @@ const CalendarList = ({
         categoryFilters={categoryFilters}
         onEditEvent={onEditEvent}
         onDeleteEvent={onDeleteEvent}
-        onEventClick={handleEventClick}
-        isDeleting={isDeleting}
-        isAdmin={isAdmin}
-      />
-
-      <EventModal
-        event={selectedEvent}
-        categoryColors={categoryFilters}
-        onClose={handleCloseModal}
-        onEdit={handleEditFromModal}
-        onDelete={handleDeleteFromModal}
+        onEventClick={onEventClick}
         isDeleting={isDeleting}
         isAdmin={isAdmin}
       />

--- a/src/components/demo-calendar/EventModal.tsx
+++ b/src/components/demo-calendar/EventModal.tsx
@@ -84,7 +84,14 @@ const EventModal = ({
             {event.location && (
               <div className="flex items-center gap-2 text-sm">
                 <MapPin className="h-4 w-4 text-muted-foreground" />
-                <span>{event.location}</span>
+                <a
+                  href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.location)}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-primary"
+                >
+                  {event.location}
+                </a>
               </div>
             )}
             

--- a/src/utils/eventSlug.ts
+++ b/src/utils/eventSlug.ts
@@ -1,0 +1,16 @@
+import { format } from "date-fns";
+import { DemoEvent } from "@/types/demo-calendar";
+import { slugify } from "./slugify";
+
+const parseLocalDate = (dateStr: string) => new Date(dateStr + 'T00:00:00');
+
+export const generateEventSlug = (event: DemoEvent): string => {
+  const titlePart = slugify(event.title);
+  const datePart = event.event_date ? format(parseLocalDate(event.event_date), 'MM-dd-yyyy') : 'tbd';
+  const timePart = event.event_time ? event.event_time.replace(':', '') : 'tbd';
+  return `${titlePart}-${datePart}-${timePart}`;
+};
+
+export const findEventBySlug = (events: DemoEvent[], slug: string): DemoEvent | null => {
+  return events.find(ev => generateEventSlug(ev) === slug) || null;
+};


### PR DESCRIPTION
## Summary
- Link demo event addresses to Google Maps within the event modal.
- Introduce slugified event URLs that sync with modal state and update browser history, enabling direct links and SEO-friendly routing.
- Include demo event pages in sitemap generation for improved discoverability.

## Testing
- `npm run lint` *(fails: TypeError: Error while loading rule '@typescript-eslint/no-unused-expressions')*
- `npm run type-check`
- `npm test` *(fails: Missing script: "test")*
- `node ./scripts/generate-sitemap.js`

------
https://chatgpt.com/codex/tasks/task_e_6894f0f762cc832081dabb03520b256b