### PR TITLE
fix: warm up entry-server import in SEO test setup

### DIFF
--- a/src/__tests__/server-seo-behavior.test.ts
+++ b/src/__tests__/server-seo-behavior.test.ts
@@ -45,6 +45,9 @@ const get = async (pathname: string) => {
 beforeAll(async () => {
   process.env.NODE_ENV = "test";
   ({ app } = await import("../../server/index.js"));
+  // Warm up the lazy entry-server.js import so the first real test isn't
+  // charged for it and pushed past the per-test timeout.
+  await get("/");
 }, 30000);
 
 describe("SEO server behavior", () => {


### PR DESCRIPTION
## Summary
- The first request in `server-seo-behavior.test.ts` paid the one-time cost of lazily importing `entry-server.js`, pushing the unknown-route 404 test past the 5s per-test timeout (5098ms).
- Warm up that import with a request in `beforeAll` (30s timeout) so no individual test is charged for it.

## Test plan
- [x] `npx vitest run src/__tests__/server-seo-behavior.test.ts` — 9/9 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)