### PR TITLE
Fix product snippets and Walden Surfboards primary images

### DIFF
--- a/src/__tests__/gear-seo-regressions.test.ts
+++ b/src/__tests__/gear-seo-regressions.test.ts
@@ -102,7 +102,7 @@ describe("Gear SEO helpers", () => {
           reviewText: "Fast paddler and easy to control in shoulder-high surf.",
         },
       ],
-      summaryText: "Test Board 5'8 is available in Encinitas, CA. Last verified 2026-03-30.",
+      summaryText: "Test Board 5'8 is available in Encinitas, CA.",
     });
 
     expect(schema.review).toEqual([
@@ -124,7 +124,7 @@ describe("Gear SEO helpers", () => {
       pricePerDay: 55,
       rating: 0,
       reviewCount: 0,
-      summaryText: "Unreviewed Board 5'6 is available in Encinitas, CA. Last verified 2026-03-30.",
+      summaryText: "Unreviewed Board 5'6 is available in Encinitas, CA.",
     });
 
     expect(schema.aggregateRating).toMatchObject({
@@ -146,7 +146,7 @@ describe("Gear SEO helpers", () => {
       pricePerDay: 55,
       rating: "bad",
       reviewCount: "bad",
-      summaryText: "Untrusted Board 5'6 is available in Encinitas, CA. Last verified 2026-03-30.",
+      summaryText: "Untrusted Board 5'6 is available in Encinitas, CA.",
     });
 
     expect(invalidSchema.aggregateRating).toBeUndefined();
@@ -161,7 +161,7 @@ describe("Gear SEO helpers", () => {
       pricePerDay: 55,
       rating: -1,
       reviewCount: 0,
-      summaryText: "Untrusted Board 5'6 is available in Encinitas, CA. Last verified 2026-03-30.",
+      summaryText: "Untrusted Board 5'6 is available in Encinitas, CA.",
     });
 
     expect(negativeRatingSchema.aggregateRating).toBeUndefined();
@@ -176,7 +176,7 @@ describe("Gear SEO helpers", () => {
       pricePerDay: 55,
       rating: 6,
       reviewCount: 1,
-      summaryText: "Untrusted Board 5'6 is available in Encinitas, CA. Last verified 2026-03-30.",
+      summaryText: "Untrusted Board 5'6 is available in Encinitas, CA.",
     });
 
     expect(aboveMaxRatingSchema.aggregateRating).toBeUndefined();

--- a/src/__tests__/gear-seo-regressions.test.ts
+++ b/src/__tests__/gear-seo-regressions.test.ts
@@ -112,6 +112,75 @@ describe("Gear SEO helpers", () => {
       }),
     ]);
   });
+
+  it("emits aggregateRating for unrated gear with zero reviews", () => {
+    const schema = buildGearProductSchema({
+      canonicalUrl: "https://www.demostoke.com/gear/unreviewed-board--123e4567-e89b-12d3-a456-426614174000",
+      category: "surfboards",
+      displayName: "Unreviewed Board 5'6",
+      imageUrls: ["https://cdn.example.com/unreviewed-board.webp"],
+      isAvailable: true,
+      lastVerified: "2026-03-30",
+      pricePerDay: 55,
+      rating: 0,
+      reviewCount: 0,
+      summaryText: "Unreviewed Board 5'6 is available in Encinitas, CA. Last verified 2026-03-30.",
+    });
+
+    expect(schema.aggregateRating).toMatchObject({
+      "@type": "AggregateRating",
+      ratingValue: 0,
+      reviewCount: 0,
+    });
+    expect(schema.review).toBeUndefined();
+  });
+
+  it("does not emit aggregateRating for invalid rating/review values", () => {
+    const invalidSchema = buildGearProductSchema({
+      canonicalUrl: "https://www.demostoke.com/gear/untrusted-board--123e4567-e89b-12d3-a456-426614174000",
+      category: "surfboards",
+      displayName: "Untrusted Board 5'6",
+      imageUrls: ["https://cdn.example.com/untrusted-board.webp"],
+      isAvailable: true,
+      lastVerified: "2026-03-30",
+      pricePerDay: 55,
+      rating: "bad",
+      reviewCount: "bad",
+      summaryText: "Untrusted Board 5'6 is available in Encinitas, CA. Last verified 2026-03-30.",
+    });
+
+    expect(invalidSchema.aggregateRating).toBeUndefined();
+
+    const negativeRatingSchema = buildGearProductSchema({
+      canonicalUrl: "https://www.demostoke.com/gear/untrusted-board--123e4567-e89b-12d3-a456-426614174000",
+      category: "surfboards",
+      displayName: "Untrusted Board 5'6",
+      imageUrls: ["https://cdn.example.com/untrusted-board.webp"],
+      isAvailable: true,
+      lastVerified: "2026-03-30",
+      pricePerDay: 55,
+      rating: -1,
+      reviewCount: 0,
+      summaryText: "Untrusted Board 5'6 is available in Encinitas, CA. Last verified 2026-03-30.",
+    });
+
+    expect(negativeRatingSchema.aggregateRating).toBeUndefined();
+
+    const aboveMaxRatingSchema = buildGearProductSchema({
+      canonicalUrl: "https://www.demostoke.com/gear/untrusted-board--123e4567-e89b-12d3-a456-426614174000",
+      category: "surfboards",
+      displayName: "Untrusted Board 5'6",
+      imageUrls: ["https://cdn.example.com/untrusted-board.webp"],
+      isAvailable: true,
+      lastVerified: "2026-03-30",
+      pricePerDay: 55,
+      rating: 6,
+      reviewCount: 1,
+      summaryText: "Untrusted Board 5'6 is available in Encinitas, CA. Last verified 2026-03-30.",
+    });
+
+    expect(aboveMaxRatingSchema.aggregateRating).toBeUndefined();
+  });
 });
 
 describe("Gear SEO server regression coverage", () => {

--- a/src/lib/seo/gearSeo.js
+++ b/src/lib/seo/gearSeo.js
@@ -49,8 +49,7 @@ export const buildLegacyGearNamePattern = (slug = '') => {
 export const buildGearSummaryText = ({
   displayName,
   locationText,
-  lastVerified,
-}) => `${displayName} is available in ${locationText || 'United States'}. Last verified ${lastVerified}.`;
+}) => `${displayName} is available in ${locationText || 'United States'}.`;
 
 export const buildGearMetaDescription = ({
   summaryText,

--- a/src/lib/seo/gearSeo.js
+++ b/src/lib/seo/gearSeo.js
@@ -178,8 +178,10 @@ export const buildGearProductSchema = ({
     category,
     offers: offerSchema,
     aggregateRating:
-      normalizedReviewCount > 0 &&
-      normalizedRating > 0 &&
+      Number.isFinite(normalizedReviewCount) &&
+      Number.isFinite(normalizedRating) &&
+      normalizedRating >= 0 &&
+      normalizedReviewCount >= 0 &&
       normalizedRating <= 5
         ? {
             '@type': 'AggregateRating',

--- a/supabase/migrations/20260520000000_fix_product_snippets.sql
+++ b/supabase/migrations/20260520000000_fix_product_snippets.sql
@@ -1,0 +1,26 @@
+-- Fix product snippet metadata and Walden Surfboards primary image sources.
+-- Update requested item names and last-verified timestamps used by metadata/snippets.
+UPDATE equipment
+SET
+  name = 'Atomic Maverick 88 CTI Skis, Boots, Poles; Adult; multiple lengths available',
+  updated_at = '2026-05-19T00:00:00Z'
+WHERE id = 'ca05cd1a-fdb2-4907-b0b3-8e8bf4ea759a';
+
+UPDATE equipment
+SET
+  name = $$South Bay Board Co. Ruccus 7’0″, 7'6"$$,
+  updated_at = '2026-05-19T00:00:00Z'
+WHERE id = 'eae3273e-fd61-4e44-82f4-7b80ac6eff79';
+
+UPDATE equipment_images
+SET
+  image_url = 'https://images.pexels.com/photos/2370006/pexels-photo-2370006.jpeg',
+  is_primary = TRUE
+WHERE equipment_id IN (
+  '20b8c12b-28e6-4f5a-9116-32b5ec9ddc9c',
+  'c30503f3-593e-4304-b3aa-449a67db1b96',
+  '5209dff2-b8c1-4c90-b9ca-bd3ab839de64',
+  'f909424e-8b99-452a-97ab-9324858c27a3'
+)
+  AND display_order = 0
+  AND is_primary = TRUE;

--- a/supabase/migrations/20260520002000_clear_seeded_aggregate_rating_for_targeted_gear.sql
+++ b/supabase/migrations/20260520002000_clear_seeded_aggregate_rating_for_targeted_gear.sql
@@ -1,0 +1,13 @@
+-- Clear seeded aggregate rating fields for targeted pages.
+-- Use this after removing synthetic review metadata so unrated items
+-- can remain as authentic zero-review products while SEO can apply
+-- a zero-review aggregateRating fallback in metadata rendering.
+UPDATE equipment
+SET
+  rating = 0,
+  review_count = 0
+WHERE id IN (
+  'ca05cd1a-fdb2-4907-b0b3-8e8bf4ea759a',
+  'eae3273e-fd61-4e44-82f4-7b80ac6eff79'
+)
+  AND (rating > 0 OR review_count > 0);

--- a/supabase/verify_product_snippets_aggregate_rating.sql
+++ b/supabase/verify_product_snippets_aggregate_rating.sql
@@ -1,0 +1,27 @@
+-- Verify targeted gear rows have truthful zero-review metadata.
+SELECT
+  id,
+  name,
+  rating,
+  review_count,
+  updated_at
+FROM public.equipment
+WHERE id IN (
+  'ca05cd1a-fdb2-4907-b0b3-8e8bf4ea759a',
+  'eae3273e-fd61-4e44-82f4-7b80ac6eff79'
+)
+ORDER BY id;
+
+-- Verify no synthetic review rows exist for the same items.
+SELECT
+  e.id AS equipment_id,
+  COUNT(er.id) AS review_rows
+FROM public.equipment e
+LEFT JOIN public.equipment_reviews er
+  ON er.equipment_id = e.id
+WHERE e.id IN (
+  'ca05cd1a-fdb2-4907-b0b3-8e8bf4ea759a',
+  'eae3273e-fd61-4e44-82f4-7b80ac6eff79'
+)
+GROUP BY e.id
+ORDER BY e.id;


### PR DESCRIPTION
## Summary

Updated the product snippet scope to remove synthetic review signal risks and remove the `Last verified` phrasing from shared SEO snippet copy, while preserving the no-synthetic-data aggregate rating behavior.

## Changes

- Updated shared gear summary generation to stop including crawl/verification dates:
  - [src/lib/seo/gearSeo.js](/Users/michaelzick/Engineering/GitHub/demostoke/src/lib/seo/gearSeo.js)

- Kept `aggregateRating` present for unrated products by allowing zero-safe numeric values, with `Review` objects still only emitted when real public review data exists:
  - [src/lib/seo/gearSeo.js](/Users/michaelzick/Engineering/GitHub/demostoke/src/lib/seo/gearSeo.js)

- Added/updated SEO regression coverage:
  - Added test for `rating=0`, `reviewCount=0` producing `AggregateRating { ratingValue: 0, reviewCount: 0 }`.
  - Added invalid-value guards (`NaN`, negative, >5) for aggregateRating.
  - Updated summary-text assertions to match new no-date snippet copy.
  - [src/__tests__/gear-seo-regressions.test.ts](/Users/michaelzick/Engineering/GitHub/demostoke/src/__tests__/gear-seo-regressions.test.ts)

- Preserved and kept the data integrity guard against synthetic review content for targeted items:
  - [supabase/migrations/20260520002000_clear_seeded_aggregate_rating_for_targeted_gear.sql](/Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260520002000_clear_seeded_aggregate_rating_for_targeted_gear.sql)

- Added reusable verification SQL for post-migration checks:
  - [supabase/verify_product_snippets_aggregate_rating.sql](/Users/michaelzick/Engineering/GitHub/demostoke/supabase/verify_product_snippets_aggregate_rating.sql)

## Test plan

- [x] `npm run test:unit -- src/__tests__/gear-seo-regressions.test.ts` (passes: 14/14)
- [x] SQL verification executed for:
  - target rows have `rating=0`, `review_count=0`
  - no `equipment_reviews` rows for the two targeted IDs
- [ ] Optional: re-run live page crawl/check once the latest frontend deployment is active to confirm structured-data output is current on production pages