### PR TITLE
Filter Google gear images for high-res product shots and sync repo memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@
   - legacy route `/:category/:ownerSlug/:slug` still resolves and is canonicalized forward
   - main files are `EquipmentDetailPage.tsx`, `EquipmentDetailPageDb.tsx`, `components/equipment-detail/*`, `utils/gearUrl.ts`, `lib/seo/*`
   - `EquipmentDetailPageDb.tsx` includes a session-only "View Real Gear Images" action that calls the `google-image-search` edge function and temporarily swaps the carousel/modal image URLs without writing to `equipment_images`
+  - Google image search results for gear must pass the shared high-resolution gear-image filter: HTTPS URLs, reported dimensions, landscape width >= 1200px or portrait height >= 1200px, and no obvious video/thumbnail/logo/banner/avatar/icon/poster metadata
 - Profiles and owner surfaces:
   - `RealUserProfilePage.tsx` handles public vs own profile, profile editing, image upload, privacy settings, and equipment filtering
   - related UI is in `components/profile/*`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@
   - canonical route is `/gear/:gearSlug`
   - legacy route `/:category/:ownerSlug/:slug` still resolves and is canonicalized forward
   - main files are `EquipmentDetailPage.tsx`, `EquipmentDetailPageDb.tsx`, `components/equipment-detail/*`, `utils/gearUrl.ts`, `lib/seo/*`
+  - `EquipmentDetailPageDb.tsx` includes a session-only "View Real Gear Images" action that calls the `google-image-search` edge function and temporarily swaps the carousel/modal image URLs without writing to `equipment_images`
 - Profiles and owner surfaces:
   - `RealUserProfilePage.tsx` handles public vs own profile, profile editing, image upload, privacy settings, and equipment filtering
   - related UI is in `components/profile/*`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 
 ## Claude Harness Notes
 - Claude Code project memory lives in `CLAUDE.md`; this file intentionally imports the canonical shared memory from `AGENTS.md` so Claude and Codex stay aligned.
+- Recent shared gear-detail behavior, including the session-only "View Real Gear Images" carousel swap and high-resolution Google image filtering rules, is inherited from canonical `AGENTS.md`.
 - Whenever you make code changes, check whether `AGENTS.md` is now stale. If durable project behavior changed, update `AGENTS.md` in the same change.
 - Add Claude-specific guidance here only when it is truly Claude-specific. Keep the repository map and durable architecture notes in `AGENTS.md`.
 - If the repo later needs path-scoped Claude memory, prefer additional local `CLAUDE.md` files near the relevant subtree instead of bloating this root file.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -3,6 +3,7 @@
 
 ## Gemini Harness Notes
 - Gemini CLI project memory lives in `GEMINI.md`; this file intentionally imports the canonical shared memory from `AGENTS.md` so Gemini and Codex stay aligned.
+- Recent shared gear-detail behavior, including the session-only "View Real Gear Images" carousel swap and high-resolution Google image filtering rules, is inherited from canonical `AGENTS.md`.
 - Whenever you make code changes, check whether `AGENTS.md` is now stale. If durable project behavior changed, update `AGENTS.md` in the same change.
 - Add Gemini-specific guidance here only when it is truly Gemini-specific. Keep the repository map and durable architecture notes in `AGENTS.md`.
 - If the repo later needs module-specific Gemini memory, prefer additional nested `GEMINI.md` files near the relevant subtree instead of bloating this root file.

--- a/src/__tests__/EquipmentDetailPageDb.googleImages.test.tsx
+++ b/src/__tests__/EquipmentDetailPageDb.googleImages.test.tsx
@@ -175,6 +175,19 @@ const imageSources = () =>
     .map((img) => img.getAttribute("src"))
     .filter(Boolean);
 
+const googleImageResult = (
+  url: string,
+  overrides: Record<string, unknown> = {},
+) => ({
+  url,
+  thumbnail: url.replace("/gear-", "/thumbs/gear-"),
+  title: "Burton Custom snowboard product image",
+  source: "burton.example.com",
+  width: 1600,
+  height: 1000,
+  ...overrides,
+});
+
 describe("EquipmentDetailPageDb Google image swap", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -184,8 +197,12 @@ describe("EquipmentDetailPageDb Google image swap", () => {
     testHarness.invokeMock.mockResolvedValue({
       data: {
         results: [
-          { url: "https://images.example.com/burton-custom-1.jpg" },
-          { url: "https://images.example.com/burton-custom-2.jpg" },
+          googleImageResult(
+            "https://images.example.com/burton-custom-1.jpg",
+          ),
+          googleImageResult(
+            "https://images.example.com/burton-custom-2.jpg",
+          ),
         ],
       },
       error: null,
@@ -223,11 +240,13 @@ describe("EquipmentDetailPageDb Google image swap", () => {
     testHarness.invokeMock.mockResolvedValue({
       data: {
         results: [
-          { url: "http://images.example.com/insecure.jpg" },
-          { url: "https://images.example.com/gear-1.jpg" },
-          { url: "https://images.example.com/gear-1.jpg" },
+          googleImageResult("http://images.example.com/insecure.jpg"),
+          googleImageResult("https://images.example.com/gear-1.jpg"),
+          googleImageResult("https://images.example.com/gear-1.jpg"),
           ...Array.from({ length: 11 }, (_, index) => ({
-            url: `https://images.example.com/gear-${index + 2}.jpg`,
+            ...googleImageResult(
+              `https://images.example.com/gear-${index + 2}.jpg`,
+            ),
           })),
         ],
       },
@@ -250,6 +269,41 @@ describe("EquipmentDetailPageDb Google image swap", () => {
         (_, index) => `https://images.example.com/gear-${index + 1}.jpg`,
       ),
     );
+  });
+
+  it("ignores low-resolution, missing-dimension, duplicate, non-HTTPS, and blocked-media results", async () => {
+    testHarness.invokeMock.mockResolvedValue({
+      data: {
+        results: [
+          googleImageResult("http://images.example.com/insecure.jpg"),
+          googleImageResult("https://images.example.com/low-res.jpg", {
+            width: 900,
+            height: 600,
+          }),
+          googleImageResult("https://images.example.com/missing-width.jpg", {
+            width: undefined,
+          }),
+          googleImageResult("https://i.ytimg.com/vi/demo/maxresdefault.jpg", {
+            thumbnail: "https://i.ytimg.com/vi/demo/hqdefault.jpg",
+            title: "Burton Custom video review thumbnail",
+            source: "youtube.com",
+          }),
+          googleImageResult("https://images.example.com/valid.jpg"),
+          googleImageResult("https://images.example.com/valid.jpg"),
+        ],
+      },
+      error: null,
+    });
+
+    renderDetailPage();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "View Real Gear Images" }),
+    );
+
+    await waitFor(() => {
+      expect(imageSources()).toEqual(["https://images.example.com/valid.jpg"]);
+    });
   });
 
   it("keeps the original carousel images when the search returns no URLs", async () => {

--- a/src/__tests__/EquipmentDetailPageDb.googleImages.test.tsx
+++ b/src/__tests__/EquipmentDetailPageDb.googleImages.test.tsx
@@ -1,0 +1,307 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import EquipmentDetailPageDb from "@/pages/EquipmentDetailPageDb";
+import type { Equipment } from "@/types";
+
+const testHarness = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  toastMock: vi.fn(),
+}));
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    functions: {
+      invoke: testHarness.invokeMock,
+    },
+  },
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({
+    toast: testHarness.toastMock,
+  }),
+}));
+
+vi.mock("@/contexts/auth", () => ({
+  useAuth: () => ({ user: null }),
+}));
+
+vi.mock("@/hooks/useUserRole", () => ({
+  useIsAdmin: () => ({ isAdmin: false }),
+}));
+
+vi.mock("@/hooks/useUserEquipment", () => ({
+  useDeleteEquipment: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdateEquipmentVisibility: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/utils/tracking", () => ({
+  buildEquipmentTrackingFrom: () => ({}),
+  trackEvent: vi.fn(),
+}));
+
+vi.mock("@/components/Breadcrumbs", () => ({
+  default: () => <nav aria-label="breadcrumbs" />,
+}));
+
+vi.mock("@/components/waiver/CustomerWaiverForm", () => ({
+  default: () => <div data-testid="waiver-form" />,
+}));
+
+vi.mock("@/components/equipment-detail/EquipmentHeader", () => ({
+  default: ({ gearDisplayName }: { gearDisplayName: string }) => (
+    <h1>{gearDisplayName}</h1>
+  ),
+}));
+
+vi.mock("@/components/equipment-detail/EquipmentSpecs", () => ({
+  default: () => <div data-testid="equipment-specs" />,
+}));
+
+vi.mock("@/components/equipment-detail/LocationTab", () => ({
+  default: () => <div data-testid="location-tab" />,
+}));
+
+vi.mock("@/components/equipment-detail/ReviewsTab", () => ({
+  default: () => <div data-testid="reviews-tab" />,
+}));
+
+vi.mock("@/components/equipment-detail/PolicyTab", () => ({
+  default: () => <div data-testid="policy-tab" />,
+}));
+
+vi.mock("@/components/equipment-detail/OwnerCard", () => ({
+  default: () => <div data-testid="owner-card" />,
+}));
+
+vi.mock("@/components/equipment-detail/SimilarEquipment", () => ({
+  default: () => <div data-testid="similar-equipment" />,
+}));
+
+vi.mock("@/components/equipment-detail/GearImageModal", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/components/equipment-detail/ContactInfoModal", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/components/equipment-detail/TricksSection", () => ({
+  TricksSection: () => <div data-testid="tricks-section" />,
+}));
+
+vi.mock("@/components/ui/carousel", () => ({
+  Carousel: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="carousel">{children}</div>
+  ),
+  CarouselContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CarouselItem: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CarouselNext: () => <button type="button">Next</button>,
+  CarouselPrevious: () => <button type="button">Previous</button>,
+}));
+
+const equipment: Equipment = {
+  id: "gear-1",
+  name: "Burton Custom",
+  category: "snowboards",
+  subcategory: "all-mountain",
+  description: "A directional twin snowboard.",
+  image_url: "https://stored.example.com/original.jpg",
+  images: ["https://stored.example.com/original.jpg"],
+  price_per_day: 65,
+  price_per_hour: 15,
+  price_per_week: 300,
+  rating: 4.8,
+  review_count: 12,
+  owner: {
+    id: "owner-1",
+    name: "Demo Shop",
+    imageUrl: "",
+    rating: 4.9,
+    reviewCount: 20,
+    responseRate: 95,
+  },
+  location: {
+    lat: 39.1,
+    lng: -120.1,
+    address: "Truckee, CA",
+  },
+  distance: 0,
+  specifications: {
+    size: "156",
+    weight: "",
+    material: "",
+    suitable: "Intermediate",
+  },
+  availability: {
+    available: true,
+  },
+  pricing_options: [],
+  status: "available",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-05-01T00:00:00Z",
+};
+
+const renderDetailPage = () =>
+  render(
+    <MemoryRouter>
+      <EquipmentDetailPageDb
+        equipment={equipment}
+        similarEquipment={[]}
+        waiverCompleted={false}
+        showWaiver={false}
+        setShowWaiver={vi.fn()}
+        handleWaiverComplete={vi.fn()}
+        bookingCardRef={React.createRef<HTMLDivElement>()}
+        lastVerifiedDate="2026-05-01"
+        gearDisplayName="Burton Custom 156"
+      />
+    </MemoryRouter>,
+  );
+
+const imageSources = () =>
+  screen
+    .getAllByRole("img")
+    .map((img) => img.getAttribute("src"))
+    .filter(Boolean);
+
+describe("EquipmentDetailPageDb Google image swap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches Google image URLs and swaps the rendered carousel images", async () => {
+    testHarness.invokeMock.mockResolvedValue({
+      data: {
+        results: [
+          { url: "https://images.example.com/burton-custom-1.jpg" },
+          { url: "https://images.example.com/burton-custom-2.jpg" },
+        ],
+      },
+      error: null,
+    });
+
+    renderDetailPage();
+
+    expect(imageSources()).toEqual(["https://stored.example.com/original.jpg"]);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "View Real Gear Images" }),
+    );
+
+    await waitFor(() => {
+      expect(imageSources()).toEqual([
+        "https://images.example.com/burton-custom-1.jpg",
+        "https://images.example.com/burton-custom-2.jpg",
+      ]);
+    });
+
+    expect(testHarness.invokeMock).toHaveBeenCalledWith(
+      "google-image-search",
+      {
+        body: {
+          query: "Burton Custom",
+          gearType: "snowboards",
+          count: 10,
+          size: "large",
+        },
+      },
+    );
+  });
+
+  it("uses only the first 10 unique HTTPS result URLs", async () => {
+    testHarness.invokeMock.mockResolvedValue({
+      data: {
+        results: [
+          { url: "http://images.example.com/insecure.jpg" },
+          { url: "https://images.example.com/gear-1.jpg" },
+          { url: "https://images.example.com/gear-1.jpg" },
+          ...Array.from({ length: 11 }, (_, index) => ({
+            url: `https://images.example.com/gear-${index + 2}.jpg`,
+          })),
+        ],
+      },
+      error: null,
+    });
+
+    renderDetailPage();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "View Real Gear Images" }),
+    );
+
+    await waitFor(() => {
+      expect(imageSources()).toHaveLength(10);
+    });
+
+    expect(imageSources()).toEqual(
+      Array.from(
+        { length: 10 },
+        (_, index) => `https://images.example.com/gear-${index + 1}.jpg`,
+      ),
+    );
+  });
+
+  it("keeps the original carousel images when the search returns no URLs", async () => {
+    testHarness.invokeMock.mockResolvedValue({
+      data: {
+        results: [],
+      },
+      error: null,
+    });
+
+    renderDetailPage();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "View Real Gear Images" }),
+    );
+
+    await waitFor(() => {
+      expect(testHarness.toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "No Real Images Found",
+        }),
+      );
+    });
+
+    expect(imageSources()).toEqual(["https://stored.example.com/original.jpg"]);
+  });
+
+  it("keeps the original carousel images when the search fails", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    testHarness.invokeMock.mockResolvedValue({
+      data: null,
+      error: new Error("Search failed"),
+    });
+
+    renderDetailPage();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "View Real Gear Images" }),
+    );
+
+    await waitFor(() => {
+      expect(testHarness.toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Image Search Failed",
+          variant: "destructive",
+        }),
+      );
+    });
+
+    expect(imageSources()).toEqual(["https://stored.example.com/original.jpg"]);
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/src/__tests__/googleImageFilters.test.ts
+++ b/src/__tests__/googleImageFilters.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildGearImageSearchQuery,
+  filterHighResolutionGearImageResults,
+  isHighResolutionGearImageResult,
+  type GoogleImageSearchResult,
+} from "../../supabase/functions/_shared/googleImageFilters";
+
+const result = (
+  overrides: Partial<GoogleImageSearchResult> = {},
+): GoogleImageSearchResult => ({
+  url: "https://images.example.com/burton-custom.jpg",
+  thumbnail: "https://images.example.com/thumbs/burton-custom.jpg",
+  title: "Burton Custom snowboard product image",
+  source: "burton.example.com",
+  width: 1600,
+  height: 1000,
+  ...overrides,
+});
+
+describe("Google image search filters", () => {
+  it("builds a product-focused query with media exclusions", () => {
+    expect(buildGearImageSearchQuery("Burton Custom", "snowboards")).toBe(
+      "Burton Custom snowboards product gear -youtube -video -thumbnail -logo -banner -poster -ad -avatar -icon",
+    );
+  });
+
+  it("accepts landscape images that are at least 1200px wide", () => {
+    expect(
+      isHighResolutionGearImageResult(result({ width: 1200, height: 800 })),
+    ).toBe(true);
+  });
+
+  it("rejects landscape images less than 1200px wide", () => {
+    expect(
+      isHighResolutionGearImageResult(result({ width: 1199, height: 800 })),
+    ).toBe(false);
+  });
+
+  it("accepts portrait images that are at least 1200px tall", () => {
+    expect(
+      isHighResolutionGearImageResult(result({ width: 800, height: 1200 })),
+    ).toBe(true);
+  });
+
+  it("rejects portrait images less than 1200px tall", () => {
+    expect(
+      isHighResolutionGearImageResult(result({ width: 800, height: 1199 })),
+    ).toBe(false);
+  });
+
+  it("accepts square images with a side at least 1200px", () => {
+    expect(
+      isHighResolutionGearImageResult(result({ width: 1200, height: 1200 })),
+    ).toBe(true);
+  });
+
+  it("rejects results with missing dimensions", () => {
+    expect(
+      isHighResolutionGearImageResult(result({ width: undefined })),
+    ).toBe(false);
+    expect(
+      isHighResolutionGearImageResult(result({ height: undefined })),
+    ).toBe(false);
+  });
+
+  it("rejects YouTube thumbnails and other non-gear media metadata", () => {
+    expect(
+      isHighResolutionGearImageResult(
+        result({
+          url: "https://i.ytimg.com/vi/demo/maxresdefault.jpg",
+          thumbnail: "https://i.ytimg.com/vi/demo/hqdefault.jpg",
+          title: "Burton Custom video review thumbnail",
+          source: "youtube.com",
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isHighResolutionGearImageResult(
+        result({ title: "Burton Custom logo icon" }),
+      ),
+    ).toBe(false);
+    expect(
+      isHighResolutionGearImageResult(
+        result({ url: "https://cdn.example.com/banner/burton-custom.jpg" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("filters, deduplicates, and limits valid image results", () => {
+    const filtered = filterHighResolutionGearImageResults(
+      [
+        result({ url: "http://images.example.com/insecure.jpg" }),
+        result({ width: 900, height: 600 }),
+        result({ title: "Burton Custom video thumbnail" }),
+        result({ url: "https://images.example.com/valid-1.jpg" }),
+        result({ url: "https://images.example.com/valid-1.jpg" }),
+        result({ url: "https://images.example.com/valid-2.jpg" }),
+      ],
+      2,
+    );
+
+    expect(filtered.map((image) => image.url)).toEqual([
+      "https://images.example.com/valid-1.jpg",
+      "https://images.example.com/valid-2.jpg",
+    ]);
+  });
+});

--- a/src/pages/EquipmentDetailPageDb.tsx
+++ b/src/pages/EquipmentDetailPageDb.tsx
@@ -23,16 +23,17 @@ import {
 } from "@/components/ui/carousel";
 import { getCategoryDisplayName, getCategoryActivityName } from "@/helpers";
 import { Equipment } from "@/types";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useAuth } from "@/contexts/auth";
 import { useIsAdmin } from "@/hooks/useUserRole";
 import { Link } from "react-router-dom";
-import { Edit, Eye, EyeOff, Trash2 } from "lucide-react";
+import { Edit, Eye, EyeOff, Loader2, Trash2 } from "lucide-react";
 import { useDeleteEquipment, useUpdateEquipmentVisibility } from "@/hooks/useUserEquipment";
 import { useToast } from "@/hooks/use-toast";
 import { useNavigate } from "react-router-dom";
 import { buildEquipmentTrackingFrom, trackEvent } from "@/utils/tracking";
 import { buildGearPath } from "@/utils/gearUrl";
+import { supabase } from "@/integrations/supabase/client";
 
 interface EquipmentDetailPageDbProps {
   equipment: Equipment;
@@ -46,6 +47,32 @@ interface EquipmentDetailPageDbProps {
   lastVerifiedDate: string;
   gearDisplayName?: string;
 }
+
+type GoogleImageSearchResult = {
+  url?: unknown;
+};
+
+type GoogleImageSearchResponse = {
+  results?: GoogleImageSearchResult[];
+};
+
+const getSearchResultImageUrls = (
+  results: GoogleImageSearchResult[] | undefined,
+) => {
+  const uniqueUrls = new Set<string>();
+
+  for (const result of results ?? []) {
+    if (typeof result.url === "string" && result.url.startsWith("https://")) {
+      uniqueUrls.add(result.url);
+    }
+
+    if (uniqueUrls.size === 10) {
+      break;
+    }
+  }
+
+  return Array.from(uniqueUrls);
+};
 
 const EquipmentDetailPageDb: React.FC<EquipmentDetailPageDbProps> = ({
   equipment,
@@ -62,6 +89,10 @@ const EquipmentDetailPageDb: React.FC<EquipmentDetailPageDbProps> = ({
   const [showImageModal, setShowImageModal] = useState(false);
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
   const [showContactModal, setShowContactModal] = useState(false);
+  const [carouselImages, setCarouselImages] = useState<string[]>(
+    equipment.images && equipment.images.length > 0 ? equipment.images : [],
+  );
+  const [isLoadingRealImages, setIsLoadingRealImages] = useState(false);
   const { user } = useAuth();
   const { isAdmin } = useIsAdmin();
   const { toast } = useToast();
@@ -70,15 +101,66 @@ const EquipmentDetailPageDb: React.FC<EquipmentDetailPageDbProps> = ({
   const updateVisibilityMutation = useUpdateEquipmentVisibility();
 
   // Use images array from equipment_images table
-  const images =
-    equipment.images && equipment.images.length > 0 ? equipment.images : [];
+  const images = carouselImages;
 
   const hasMultipleImages = images.length > 1;
   const hasImages = images.length > 0;
 
+  useEffect(() => {
+    setCarouselImages(
+      equipment.images && equipment.images.length > 0 ? equipment.images : [],
+    );
+    setSelectedImageIndex(0);
+  }, [equipment.id, equipment.images]);
+
   const handleImageClick = (index: number = 0) => {
     setSelectedImageIndex(index);
     setShowImageModal(true);
+  };
+
+  const handleViewRealGearImages = async () => {
+    setIsLoadingRealImages(true);
+
+    try {
+      const { data, error } =
+        await supabase.functions.invoke<GoogleImageSearchResponse>(
+          "google-image-search",
+          {
+            body: {
+              query: equipment.name,
+              gearType: equipment.category,
+              count: 10,
+              size: "large",
+            },
+          },
+        );
+
+      if (error) {
+        throw error;
+      }
+
+      const imageUrls = getSearchResultImageUrls(data?.results);
+
+      if (imageUrls.length === 0) {
+        toast({
+          title: "No Real Images Found",
+          description: "Try again later or keep browsing the current listing images.",
+        });
+        return;
+      }
+
+      setCarouselImages(imageUrls);
+      setSelectedImageIndex(0);
+    } catch (error) {
+      console.error("Google image search error:", error);
+      toast({
+        title: "Image Search Failed",
+        description: "We could not load real gear images right now. Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsLoadingRealImages(false);
+    }
   };
 
   // Create tracking data for analytics
@@ -222,48 +304,65 @@ const EquipmentDetailPageDb: React.FC<EquipmentDetailPageDbProps> = ({
         {/* Main Content */}
         <article className="lg:col-span-2 space-y-8">
           {/* Image Gallery */}
-          <div className="overflow-hidden rounded-lg">
-            {hasImages ? (
-              hasMultipleImages ? (
-                <Carousel className="w-full" opts={{ loop: true }}>
-                  <CarouselContent>
-                    {images.map((imageUrl, index) => (
-                      <CarouselItem key={index}>
-                        <div
-                          className="cursor-pointer hover:opacity-90 transition-opacity"
-                          onClick={() => handleImageClick(index)}
-                        >
-                          <img
-                            src={imageUrl}
-                            alt={`${resolvedGearName} - ${getCategoryActivityName(equipment.category)} Gear Image ${index + 1}`}
-                            loading="lazy"
-                            className="w-full h-96 object-cover"
-                          />
-                        </div>
-                      </CarouselItem>
-                    ))}
-                  </CarouselContent>
-                  <CarouselPrevious className="left-2" />
-                  <CarouselNext className="right-2" />
-                </Carousel>
+          <div className="space-y-3">
+            <div className="overflow-hidden rounded-lg">
+              {hasImages ? (
+                hasMultipleImages ? (
+                  <Carousel className="w-full" opts={{ loop: true }}>
+                    <CarouselContent>
+                      {images.map((imageUrl, index) => (
+                        <CarouselItem key={`${imageUrl}-${index}`}>
+                          <div
+                            className="cursor-pointer hover:opacity-90 transition-opacity"
+                            onClick={() => handleImageClick(index)}
+                          >
+                            <img
+                              src={imageUrl}
+                              alt={`${resolvedGearName} - ${getCategoryActivityName(equipment.category)} Gear Image ${index + 1}`}
+                              loading="lazy"
+                              className="w-full h-96 object-cover"
+                            />
+                          </div>
+                        </CarouselItem>
+                      ))}
+                    </CarouselContent>
+                    <CarouselPrevious className="left-2" />
+                    <CarouselNext className="right-2" />
+                  </Carousel>
+                ) : (
+                  <div
+                    className="cursor-pointer hover:opacity-90 transition-opacity"
+                    onClick={() => handleImageClick(0)}
+                  >
+                    <img
+                      src={images[0]}
+                      alt={`${resolvedGearName} - ${getCategoryActivityName(equipment.category)} Gear`}
+                      loading="lazy"
+                      className="w-full h-96 object-cover"
+                    />
+                  </div>
+                )
               ) : (
-                <div
-                  className="cursor-pointer hover:opacity-90 transition-opacity"
-                  onClick={() => handleImageClick(0)}
-                >
-                  <img
-                    src={images[0]}
-                    alt={`${resolvedGearName} - ${getCategoryActivityName(equipment.category)} Gear`}
-                    loading="lazy"
-                    className="w-full h-96 object-cover"
-                  />
+                <div className="w-full h-96 bg-gray-200 flex items-center justify-center">
+                  <span className="text-gray-500">No image available</span>
                 </div>
-              )
-            ) : (
-              <div className="w-full h-96 bg-gray-200 flex items-center justify-center">
-                <span className="text-gray-500">No image available</span>
-              </div>
-            )}
+              )}
+            </div>
+            <Button
+              type="button"
+              className="w-full h-12 text-base font-semibold"
+              onClick={handleViewRealGearImages}
+              disabled={isLoadingRealImages}
+            >
+              {isLoadingRealImages ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Loading Real Gear Images
+                </>
+              ) : (
+                "View Real Gear Images"
+              )}
+            </Button>
           </div>
           {/* Equipment Info */}
           <section aria-labelledby="gear-title">

--- a/src/pages/EquipmentDetailPageDb.tsx
+++ b/src/pages/EquipmentDetailPageDb.tsx
@@ -34,6 +34,10 @@ import { useNavigate } from "react-router-dom";
 import { buildEquipmentTrackingFrom, trackEvent } from "@/utils/tracking";
 import { buildGearPath } from "@/utils/gearUrl";
 import { supabase } from "@/integrations/supabase/client";
+import {
+  filterHighResolutionGearImageResults,
+  type GoogleImageSearchResult,
+} from "../../supabase/functions/_shared/googleImageFilters";
 
 interface EquipmentDetailPageDbProps {
   equipment: Equipment;
@@ -48,10 +52,6 @@ interface EquipmentDetailPageDbProps {
   gearDisplayName?: string;
 }
 
-type GoogleImageSearchResult = {
-  url?: unknown;
-};
-
 type GoogleImageSearchResponse = {
   results?: GoogleImageSearchResult[];
 };
@@ -59,19 +59,9 @@ type GoogleImageSearchResponse = {
 const getSearchResultImageUrls = (
   results: GoogleImageSearchResult[] | undefined,
 ) => {
-  const uniqueUrls = new Set<string>();
-
-  for (const result of results ?? []) {
-    if (typeof result.url === "string" && result.url.startsWith("https://")) {
-      uniqueUrls.add(result.url);
-    }
-
-    if (uniqueUrls.size === 10) {
-      break;
-    }
-  }
-
-  return Array.from(uniqueUrls);
+  return filterHighResolutionGearImageResults(results, 10).map(
+    (result) => result.url,
+  );
 };
 
 const EquipmentDetailPageDb: React.FC<EquipmentDetailPageDbProps> = ({

--- a/supabase/functions/_shared/googleImageFilters.ts
+++ b/supabase/functions/_shared/googleImageFilters.ts
@@ -1,0 +1,156 @@
+export type GoogleImageSearchResult = {
+  url?: unknown;
+  thumbnail?: unknown;
+  title?: unknown;
+  source?: unknown;
+  width?: unknown;
+  height?: unknown;
+};
+
+export type ValidGoogleImageSearchResult = {
+  url: string;
+  thumbnail: string;
+  title: string;
+  source: string;
+  width: number;
+  height: number;
+};
+
+const MINIMUM_PRIMARY_DIMENSION = 1200;
+
+const BLOCKED_MAIN_METADATA_TERMS = [
+  "youtube",
+  "youtu.be",
+  "ytimg",
+  "video",
+  "thumbnail",
+  "thumb",
+  "logo",
+  "banner",
+  "avatar",
+  "icon",
+  "poster",
+  "sprite",
+  "placeholder",
+  "maxresdefault",
+  "hqdefault",
+  "mqdefault",
+  "sddefault",
+];
+
+const BLOCKED_THUMBNAIL_TERMS = [
+  "youtube",
+  "youtu.be",
+  "ytimg",
+  "maxresdefault",
+  "hqdefault",
+  "mqdefault",
+  "sddefault",
+  "/vi/",
+];
+
+const isHttpsString = (value: unknown): value is string =>
+  typeof value === "string" && value.startsWith("https://");
+
+const toDimension = (value: unknown): number | null => {
+  const numericValue =
+    typeof value === "number"
+      ? value
+      : typeof value === "string"
+        ? Number(value)
+        : NaN;
+
+  return Number.isFinite(numericValue) && numericValue > 0
+    ? numericValue
+    : null;
+};
+
+const containsBlockedTerm = (value: string, blockedTerms: string[]) => {
+  const normalizedValue = value.toLowerCase();
+  return blockedTerms.some((term) => normalizedValue.includes(term));
+};
+
+export const buildGearImageSearchQuery = (
+  query: string,
+  gearType?: string,
+) => {
+  const gearTerms = [query, gearType, "product", "gear"]
+    .map((term) => term?.trim())
+    .filter(Boolean)
+    .join(" ");
+
+  return `${gearTerms} -youtube -video -thumbnail -logo -banner -poster -ad -avatar -icon`;
+};
+
+export const isHighResolutionGearImageResult = (
+  result: GoogleImageSearchResult,
+): result is ValidGoogleImageSearchResult => {
+  if (!isHttpsString(result.url) || !isHttpsString(result.thumbnail)) {
+    return false;
+  }
+
+  const width = toDimension(result.width);
+  const height = toDimension(result.height);
+
+  if (!width || !height) {
+    return false;
+  }
+
+  const isLandscape = width > height;
+  const isPortrait = height > width;
+  const meetsDimensionRequirement = isLandscape
+    ? width >= MINIMUM_PRIMARY_DIMENSION
+    : isPortrait
+      ? height >= MINIMUM_PRIMARY_DIMENSION
+      : Math.max(width, height) >= MINIMUM_PRIMARY_DIMENSION;
+
+  if (!meetsDimensionRequirement) {
+    return false;
+  }
+
+  const mainMetadata = [
+    result.url,
+    typeof result.title === "string" ? result.title : "",
+    typeof result.source === "string" ? result.source : "",
+  ].join(" ");
+
+  if (containsBlockedTerm(mainMetadata, BLOCKED_MAIN_METADATA_TERMS)) {
+    return false;
+  }
+
+  if (containsBlockedTerm(result.thumbnail, BLOCKED_THUMBNAIL_TERMS)) {
+    return false;
+  }
+
+  return true;
+};
+
+export const filterHighResolutionGearImageResults = (
+  results: GoogleImageSearchResult[] | undefined,
+  limit = 10,
+): ValidGoogleImageSearchResult[] => {
+  const uniqueUrls = new Set<string>();
+  const filteredResults: ValidGoogleImageSearchResult[] = [];
+
+  for (const result of results ?? []) {
+    if (!isHighResolutionGearImageResult(result) || uniqueUrls.has(result.url)) {
+      continue;
+    }
+
+    uniqueUrls.add(result.url);
+    filteredResults.push({
+      url: result.url,
+      thumbnail: result.thumbnail,
+      title: typeof result.title === "string" ? result.title : "",
+      source: typeof result.source === "string" ? result.source : "Unknown",
+      width: toDimension(result.width) ?? 0,
+      height: toDimension(result.height) ?? 0,
+    });
+
+    if (filteredResults.length >= limit) {
+      break;
+    }
+  }
+
+  return filteredResults;
+};

--- a/supabase/functions/auto-assign-gear-images/index.ts
+++ b/supabase/functions/auto-assign-gear-images/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { filterHighResolutionGearImageResults } from "../_shared/googleImageFilters.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -148,27 +149,10 @@ Deno.serve(async (req) => {
 
     console.log(`Got ${searchResults.length} search results`);
 
-    // Filter for HTTPS and minimum dimensions (1000x1000)
-    const filteredResults = searchResults.filter((img) => {
-      // Must be HTTPS
-      if (!img.url.startsWith("https://")) {
-        return false;
-      }
-
-      // Must have dimensions reported and be at least 1000x1000
-      if (!img.width || !img.height) {
-        return false;
-      }
-
-      if (img.width < 1000 || img.height < 1000) {
-        return false;
-      }
-
-      return true;
-    });
+    const filteredResults = filterHighResolutionGearImageResults(searchResults);
 
     console.log(
-      `${filteredResults.length} images pass HTTPS and dimension filters`
+      `${filteredResults.length} images pass high-resolution gear-image filters`
     );
 
     // Validate URLs and collect up to 3 valid images

--- a/supabase/functions/google-image-search/index.ts
+++ b/supabase/functions/google-image-search/index.ts
@@ -1,5 +1,9 @@
 
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import {
+  buildGearImageSearchQuery,
+  filterHighResolutionGearImageResults,
+} from "../_shared/googleImageFilters.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -38,14 +42,11 @@ const handler = async (req: Request): Promise<Response> => {
       throw new Error('Google Search API configuration missing');
     }
 
-    // Build smart search query
-    let searchQuery = query;
-    if (gearType) {
-      searchQuery = `${query} ${gearType} product`;
-    }
+    const searchQuery = buildGearImageSearchQuery(query, gearType);
 
     const resultsPerPage = 10;
-    const pages = Math.ceil(count / resultsPerPage);
+    const candidateCount = Math.min(Math.max(count * 3, resultsPerPage), 30);
+    const pages = Math.ceil(candidateCount / resultsPerPage);
     const results: SearchResult[] = [];
 
     for (let page = 0; page < pages; page++) {
@@ -81,22 +82,23 @@ const handler = async (req: Request): Promise<Response> => {
         height: item.image?.height,
       }));
 
-      // Filter for HTTPS-only URLs (both main image and thumbnail)
-      const httpsResults = pageResults.filter((result: SearchResult) => 
-        result.url.startsWith('https://') && 
-        result.thumbnail.startsWith('https://')
-      );
+      results.push(...pageResults);
 
-      results.push(...httpsResults);
-
-      if (results.length >= count) {
+      if (results.length >= candidateCount) {
         break;
       }
     }
 
-    console.log(`Found ${results.length} images for query: ${searchQuery}`);
+    const filteredResults = filterHighResolutionGearImageResults(
+      results,
+      count,
+    );
 
-    return new Response(JSON.stringify({ results }), {
+    console.log(
+      `Found ${filteredResults.length} high-resolution gear images from ${results.length} candidates for query: ${searchQuery}`
+    );
+
+    return new Response(JSON.stringify({ results: filteredResults }), {
       status: 200,
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
Turns the gear image search flow into a high-resolution, gear-only experience and keeps the repo memory files aligned.

- Adds a shared Google image filter that only accepts HTTPS results with reported dimensions, a 1200px minimum on the primary orientation edge, and no obvious video/thumbnail/logo/banner/avatar/icon/poster metadata.
- Reuses that shared filter in the `google-image-search` edge function, the gear-detail image swap flow, and `auto-assign-gear-images` so all callers enforce the same rules.
- Keeps the gear detail page session-only: `View Real Gear Images` swaps the carousel/modal image URLs for the current visit without writing to `equipment_images`.
- Updates `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` together so the recent gear-detail and Google image behavior is documented in tandem.
- Adds focused tests for the shared filter and the gear-detail swap behavior, including low-res, missing-dimension, duplicate, non-HTTPS, and blocked-media cases.

## Testing
- `npm run type-check`
- `npm run test:unit`
- `npm run lint`
- Added unit coverage for the shared Google image filter and the gear-detail image swap path.