### PR TITLE
Bump fast-uri to 3.1.2 to fix npm audit advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5119,7 +5119,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
- Runs `npm audit fix` to bump transitive dep `fast-uri` from 3.1.0 → 3.1.2.
- Dependency path: `serve` → `ajv@8.18.0` → `fast-uri`.
- Resolves two high-severity advisories:
  - [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) — path traversal via percent-encoded dot segments
  - [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) — host confusion via percent-encoded authority delimiters
- Package-lock-only change; no `package.json` edits and no direct dep upgrades.

## Test plan
- [x] `npm audit` now reports `found 0 vulnerabilities`.
- [ ] CI (`lint`, `type-check`, `build`, `test:unit`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)