### PR TITLE
Stabilize calculate-distance CTA tests with a fixed clock

### DIFF
--- a/src/__tests__/calculate-distance-cta.test.tsx
+++ b/src/__tests__/calculate-distance-cta.test.tsx
@@ -125,11 +125,14 @@ describe("Property 1: No auto-request on mount without cache", () => {
  */
 describe("Property 6: Fresh cache skips permission prompt", () => {
   let getCurrentPositionMock: ReturnType<typeof vi.fn>;
+  const fixedNow = new Date("2026-01-01T00:00:00.000Z");
 
   beforeEach(async () => {
     const real = await vi.importActual<typeof import("../hooks/useGeolocation")>("../hooks/useGeolocation");
     vi.mocked(useGeolocation).mockImplementation(real.useGeolocation);
 
+    vi.useFakeTimers();
+    vi.setSystemTime(fixedNow);
     localStorage.clear();
 
     getCurrentPositionMock = vi.fn();
@@ -142,6 +145,7 @@ describe("Property 6: Fresh cache skips permission prompt", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
     localStorage.clear();
   });
 


### PR DESCRIPTION
## Summary
- Fix the flaky fresh-cache property in `src/__tests__/calculate-distance-cta.test.tsx` by freezing time inside the affected describe block
- Keep the cache age invariant intact while removing the CI race between seeding `localStorage` and reading the cached timestamp
- This branch is a focused test-only change relative to `main`

## Testing
- `npm run test:unit -- src/__tests__/calculate-distance-cta.test.tsx`
- `npm run type-check`
- `npm run test:unit`