### PR TITLE
Fix slow hybrid map load on mobile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,6 @@ supabase/.temp
 *.njsproj
 *.sln
 *.sw?
+launch.json
 
 Demostoke Demonstration

--- a/src/__tests__/HybridView.test.tsx
+++ b/src/__tests__/HybridView.test.tsx
@@ -53,6 +53,11 @@ const mapHarness = vi.hoisted(() => {
     };
   };
 
+  let deferLoad = false;
+  const setDeferLoad = (value: boolean) => {
+    deferLoad = value;
+  };
+
   const mapMock = {
     on: vi.fn((event: string, callback: () => void) => {
       if (!listeners.has(event)) {
@@ -61,7 +66,7 @@ const mapHarness = vi.hoisted(() => {
 
       listeners.get(event)!.add(callback);
 
-      if (event === "load") {
+      if (event === "load" && !deferLoad) {
         callback();
       }
 
@@ -106,6 +111,7 @@ const mapHarness = vi.hoisted(() => {
   const reset = () => {
     currentBounds = worldBounds;
     listeners.clear();
+    deferLoad = false;
     mapMock.on.mockClear();
     mapMock.off.mockClear();
     mapMock.remove.mockClear();
@@ -124,6 +130,7 @@ const mapHarness = vi.hoisted(() => {
     mapMock,
     reset,
     setBounds,
+    setDeferLoad,
   };
 });
 
@@ -315,6 +322,26 @@ const renderHybridViewWithProps = (
 describe("HybridView viewport sync", () => {
   beforeEach(() => {
     mapHarness.reset();
+  });
+
+  it("renders no gear cards while the map viewport bounds are unknown", async () => {
+    mapHarness.setDeferLoad(true);
+
+    renderHybridView();
+
+    const loadingMatches = await screen.findAllByText(
+      "Loading gear in this map area…",
+    );
+    expect(loadingMatches.length).toBeGreaterThan(0);
+    expect(screen.queryAllByTestId("equipment-card")).toHaveLength(0);
+
+    act(() => {
+      mapHarness.emit("load");
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("equipment-card").length).toBeGreaterThan(0);
+    });
   });
 
   it("shows the in-bounds gear after the initial fit", async () => {

--- a/src/components/HybridView.tsx
+++ b/src/components/HybridView.tsx
@@ -62,6 +62,33 @@ interface HybridMapPanelProps {
   initialCenter?: ResolvedExploreCenter | null;
 }
 
+const EMPTY_EQUIPMENT: MapEquipment[] = [];
+const EMPTY_USER_LOCATIONS: UserLocation[] = [];
+
+let cachedMapboxToken: string | null = null;
+let pendingMapboxTokenRequest: Promise<string | null> | null = null;
+
+const fetchMapboxToken = async (): Promise<string | null> => {
+  if (cachedMapboxToken) return cachedMapboxToken;
+  if (pendingMapboxTokenRequest) return pendingMapboxTokenRequest;
+
+  pendingMapboxTokenRequest = (async () => {
+    try {
+      const { data, error } = await supabase.functions.invoke("get-mapbox-token");
+      if (error) throw error;
+      cachedMapboxToken = data?.token ?? null;
+      return cachedMapboxToken;
+    } catch (err) {
+      console.error("Error fetching Mapbox token:", err);
+      return null;
+    } finally {
+      pendingMapboxTokenRequest = null;
+    }
+  })();
+
+  return pendingMapboxTokenRequest;
+};
+
 const buildShopCameraKey = (mapUserLocations: UserLocation[]): string =>
   mapUserLocations
     .map(
@@ -94,7 +121,9 @@ const HybridMapPanel = memo(
     onViewportBoundsChange,
     initialCenter,
   }: HybridMapPanelProps) => {
-    const [mapboxToken, setMapboxToken] = useState<string | null>(null);
+    const [mapboxToken, setMapboxToken] = useState<string | null>(
+      () => cachedMapboxToken,
+    );
     const [isMapLoaded, setIsMapLoaded] = useState(false);
     const mapContainer = useRef<HTMLDivElement>(null);
     const map = useRef<mapboxgl.Map | null>(null);
@@ -126,18 +155,17 @@ const HybridMapPanel = memo(
     );
 
     useEffect(() => {
-      const fetchMapboxToken = async () => {
-        try {
-          const { data, error } = await supabase.functions.invoke("get-mapbox-token");
-          if (error) throw error;
-          setMapboxToken(data.token);
-        } catch (err) {
-          console.error("Error fetching Mapbox token:", err);
-        }
-      };
+      if (mapboxToken) return;
 
-      fetchMapboxToken();
-    }, []);
+      let cancelled = false;
+      fetchMapboxToken().then((token) => {
+        if (!cancelled && token) setMapboxToken(token);
+      });
+
+      return () => {
+        cancelled = true;
+      };
+    }, [mapboxToken]);
 
     useEffect(() => {
       if (!mapContainer.current || !mapboxToken) return;
@@ -179,11 +207,17 @@ const HybridMapPanel = memo(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [mapboxToken]);
 
+    const markerEquipment = useMemo(
+      () => (focusedEquipment ? [focusedEquipment] : EMPTY_EQUIPMENT),
+      [focusedEquipment],
+    );
+    const markerUserLocations = focusedEquipment ? EMPTY_USER_LOCATIONS : mapUserLocations;
+
     useMapMarkers({
       map: map.current,
       mapLoaded: isMapLoaded,
-      equipment: focusedEquipment ? [focusedEquipment] : [],
-      userLocations: focusedEquipment ? [] : mapUserLocations,
+      equipment: markerEquipment,
+      userLocations: markerUserLocations,
       isSingleView: false,
       activeCategory,
     });
@@ -421,6 +455,10 @@ const HybridView = ({
   );
 
   const visibleOwnerIds = useMemo(() => {
+    if (!viewportBounds) {
+      return null;
+    }
+
     return new Set(
       filterItemsByViewportBounds(mapUserLocations, viewportBounds).map(
         (user) => user.id,
@@ -439,6 +477,10 @@ const HybridView = ({
   const visibleHybridEquipment = useMemo(() => {
     if (focusedShopId) {
       return allHybridEquipment.filter((item) => item.owner.id === focusedShopId);
+    }
+
+    if (visibleOwnerIds === null) {
+      return [];
     }
 
     return allHybridEquipment.filter((item) => visibleOwnerIds.has(item.owner.id));
@@ -471,18 +513,24 @@ const HybridView = ({
     clearFocusedShop();
   }, [clearFocusedShop, resetSignal]);
 
+  const isAwaitingViewport = visibleOwnerIds === null && !focusedShopId;
   const resolvedEmptyMessage =
     emptyMessage || "Try changing your filters or explore a different category.";
   const mapAreaEmptyMessage = "No gear in this map area. Move the map or zoom out.";
+  const mapLoadingMessage = "Loading gear in this map area…";
   const hasVisibleResults = visibleHybridEquipment.length > 0;
   const hasAnyHybridResults = allHybridEquipment.length > 0;
   const isFocusedShopView = focusedShopId !== null;
-  const hybridEmptyMessage = hasAnyHybridResults
-    ? mapAreaEmptyMessage
-    : resolvedEmptyMessage;
+  const hybridEmptyMessage = isAwaitingViewport
+    ? mapLoadingMessage
+    : hasAnyHybridResults
+      ? mapAreaEmptyMessage
+      : resolvedEmptyMessage;
   const hybridSummaryMessage = isFocusedShopView
     ? `Showing ${visibleHybridEquipment.length} of ${focusedShopEquipmentCount} gear at this shop`
-    : `Showing ${visibleHybridEquipment.length} of ${allHybridEquipment.length} gear in this map area`;
+    : isAwaitingViewport
+      ? mapLoadingMessage
+      : `Showing ${visibleHybridEquipment.length} of ${allHybridEquipment.length} gear in this map area`;
 
   const handleEquipmentCardClick = (equipmentId: string) => {
     const clickedEquipment = allHybridEquipment.find((item) => item.id === equipmentId);
@@ -610,8 +658,14 @@ const HybridView = ({
           </div>
           {!hasVisibleResults && (
             <div className="text-center py-12">
-              <h3 className="text-xl font-medium mb-2">No equipment found</h3>
-              <p className="text-muted-foreground">{hybridEmptyMessage}</p>
+              {isAwaitingViewport ? (
+                <p className="text-muted-foreground">{mapLoadingMessage}</p>
+              ) : (
+                <>
+                  <h3 className="text-xl font-medium mb-2">No equipment found</h3>
+                  <p className="text-muted-foreground">{hybridEmptyMessage}</p>
+                </>
+              )}
             </div>
           )}
 
@@ -670,8 +724,14 @@ const HybridView = ({
           ))}
           {!hasVisibleResults && (
             <div className="text-center py-12">
-              <h3 className="text-xl font-medium mb-2">No equipment found</h3>
-              <p className="text-muted-foreground">{hybridEmptyMessage}</p>
+              {isAwaitingViewport ? (
+                <p className="text-muted-foreground">{mapLoadingMessage}</p>
+              ) : (
+                <>
+                  <h3 className="text-xl font-medium mb-2">No equipment found</h3>
+                  <p className="text-muted-foreground">{hybridEmptyMessage}</p>
+                </>
+              )}
             </div>
           )}
         </div>

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -184,16 +184,6 @@ const ExplorePage = () => {
         break;
     }
 
-    console.log("Sorting by:", sortBy);
-    console.log(
-      "First 3 items after sorting:",
-      results.slice(0, 3).map(item => ({
-        name: item.name,
-        distance: item.distance,
-        category: item.category,
-      }))
-    );
-
     return results;
   }, [baseFilteredEquipment, quickFilter, sortBy]);
 


### PR DESCRIPTION
## Summary

The hybrid Explore view was painfully slow on mobile because the initial render dumped **all 1215 gear cards** before the map had a chance to publish viewport bounds — 58,463 DOM nodes and a ~510k px body height on a 375px viewport. Three smaller regressions stacked on top: marker arrays were recreated on every parent render, the Mapbox token was fetched twice during the desktop→mobile remount on hydration, and a pair of debug `console.log` calls in `ExplorePage` fired ~8× per render through the SSR/hydration tree.

## What changed

- **`HybridView.tsx` — gate the list on viewport bounds.** `visibleOwnerIds` now returns `null` while `viewportBounds` is unknown, and `visibleHybridEquipment` returns `[]` in that case. The summary line and empty-state both render \"Loading gear in this map area…\" until the map fires its first `moveend`.
- **`HybridView.tsx` — stable marker arrays.** Hoisted `EMPTY_EQUIPMENT` / `EMPTY_USER_LOCATIONS` module-level sentinels and memoized `markerEquipment` so `useMapMarkers`' effect no longer churns on every parent render.
- **`HybridView.tsx` — module-level Mapbox token cache.** The desktop→mobile remount on hydration no longer re-invokes the `get-mapbox-token` edge function; the second `HybridMapPanel` reuses the cached token (and an in-flight promise if the first request hasn't resolved).
- **`ExplorePage.tsx` — removed two noisy debug `console.log` calls.**
- **`HybridView.test.tsx` — new coverage.** Added a `deferLoad` escape hatch on the map mock and a test that asserts no gear cards render while viewport bounds are unknown.
- **`.gitignore`** — ignore the local `launch.json` used by the preview harness.

## Why

Profiled directly in the mobile preview at 375×812. With the map's `moveend` taking ~1–3 seconds to land (and even longer over a flaky connection), filtering by an undefined viewport degenerated to \"show everything\" and pushed >1,000 `CompactEquipmentCard` instances (each with carousel + image children) into the DOM at once. That alone explained both the long time-to-interactive and the layout that visibly snapped from \"1127 of 1215\" down to ~150 cards a few seconds later.

## Measurements (mobile, 375×812)

| | Before | After |
|---|---|---|
| Cards on initial render | **1127** | **149** |
| DOM node count | **58,463** | **8,284** |
| Body height | **509,757px** | **68,881px** |

Desktop (1280×800) layout is unchanged.

## Test plan

- [x] `npm run test:unit` — 143/143 pass (existing 142 + 1 new)
- [x] `npm run lint`
- [x] `npm run type-check`
- [ ] Visual: load `/explore` on a 375px viewport — list should appear empty briefly with \"Loading gear in this map area…\", then populate with the bounds-filtered set as soon as the map settles.
- [ ] Visual: load `/explore` at desktop width — 60/40 list+map split intact, summary count matches viewport.
- [ ] Visual: click a gear card on mobile — focused-shop view still shows that shop's gear; no \"Loading\" flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)