### PR TITLE
Add Vermont ski, snowboard, and mountain-bike seed package

### DIFF
--- a/supabase/migrations/20260522190000_seed_vermont_ski_snowboard_mtb_shops.sql
+++ b/supabase/migrations/20260522190000_seed_vermont_ski_snowboard_mtb_shops.sql
@@ -1,0 +1,242 @@
+-- Seed migration: Vermont ski, snowboard, and mountain-bike shops
+-- Batch: vermont_ski_snowboard_mtb
+-- Created: 2026-05-22
+-- Apply to remote (human approval required):
+--   supabase db query --linked -f "/Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260522190000_seed_vermont_ski_snowboard_mtb_shops.sql"
+-- Do NOT use supabase db push or supabase migration up.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- =============================================
+-- VERMONT SHOPS
+-- Shop/user inserts (auth.users + auth.identities + public.profiles + public.user_roles)
+-- Password: $uO9RX^1P%bd#8crEAM!
+-- NOTE: auth.users insert is guarded by email lookup for idempotent local testing.
+-- NOTE: user_roles upsert uses UPDATE...IF NOT FOUND THEN INSERT
+-- NOTE: profile upsert uses UPDATE...IF NOT FOUND THEN INSERT
+-- =============================================
+
+DO $$
+DECLARE
+  shop record;
+  new_user_id uuid;
+  v_avatar_url text;
+  v_hero_image_url text;
+  v_display_role text := 'retail-store';
+BEGIN
+  FOR shop IN
+    SELECT *
+    FROM (
+      VALUES
+        (
+          'Base Camp Bike and Ski',
+          'Killington, VT',
+          'michaelzick+basecampkillington@gmail.com',
+          'mountain-bikes',
+          'https://basecampvt.com/',
+          '802-775-0166',
+          '2363 Route 4, Killington, VT 05751',
+          E'Full-service Killington ski and bike shop with public mountain-bike demo and rental listings. Base Camp publishes adult trail, freeride, downhill, and e-mountain-bike rental models with day rates.',
+          43.6686148,
+          -72.8030764
+        ),
+        (
+          'Alpine Bike Works Killington',
+          'Killington, VT',
+          'michaelzick+alpinebikeworkskillington@gmail.com',
+          'mountain-bikes',
+          'https://www.alpinebikeworks.com/demo-bike-rentals/killington-demo-bike-rentals/',
+          '(802) 773-0000',
+          '2326 US Route 4, Killington, VT 05751',
+          E'Mountain-bike-focused shop with a Killington demo rental fleet for park, trail, and downhill riding. Alpine Bike Works publishes specific demo bike models, day rates, and supporting rental gear details.',
+          43.6677035,
+          -72.8041879
+        ),
+        (
+          'Ranch Camp Stowe',
+          'Stowe, VT',
+          'michaelzick+ranchcampstowe@gmail.com',
+          'mountain-bikes',
+          'https://www.ranchcampvt.com/articles/rentals-demos-pg191.htm',
+          '(802) 253-2753',
+          '311 Mountain Road, Stowe, VT 05672',
+          E'Rider-owned Stowe bike shop and restaurant with a public rental and demo fleet. Ranch Camp Stowe lists full-suspension, elite, and e-mountain-bike models with full-day, half-day, and two-hour rates.',
+          44.4699332,
+          -72.6879014
+        ),
+        (
+          'Ranch Camp Woodstock',
+          'Woodstock, VT',
+          'michaelzick+ranchcampwoodstock@gmail.com',
+          'mountain-bikes',
+          'https://www.ranchcampwoodstock.com/articles/rentals-demos-pg191.htm',
+          '(802) 457-1561',
+          '431 Woodstock Road, Woodstock, VT 05091',
+          E'Woodstock mountain-bike shop and restaurant with a public rental and demo fleet. Ranch Camp Woodstock lists premium, elite, and e-mountain-bike models with source-backed day rates.',
+          43.6280004,
+          -72.5067600
+        ),
+        (
+          'The Boot Pro Ski and Bike Shop',
+          'Ludlow, VT',
+          'michaelzick+thebootproludlow@gmail.com',
+          'skis',
+          'https://www.thebootpro.net/',
+          '802-228-2776',
+          '44 Pond Street, Ludlow, VT 05149',
+          E'Ludlow ski and bike shop with public ski demo and mountain-bike rental pages. The Boot Pro publishes daily ski demo pricing plus Specialized mountain-bike rental models and rates.',
+          43.3992888,
+          -72.7066947
+        ),
+        (
+          'Burke Mountain Bike Shop',
+          'East Burke, VT',
+          'michaelzick+burkemountainbikeshop@gmail.com',
+          'mountain-bikes',
+          'https://www.skiburke.com/lessons-rentals/mountain-bike-rentals',
+          '(802) 626-7338',
+          '223 Sherburne Lodge Road, East Burke, VT 05832',
+          E'Bike Burke rental shop at Sherburne Base Lodge with public downhill and enduro rental pricing. Burke Mountain lists current Transition rental models for on-site bike park use.',
+          44.5876492,
+          -71.9161938
+        )
+    ) AS s(name, city, email, category, website, phone, address, about, lat, lng)
+  LOOP
+    IF v_display_role IN ('retail-store', 'builder') THEN
+      CASE shop.category
+        WHEN 'surfboards' THEN
+          v_avatar_url := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/73de4049-7ffd-45cd-868b-c2d0076107b3/profile-1752863282257.png';
+          v_hero_image_url := 'https://images.unsplash.com/photo-1502680390469-be75c86b636f?q=80&w=3540&auto=format&fit=crop&ixlib=rb-4.0.3';
+        WHEN 'snowboards' THEN
+          v_avatar_url := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/c5b450a8-7414-463b-b863-d78698fd0f95/profile-1752636842828.png';
+          v_hero_image_url := 'https://images.unsplash.com/photo-1590461283969-47fedf408cfd?q=80&w=2670&auto=format&fit=crop&ixlib=rb-4.1.0';
+        WHEN 'skis' THEN
+          v_avatar_url := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/7ef925ac-4b8f-496c-b4d9-10895164f03c/profile-1769637319540.png';
+          v_hero_image_url := 'https://images.unsplash.com/photo-1509791413599-93ba127a66b7?q=80&w=3540&auto=format&fit=crop&ixlib=rb-4.0.3';
+        WHEN 'mountain-bikes' THEN
+          v_avatar_url := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/ad2ad153-bb35-4e88-bfb0-d0d4f85ba62f/profile-1752637760487.png';
+          v_hero_image_url := 'https://images.unsplash.com/photo-1506316940527-4d1c138978a0?q=80&w=3512&auto=format&fit=crop&ixlib=rb-4.0.3';
+        ELSE
+          v_avatar_url := NULL;
+          v_hero_image_url := NULL;
+      END CASE;
+    ELSE
+      v_avatar_url := NULL;
+      v_hero_image_url := NULL;
+    END IF;
+
+    SELECT id INTO new_user_id
+    FROM auth.users
+    WHERE email = shop.email
+    LIMIT 1;
+
+    IF new_user_id IS NULL THEN
+      new_user_id := gen_random_uuid();
+
+      INSERT INTO auth.users (
+        id,
+        instance_id,
+        aud,
+        role,
+        email,
+        encrypted_password,
+        email_confirmed_at,
+        raw_user_meta_data,
+        raw_app_meta_data,
+        created_at,
+        updated_at,
+        confirmation_token,
+        recovery_token,
+        email_change,
+        email_change_token_current,
+        email_change_token_new,
+        email_change_confirm_status,
+        phone_change,
+        phone_change_token,
+        reauthentication_token
+      ) VALUES (
+        new_user_id,
+        '00000000-0000-0000-0000-000000000000',
+        'authenticated',
+        'authenticated',
+        shop.email,
+        crypt('$uO9RX^1P%bd#8crEAM!', gen_salt('bf')),
+        now(),
+        jsonb_build_object('name', shop.name),
+        jsonb_build_object('provider', 'email', 'providers', ARRAY['email']),
+        now(),
+        now(),
+        '',
+        '',
+        '',
+        '',
+        '',
+        0,
+        '',
+        '',
+        ''
+      );
+
+      INSERT INTO auth.identities (
+        id,
+        user_id,
+        identity_data,
+        provider,
+        provider_id,
+        last_sign_in_at,
+        created_at,
+        updated_at
+      ) VALUES (
+        gen_random_uuid(),
+        new_user_id,
+        jsonb_build_object('sub', new_user_id::text, 'email', shop.email),
+        'email',
+        new_user_id::text,
+        now(),
+        now(),
+        now()
+      );
+    END IF;
+
+    UPDATE public.profiles SET
+      name = shop.name,
+      website = shop.website,
+      phone = shop.phone,
+      address = shop.address,
+      about = shop.about,
+      location_lat = shop.lat,
+      location_lng = shop.lng,
+      avatar_url = COALESCE(v_avatar_url, avatar_url),
+      hero_image_url = COALESCE(v_hero_image_url, hero_image_url)
+    WHERE id = new_user_id;
+
+    IF NOT FOUND THEN
+      INSERT INTO public.profiles (
+        id, name, website, phone, address, about,
+        location_lat, location_lng, avatar_url, hero_image_url
+      ) VALUES (
+        new_user_id,
+        shop.name,
+        shop.website,
+        shop.phone,
+        shop.address,
+        shop.about,
+        shop.lat,
+        shop.lng,
+        v_avatar_url,
+        v_hero_image_url
+      );
+    END IF;
+
+    UPDATE public.user_roles
+      SET display_role = v_display_role
+      WHERE user_id = new_user_id;
+
+    IF NOT FOUND THEN
+      INSERT INTO public.user_roles (user_id, display_role)
+      VALUES (new_user_id, v_display_role);
+    END IF;
+
+    RAISE NOTICE 'User upserted successfully: id=%, email=%, role=%', new_user_id, shop.email, v_display_role;
+  END LOOP;
+END $$;

--- a/supabase/migrations/20260522190100_seed_vermont_skis_gear.sql
+++ b/supabase/migrations/20260522190100_seed_vermont_skis_gear.sql
@@ -1,0 +1,167 @@
+-- Seed migration: Vermont skis gear
+-- Batch: vermont_ski_snowboard_mtb
+-- Created: 2026-05-22
+-- Depends on: 20260522190000_seed_vermont_ski_snowboard_mtb_shops.sql (apply shops first)
+-- Apply to remote (human approval required):
+--   supabase db query --linked -f "/Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260522190100_seed_vermont_skis_gear.sql"
+-- Do NOT use supabase db push or supabase migration up.
+--
+-- Gear batches are category-homogeneous.
+-- Skis primary image:   https://images.pexels.com/photos/848699/pexels-photo-848699.jpeg
+-- Skis secondary image: https://images.pexels.com/photos/36084973/pexels-photo-36084973.jpeg
+
+-- =============================================
+-- EQUIPMENT: The Boot Pro Ski and Bike Shop (Ludlow, VT) - skis
+-- Email: michaelzick+thebootproludlow@gmail.com
+-- Price basis: The Boot Pro official demo ski page, daily adult recreational demo rate, retrieved 2026-05-22.
+-- Coordinates sourced from Nominatim street-level geocode for 44 Pond Street, Ludlow, VT 05149.
+-- =============================================
+DO $$
+DECLARE
+  missing_email text;
+  v_equipment_inserted int := 0;
+  v_primary_images_added int := 0;
+  v_secondary_images_added int := 0;
+BEGIN
+  SELECT seed_email INTO missing_email
+  FROM (
+    VALUES
+      ('michaelzick+thebootproludlow@gmail.com')
+  ) AS planned(seed_email)
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM auth.users au
+    WHERE au.email = planned.seed_email
+  )
+  LIMIT 1;
+
+  IF missing_email IS NOT NULL THEN
+    RAISE EXCEPTION 'User not found for email: %', missing_email;
+  END IF;
+
+  WITH seed_equipment (
+    seed_email,
+    name,
+    category,
+    description,
+    price_per_day,
+    price_per_hour,
+    price_per_week,
+    size,
+    weight,
+    material,
+    suitable_skill_level,
+    status,
+    location_lat,
+    location_lng,
+    location_address,
+    subcategory,
+    damage_deposit,
+    visible_on_map
+  ) AS (
+    VALUES
+      (
+        'michaelzick+thebootproludlow@gmail.com',
+        'Atomic Maverick 115 CTI',
+        'skis',
+        'The Atomic Maverick 115 CTI is a freeride-oriented all-mountain ski for deep snow and mixed off-piste terrain. Its wide platform and powerful construction support confident turns in variable Vermont conditions. It is best suited to advanced riders looking for a directional demo ski with stability at speed.',
+        70.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        43.3992888, -72.7066947,
+        '44 Pond Street, Ludlow, VT 05149',
+        'freeride', NULL::numeric, true
+      ),
+      (
+        'michaelzick+thebootproludlow@gmail.com',
+        'Atomic Maven 84',
+        'skis',
+        'The Atomic Maven 84 is an approachable all-mountain ski built for groomers, mixed snow, and everyday resort laps. Its lighter construction favors easy turn initiation while keeping enough edge hold for firm surfaces. It fits newer through advancing skiers who want a composed frontside demo option.',
+        70.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced',
+        'available',
+        43.3992888, -72.7066947,
+        '44 Pond Street, Ludlow, VT 05149',
+        'all-mountain', NULL::numeric, true
+      )
+  ),
+  resolved AS (
+    SELECT
+      au.id AS user_id,
+      s.*
+    FROM seed_equipment s
+    JOIN auth.users au ON au.email = s.seed_email
+  ),
+  inserted AS (
+    INSERT INTO public.equipment (
+      id, user_id, name, category, description,
+      price_per_day, price_per_hour, price_per_week,
+      size, weight, material, suitable_skill_level, status,
+      location_lat, location_lng, location_address, subcategory,
+      damage_deposit, visible_on_map
+    )
+    SELECT
+      gen_random_uuid(),
+      r.user_id,
+      r.name, r.category, r.description,
+      r.price_per_day, r.price_per_hour, r.price_per_week,
+      r.size, r.weight, r.material, r.suitable_skill_level, r.status,
+      r.location_lat, r.location_lng, r.location_address, r.subcategory,
+      r.damage_deposit, r.visible_on_map
+    FROM resolved r
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment e
+      WHERE e.user_id = r.user_id
+        AND e.name = r.name
+    )
+    RETURNING id
+  ),
+  ins1 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT
+      i.id,
+      'https://images.pexels.com/photos/848699/pexels-photo-848699.jpeg',
+      0,
+      true
+    FROM inserted i
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment_images ei
+      WHERE ei.equipment_id = i.id
+        AND ei.display_order = 0
+    )
+    RETURNING equipment_id
+  ),
+  ins2 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT
+      i.id,
+      'https://images.pexels.com/photos/36084973/pexels-photo-36084973.jpeg',
+      1,
+      false
+    FROM inserted i
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment_images ei
+      WHERE ei.equipment_id = i.id
+        AND ei.display_order = 1
+    )
+    RETURNING equipment_id
+  )
+  SELECT
+    (SELECT count(*) FROM inserted),
+    (SELECT count(*) FROM ins1),
+    (SELECT count(*) FROM ins2)
+  INTO
+    v_equipment_inserted,
+    v_primary_images_added,
+    v_secondary_images_added;
+
+  RAISE NOTICE 'Vermont skis inserted=%, primary_images_added=%, secondary_images_added=%',
+    v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+END $$;

--- a/supabase/migrations/20260522190200_seed_vermont_mountain_bikes_gear.sql
+++ b/supabase/migrations/20260522190200_seed_vermont_mountain_bikes_gear.sql
@@ -1,0 +1,535 @@
+-- Seed migration: Vermont mountain-bike gear
+-- Batch: vermont_ski_snowboard_mtb
+-- Created: 2026-05-22
+-- Depends on: 20260522190000_seed_vermont_ski_snowboard_mtb_shops.sql (apply shops first)
+-- Apply to remote (human approval required):
+--   supabase db query --linked -f "/Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260522190200_seed_vermont_mountain_bikes_gear.sql"
+-- Do NOT use supabase db push or supabase migration up.
+--
+-- Gear batches are category-homogeneous.
+-- Mountain-bikes primary image:   https://images.pexels.com/photos/30447388/pexels-photo-30447388.jpeg
+-- Mountain-bikes secondary image: https://images.pexels.com/photos/25753440/pexels-photo-25753440.jpeg
+
+-- =============================================
+-- EQUIPMENT: Vermont accepted mountain-bike shops
+-- Price basis: official Vermont rental/demo pages retrieved 2026-05-22.
+-- Coordinates sourced from Nominatim street-level geocodes for each shop address.
+-- =============================================
+DO $$
+DECLARE
+  missing_email text;
+  v_equipment_inserted int := 0;
+  v_primary_images_added int := 0;
+  v_secondary_images_added int := 0;
+BEGIN
+  SELECT seed_email INTO missing_email
+  FROM (
+    VALUES
+      ('michaelzick+basecampkillington@gmail.com'),
+      ('michaelzick+alpinebikeworkskillington@gmail.com'),
+      ('michaelzick+ranchcampstowe@gmail.com'),
+      ('michaelzick+ranchcampwoodstock@gmail.com'),
+      ('michaelzick+thebootproludlow@gmail.com'),
+      ('michaelzick+burkemountainbikeshop@gmail.com')
+  ) AS planned(seed_email)
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM auth.users au
+    WHERE au.email = planned.seed_email
+  )
+  LIMIT 1;
+
+  IF missing_email IS NOT NULL THEN
+    RAISE EXCEPTION 'User not found for email: %', missing_email;
+  END IF;
+
+  WITH seed_equipment (
+    seed_email,
+    name,
+    category,
+    description,
+    price_per_day,
+    price_per_hour,
+    price_per_week,
+    size,
+    weight,
+    material,
+    suitable_skill_level,
+    status,
+    location_lat,
+    location_lng,
+    location_address,
+    subcategory,
+    damage_deposit,
+    visible_on_map
+  ) AS (
+    VALUES
+      (
+        'michaelzick+basecampkillington@gmail.com',
+        'Pivot Switchblade Pro XO',
+        'mountain-bikes',
+        'The Pivot Switchblade Pro XO is a versatile full-suspension trail bike for all-day Killington-area rides. Its balanced travel profile works well for technical singletrack, rolling climbs, and confident descents. It is a strong choice for intermediate riders who want one premium demo bike for mixed terrain.',
+        120.00::numeric, NULL::numeric, NULL::numeric,
+        'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced',
+        'available',
+        43.6686148, -72.8030764,
+        '2363 Route 4, Killington, VT 05751',
+        'trail', NULL::numeric, true
+      ),
+      (
+        'michaelzick+basecampkillington@gmail.com',
+        'Pivot Firebird Pro XO',
+        'mountain-bikes',
+        'The Pivot Firebird Pro XO is a long-travel enduro bike built for steep trails and bike-park speed. It gives riders a composed platform for rough descents while retaining enough efficiency for pedal-accessed terrain. It is best for confident riders moving into more aggressive lines.',
+        120.00::numeric, NULL::numeric, NULL::numeric,
+        'Small, Medium, Large',
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        43.6686148, -72.8030764,
+        '2363 Route 4, Killington, VT 05751',
+        'enduro', NULL::numeric, true
+      ),
+      (
+        'michaelzick+basecampkillington@gmail.com',
+        'Transition TR11',
+        'mountain-bikes',
+        'The Transition TR11 is a downhill rental for lift-served park riding. Its dedicated gravity setup is aimed at riders spending the day on steeper descents and repeated bike-park laps. It fits advanced riders who want maximum control on rough terrain.',
+        150.00::numeric, NULL::numeric, NULL::numeric,
+        'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        43.6686148, -72.8030764,
+        '2363 Route 4, Killington, VT 05751',
+        'downhill', NULL::numeric, true
+      ),
+      (
+        'michaelzick+basecampkillington@gmail.com',
+        'Transition Bottlerocket',
+        'mountain-bikes',
+        'The Transition Bottlerocket is a freeride-focused rental for riders who want a playful bike with downhill capability. It suits jump lines, park laps, and rougher descents where extra travel adds confidence. It is best matched to intermediate and advanced riders.',
+        130.00::numeric, NULL::numeric, NULL::numeric,
+        'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        43.6686148, -72.8030764,
+        '2363 Route 4, Killington, VT 05751',
+        'freeride', NULL::numeric, true
+      ),
+      (
+        'michaelzick+basecampkillington@gmail.com',
+        'Norco Sight VLT TQ',
+        'mountain-bikes',
+        'The Norco Sight VLT TQ is an e-mountain-bike rental for riders who want motor support on longer trail days. Its mixed-wheel trail platform favors technical climbing, sustained descents, and extended exploration. It is a useful option for intermediate riders looking to cover more terrain.',
+        130.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced',
+        'available',
+        43.6686148, -72.8030764,
+        '2363 Route 4, Killington, VT 05751',
+        'e-mountain-bike', NULL::numeric, true
+      ),
+      (
+        'michaelzick+basecampkillington@gmail.com',
+        'Norco Sight VLT Bosch',
+        'mountain-bikes',
+        'The Norco Sight VLT Bosch is an e-mountain-bike rental for riders who want a powerful pedal-assist trail platform. It is built for mixed climbing and descending where support helps extend the day. It fits progressing trail riders who want help reaching more Vermont singletrack.',
+        130.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced',
+        'available',
+        43.6686148, -72.8030764,
+        '2363 Route 4, Killington, VT 05751',
+        'e-mountain-bike', NULL::numeric, true
+      ),
+      (
+        'michaelzick+alpinebikeworkskillington@gmail.com',
+        'GT Fury Carbon Pro',
+        'mountain-bikes',
+        'The GT Fury Carbon Pro is a dedicated downhill bike for Killington Bike Park laps. Its high-pivot gravity layout is designed for fast descents, braking bumps, and repeated lift-served runs. It is best for riders with park experience who want a stable downhill platform.',
+        120.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        43.6677035, -72.8041879,
+        '2326 US Route 4, Killington, VT 05751',
+        'downhill', NULL::numeric, true
+      ),
+      (
+        'michaelzick+alpinebikeworkskillington@gmail.com',
+        'GT Force Carbon Pro',
+        'mountain-bikes',
+        'The GT Force Carbon Pro is an enduro rental for local trails and bike-park days. Its long-travel suspension gives riders control on rough descents while staying practical for varied terrain. It works for a wide range of riders who want one aggressive demo bike.',
+        120.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced',
+        'available',
+        43.6677035, -72.8041879,
+        '2326 US Route 4, Killington, VT 05751',
+        'enduro', NULL::numeric, true
+      ),
+      (
+        'michaelzick+alpinebikeworkskillington@gmail.com',
+        'Giant Reign SX Mullet',
+        'mountain-bikes',
+        'The Giant Reign SX Mullet is a downhill-focused rental for lift-served riding. Its mixed-wheel setup and long-travel suspension are aimed at riders who want stability with responsive handling. It is best for intermediate and advanced riders at Killington Bike Park.',
+        80.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        43.6677035, -72.8041879,
+        '2326 US Route 4, Killington, VT 05751',
+        'downhill', NULL::numeric, true
+      ),
+      (
+        'michaelzick+ranchcampstowe@gmail.com',
+        'Norco Fluid Alloy',
+        'mountain-bikes',
+        'The Norco Fluid Alloy is a standard full-suspension mountain-bike rental for Stowe trail riding. It gives newer and intermediate riders a predictable platform for singletrack, climbs, and rolling descents. It is a practical choice for riders stepping up from hardtails into full suspension.',
+        85.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate',
+        'available',
+        44.4699332, -72.6879014,
+        '311 Mountain Road, Stowe, VT 05672',
+        'full-suspension', NULL::numeric, true
+      ),
+      (
+        'michaelzick+ranchcampstowe@gmail.com',
+        'Ibis Ripmo AF',
+        'mountain-bikes',
+        'The Ibis Ripmo AF is a premium full-suspension rental for bigger trail rides around Stowe. Its all-mountain character gives riders a confident feel on technical climbs and rougher descents. It fits intermediate riders who want a sturdy, capable demo platform.',
+        99.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced',
+        'available',
+        44.4699332, -72.6879014,
+        '311 Mountain Road, Stowe, VT 05672',
+        'all-mountain', NULL::numeric, true
+      ),
+      (
+        'michaelzick+ranchcampstowe@gmail.com',
+        'Norco Revolver C1',
+        'mountain-bikes',
+        'The Norco Revolver C1 is an elite full-suspension demo bike with a fast cross-country feel. It favors efficient pedaling, quick handling, and longer trail days where speed matters. It is well matched to riders who want a lighter premium mountain-bike rental.',
+        119.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced',
+        'available',
+        44.4699332, -72.6879014,
+        '311 Mountain Road, Stowe, VT 05672',
+        'cross-country', NULL::numeric, true
+      ),
+      (
+        'michaelzick+ranchcampstowe@gmail.com',
+        'Yeti SB140',
+        'mountain-bikes',
+        'The Yeti SB140 is an elite trail bike for riders who want a lively all-mountain demo. It balances efficient pedaling with confident descending on varied Vermont singletrack. It suits intermediate and advanced riders looking for a premium trail feel.',
+        119.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced',
+        'available',
+        44.4699332, -72.6879014,
+        '311 Mountain Road, Stowe, VT 05672',
+        'trail', NULL::numeric, true
+      ),
+      (
+        'michaelzick+ranchcampstowe@gmail.com',
+        'Ibis Ripley SL',
+        'mountain-bikes',
+        'The Ibis Ripley SL is an elite lightweight trail bike for fast singletrack and longer rides. Its efficient ride feel helps riders cover ground without giving up full-suspension control. It is a strong fit for intermediate riders who value speed and precision.',
+        119.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced',
+        'available',
+        44.4699332, -72.6879014,
+        '311 Mountain Road, Stowe, VT 05672',
+        'trail', NULL::numeric, true
+      ),
+      (
+        'michaelzick+ranchcampstowe@gmail.com',
+        'Yeti MTe',
+        'mountain-bikes',
+        'The Yeti MTe is an e-mountain-bike rental for riders who want premium pedal assist on Stowe terrain. It supports longer loops, repeated climbs, and mixed technical trail days. It is useful for intermediate and advanced riders who want more range from a demo ride.',
+        129.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced',
+        'available',
+        44.4699332, -72.6879014,
+        '311 Mountain Road, Stowe, VT 05672',
+        'e-mountain-bike', NULL::numeric, true
+      ),
+      (
+        'michaelzick+ranchcampstowe@gmail.com',
+        'Norco Fluid VLT',
+        'mountain-bikes',
+        'The Norco Fluid VLT is an e-mountain-bike rental with full-suspension trail capability. It gives riders extra support for climbs while staying composed on descents. It is a good fit for riders exploring more Stowe mileage in a single rental window.',
+        129.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced',
+        'available',
+        44.4699332, -72.6879014,
+        '311 Mountain Road, Stowe, VT 05672',
+        'e-mountain-bike', NULL::numeric, true
+      ),
+      (
+        'michaelzick+ranchcampstowe@gmail.com',
+        'Trek Fuel EXe',
+        'mountain-bikes',
+        'The Trek Fuel EXe is an e-mountain-bike rental with a natural trail-bike ride feel. It adds quiet support for longer climbs while keeping handling familiar on rolling singletrack. It suits riders who want a lighter-feeling assist bike for Stowe trails.',
+        129.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced',
+        'available',
+        44.4699332, -72.6879014,
+        '311 Mountain Road, Stowe, VT 05672',
+        'e-mountain-bike', NULL::numeric, true
+      ),
+      (
+        'michaelzick+ranchcampwoodstock@gmail.com',
+        'Ibis Ripley AF',
+        'mountain-bikes',
+        'The Ibis Ripley AF is a premium full-suspension rental for Woodstock trail riding. It gives riders an efficient and stable platform for local singletrack, rolling terrain, and technical sections. It works well for intermediate riders looking for a capable trail demo.',
+        99.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced',
+        'available',
+        43.6280004, -72.5067600,
+        '431 Woodstock Road, Woodstock, VT 05091',
+        'trail', NULL::numeric, true
+      ),
+      (
+        'michaelzick+ranchcampwoodstock@gmail.com',
+        'Yeti SB140',
+        'mountain-bikes',
+        'The Yeti SB140 is an elite trail demo for riders who want a premium all-mountain bike in Woodstock. It balances responsive handling with confident descending on varied terrain. It fits intermediate and advanced riders looking for a lively full-suspension ride.',
+        119.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced',
+        'available',
+        43.6280004, -72.5067600,
+        '431 Woodstock Road, Woodstock, VT 05091',
+        'trail', NULL::numeric, true
+      ),
+      (
+        'michaelzick+ranchcampwoodstock@gmail.com',
+        'Norco Revolver',
+        'mountain-bikes',
+        'The Norco Revolver is an elite full-suspension demo bike with a fast and efficient trail personality. It is well suited to longer loops, quick climbs, and flowy Woodstock singletrack. It gives riders a lighter premium option for cross-country-leaning rides.',
+        119.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced',
+        'available',
+        43.6280004, -72.5067600,
+        '431 Woodstock Road, Woodstock, VT 05091',
+        'cross-country', NULL::numeric, true
+      ),
+      (
+        'michaelzick+ranchcampwoodstock@gmail.com',
+        'Ibis Ripley SL',
+        'mountain-bikes',
+        'The Ibis Ripley SL is an elite lightweight trail rental for riders who value speed and precision. It is built for efficient pedaling while still offering full-suspension control on rougher sections. It suits intermediate and advanced riders exploring Woodstock trails.',
+        119.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced',
+        'available',
+        43.6280004, -72.5067600,
+        '431 Woodstock Road, Woodstock, VT 05091',
+        'trail', NULL::numeric, true
+      ),
+      (
+        'michaelzick+ranchcampwoodstock@gmail.com',
+        'Yeti MTe',
+        'mountain-bikes',
+        'The Yeti MTe is an e-mountain-bike rental for riders who want premium pedal assist on Vermont trails. It helps extend longer rides while keeping a confident trail-bike feel. It is a good option for intermediate riders who want extra range around Woodstock.',
+        129.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced',
+        'available',
+        43.6280004, -72.5067600,
+        '431 Woodstock Road, Woodstock, VT 05091',
+        'e-mountain-bike', NULL::numeric, true
+      ),
+      (
+        'michaelzick+ranchcampwoodstock@gmail.com',
+        'Norco Fluid VLT',
+        'mountain-bikes',
+        'The Norco Fluid VLT is an e-mountain-bike rental for riders seeking support on climbs and control on descents. Its full-suspension trail focus makes it useful for mixed Woodstock terrain. It fits riders who want an approachable assist bike for longer outings.',
+        129.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced',
+        'available',
+        43.6280004, -72.5067600,
+        '431 Woodstock Road, Woodstock, VT 05091',
+        'e-mountain-bike', NULL::numeric, true
+      ),
+      (
+        'michaelzick+ranchcampwoodstock@gmail.com',
+        'Trek Fuel EXe',
+        'mountain-bikes',
+        'The Trek Fuel EXe is an e-mountain-bike rental that keeps a natural-feeling trail-bike character. It adds discreet support for longer rides and repeated climbs without overwhelming handling. It suits riders who want an efficient assist option for Woodstock singletrack.',
+        129.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced',
+        'available',
+        43.6280004, -72.5067600,
+        '431 Woodstock Road, Woodstock, VT 05091',
+        'e-mountain-bike', NULL::numeric, true
+      ),
+      (
+        'michaelzick+thebootproludlow@gmail.com',
+        'Specialized Stumpjumper',
+        'mountain-bikes',
+        'The Specialized Stumpjumper is a full-suspension trail bike for Ludlow-area dirt roads and local mountain-bike trails. It gives riders a dependable mid-travel platform for mixed terrain and confident descending. It is an approachable analog rental for intermediate riders.',
+        80.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced',
+        'available',
+        43.3992888, -72.7066947,
+        '44 Pond Street, Ludlow, VT 05149',
+        'trail', NULL::numeric, true
+      ),
+      (
+        'michaelzick+thebootproludlow@gmail.com',
+        'Specialized Turbo Levo',
+        'mountain-bikes',
+        'The Specialized Turbo Levo is an e-mountain-bike rental for riders who want support on Vermont climbs and trail loops. Its pedal-assist system helps extend range while keeping full-suspension control for descending. It fits riders who want a powerful trail rental for Ascutney, Woodstock, or Ludlow-area riding.',
+        100.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced',
+        'available',
+        43.3992888, -72.7066947,
+        '44 Pond Street, Ludlow, VT 05149',
+        'e-mountain-bike', NULL::numeric, true
+      ),
+      (
+        'michaelzick+burkemountainbikeshop@gmail.com',
+        'Transition TR-11',
+        'mountain-bikes',
+        'The Transition TR-11 is a downhill rental for on-site Burke Mountain bike park use. Its mixed-wheel gravity setup is aimed at riders spending the day on lift-served descents. It is best for intermediate and advanced riders who want a dedicated downhill bike.',
+        119.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        44.5876492, -71.9161938,
+        '223 Sherburne Lodge Road, East Burke, VT 05832',
+        'downhill', NULL::numeric, true
+      ),
+      (
+        'michaelzick+burkemountainbikeshop@gmail.com',
+        'Transition Spire',
+        'mountain-bikes',
+        'The Transition Spire is an enduro rental for Burke Mountain riders who want stability on bigger terrain. It is suited to rough descents, bike-park laps, and aggressive trail riding. It gives advanced riders a capable long-travel platform for on-site use.',
+        119.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        44.5876492, -71.9161938,
+        '223 Sherburne Lodge Road, East Burke, VT 05832',
+        'enduro', NULL::numeric, true
+      )
+  ),
+  resolved AS (
+    SELECT
+      au.id AS user_id,
+      s.*
+    FROM seed_equipment s
+    JOIN auth.users au ON au.email = s.seed_email
+  ),
+  inserted AS (
+    INSERT INTO public.equipment (
+      id, user_id, name, category, description,
+      price_per_day, price_per_hour, price_per_week,
+      size, weight, material, suitable_skill_level, status,
+      location_lat, location_lng, location_address, subcategory,
+      damage_deposit, visible_on_map
+    )
+    SELECT
+      gen_random_uuid(),
+      r.user_id,
+      r.name, r.category, r.description,
+      r.price_per_day, r.price_per_hour, r.price_per_week,
+      r.size, r.weight, r.material, r.suitable_skill_level, r.status,
+      r.location_lat, r.location_lng, r.location_address, r.subcategory,
+      r.damage_deposit, r.visible_on_map
+    FROM resolved r
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment e
+      WHERE e.user_id = r.user_id
+        AND e.name = r.name
+    )
+    RETURNING id
+  ),
+  ins1 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT
+      i.id,
+      'https://images.pexels.com/photos/30447388/pexels-photo-30447388.jpeg',
+      0,
+      true
+    FROM inserted i
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment_images ei
+      WHERE ei.equipment_id = i.id
+        AND ei.display_order = 0
+    )
+    RETURNING equipment_id
+  ),
+  ins2 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT
+      i.id,
+      'https://images.pexels.com/photos/25753440/pexels-photo-25753440.jpeg',
+      1,
+      false
+    FROM inserted i
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment_images ei
+      WHERE ei.equipment_id = i.id
+        AND ei.display_order = 1
+    )
+    RETURNING equipment_id
+  )
+  SELECT
+    (SELECT count(*) FROM inserted),
+    (SELECT count(*) FROM ins1),
+    (SELECT count(*) FROM ins2)
+  INTO
+    v_equipment_inserted,
+    v_primary_images_added,
+    v_secondary_images_added;
+
+  RAISE NOTICE 'Vermont mountain-bikes inserted=%, primary_images_added=%, secondary_images_added=%',
+    v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+END $$;


### PR DESCRIPTION
## Summary
- Added a new Vermont seed package for DemoStoke with three data-only Supabase migrations: one shop migration, one ski gear migration, and one mountain-bike gear migration.
- Seeded 6 Vermont shops with idempotent auth/profile/role upserts, plus 30 gear rows total across skis and mountain bikes; no snowboard rows qualified under the strict evidence bar.
- Built the supporting Hermes audit package: `discovery_audit.md`, `rejected_candidates.md`, `sources.json`, `validation.sql`, `remote_validation_report.md`, and `remote_runbook.md`.
- Updated `seeded_shops_registry.md` with the new applied Vermont shops, runtime user IDs, and gear counts.
- Full branch delta vs `main` is limited to the Vermont seed migrations and Hermes seed-batch documentation/registry updates.

## Testing
- Passed static scans for forbidden migration patterns (`DELETE FROM`, `TRUNCATE`, `DROP`, `ALTER TABLE`, `ON CONFLICT`, `specs`) and verified `sources.json` is valid JSON.
- Ran a rollback-only remote dry run with the exact Vermont migrations plus `validation.sql`; validation returned all `ok` rows and rolled back cleanly.
- Ran the migrations for real against remote Supabase, confirmed no table count decreases, ran post-commit validation successfully, and reran the migrations inside a rollback transaction to prove idempotency.
- Refreshed migration history with `supabase migration repair --linked --status applied 20260522190000 20260522190100 20260522190200` and confirmed the linked list is aligned.