### PR TITLE
Fix hero image mapping and author slugs

### DIFF
--- a/src/pages/BlogCreatePage.tsx
+++ b/src/pages/BlogCreatePage.tsx
@@ -20,6 +20,7 @@ import { SidebarProvider, SidebarInset, useSidebar } from "@/components/ui/sideb
 import { BlogCreateSidebar } from "@/components/blog/BlogCreateSidebar";
 import BlogFooter from "@/components/BlogFooter";
 import { cn } from "@/lib/utils";
+import { slugify } from "@/utils/slugify";
 
 const categories = [
   "snowboards",
@@ -122,16 +123,12 @@ function BlogCreatePageInner() {
 
       const readTime = Math.ceil(content.split(' ').length / 200);
 
-      // Handle image field mapping correctly
+      // Prepare image URLs
       const heroImg = imageUrl.trim();
       const thumbImg = thumbnailUrl.trim();
-      
-      // Determine final image URLs based on logic
+
       let finalThumbnail = '';
-      let finalHeroImage = '';
-      
       if (useYoutubeThumbnail && youtubeUrl) {
-        // Extract YouTube thumbnail from URL
         const youtubeId = youtubeUrl.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&\n?#]+)/)?.[1];
         if (youtubeId) {
           finalThumbnail = `https://img.youtube.com/vi/${youtubeId}/maxresdefault.jpg`;
@@ -141,21 +138,17 @@ function BlogCreatePageInner() {
       } else if (heroImg) {
         finalThumbnail = heroImg;
       }
-      
-      if (useHeroImage && heroImg) {
-        finalHeroImage = heroImg;
-      } else {
-        finalHeroImage = finalThumbnail;
-      }
 
+      const finalHeroImage = heroImg || finalThumbnail;
       const formattedCategory = category.replace(/-/g, " ");
+      const authorSlug = slugify(author.trim());
       const postData = {
         title: title.trim(),
         excerpt: excerpt.trim(),
         content: content.trim(),
         category: formattedCategory,
         author: author.trim(),
-        authorId: user?.id || '',
+        authorId: authorSlug,
         slug,
         readTime,
         tags: tags.split(',').map(tag => tag.trim()).filter(Boolean),

--- a/src/services/blog/generateBlogPost.ts
+++ b/src/services/blog/generateBlogPost.ts
@@ -5,7 +5,6 @@ export interface GenerateBlogPostParams {
   prompt: string;
   category: string;
   author: string;
-  authorId: string;
   tags: string[];
   thumbnail: string;
   heroImage: string;

--- a/supabase/functions/generate-blog-post/index.ts
+++ b/supabase/functions/generate-blog-post/index.ts
@@ -12,7 +12,6 @@ interface GenerateBlogPostRequest {
   prompt: string;
   category: string;
   author: string;
-  authorId: string;
   tags: string[];
   thumbnail: string;
   heroImage: string;
@@ -20,6 +19,13 @@ interface GenerateBlogPostRequest {
   useYoutubeThumbnail: boolean;
   useYoutubeHero: boolean;
   publishedAt: string;
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
 }
 
 serve(async (req) => {
@@ -202,6 +208,7 @@ Format the response as a JSON object with the following structure:
       .replace(/[^a-z0-9]+/g, '-')
       .replace(/^-+|-+$/g, '');
 
+    const authorSlug = slugify(requestData.author);
     const { data: blogPost, error: insertError } = await supabase
       .from('blog_posts')
       .insert([{
@@ -211,7 +218,7 @@ Format the response as a JSON object with the following structure:
         content: parsedContent.content,
         category: requestData.category,
         author: requestData.author,
-        author_id: requestData.authorId,
+        author_id: authorSlug,
         tags: requestData.tags,
         thumbnail: requestData.thumbnail,
         hero_image: requestData.heroImage,


### PR DESCRIPTION
## Summary
- Ensure blog creation uses dedicated hero image when provided and slugifies author names for IDs.
- Slugify author names in blog post generation edge function and store in `author_id`.
- Drop unused authorId parameter from blog post generation service.

## Testing
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68a0d3c0a6188320bb7ca5f334c7b84c