### PR TITLE
Document Supabase Data API GRANT requirement for new tables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,23 @@
 - Durable schema/type source for agents is `src/integrations/supabase/types.ts`. If migrations change tables or RPCs, update that type file and this memory.
 - Public marketplace reads often flow through `getEquipmentData()` in `src/services/equipment/equipmentDataService.ts`, which can switch between Supabase and an external shop feed.
 
+## Supabase Data API Grants (new tables only)
+
+Starting Oct 30, 2026, new tables in `public` are not auto-exposed to the Data API (supabase-js / PostgREST / GraphQL). Existing tables are grandfathered — no retroactive migration is needed.
+
+Any new `CREATE TABLE public.<name>` migration must include explicit grants in the same file, e.g.:
+
+```sql
+grant select, insert, update, delete on public.<name> to authenticated;
+grant select, insert, update, delete on public.<name> to service_role;
+grant select on public.<name> to anon;  -- only if anon should read it
+
+alter table public.<name> enable row level security;
+-- ... policies ...
+```
+
+If a grant is missing, PostgREST returns error code `42501` with the exact GRANT statement needed.
+
 ## Supabase Edge Function Inventory
 - Search / AI:
   - `ai-search`


### PR DESCRIPTION
## Summary
- Supabase is changing Data API exposure: as of **Oct 30, 2026**, new `public`-schema tables will not be auto-exposed to `supabase-js` / PostgREST / GraphQL without explicit `GRANT` statements. Existing tables are grandfathered.
- Adds a "Supabase Data API Grants (new tables only)" section to `AGENTS.md` so future `CREATE TABLE public.*` migrations include the required GRANTs from the start. `CLAUDE.md` and `GEMINI.md` already import `AGENTS.md`, so they inherit it.
- No SQL migrations, no code changes — existing tables retain their current grants and need no retroactive patches.

## Test plan
- [ ] Docs-only change; no runtime impact.
- [ ] Next time a public table is added, confirm the new migration includes `grant ... to authenticated` (and `service_role`/`anon` as appropriate) and that the table is reachable via `supabase-js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)