### PR TITLE
Seed Canada gear shops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,7 +241,7 @@ Do not substitute other image sources for seed data. If new categories are added
 
 ## Seed Data — Current Seeded Shops
 
-This summary reflects read-only linked DemoStoke data checks during the May 21, 2026 migration reconciliation.
+This summary reflects read-only linked DemoStoke data checks after the May 24, 2026 Canada seed apply. The Wax Bench row is an existing live profile retargeted by the Canada batch; its gear count is the current profile count after 17 inserts and 11 updates, not a newly created shop.
 
 | # | Shop | Region | Category | Gear | Status |
 |---|---|---|---|---|---|
@@ -262,7 +262,20 @@ This summary reflects read-only linked DemoStoke data checks during the May 21, 
 | 15 | Cripple Creek Bike and Backcountry Aspen | Aspen, CO | mountain-bikes | 2 | applied |
 | 16 | Walden Surfboards | Ventura, CA | surfboards | 4 | applied |
 | 17 | Spider Mountain Bike Park | Burnet, TX | mountain-bikes | 6 | applied |
-| | **Total** | | | **141** | |
+| 18 | GearHub Sports | Fernie, BC | mountain-bikes + snowboards | 8 | applied |
+| 19 | Coastal Culture Sports | Whistler, BC | mountain-bikes | 3 | applied |
+| 20 | Whistler Sports Rentals | Whistler, BC | mountain-bikes | 5 | applied |
+| 21 | Cross Country Connection | Whistler, BC | mountain-bikes + skis | 9 | applied |
+| 22 | Big White Bike Park | Big White, BC | mountain-bikes | 2 | applied |
+| 23 | Dialed In Cycling | Squamish, BC | mountain-bikes | 6 | applied |
+| 24 | Essential Cycles | North Vancouver, BC | mountain-bikes | 4 | applied |
+| 25 | Lynn Valley Bikes | North Vancouver, BC | mountain-bikes | 2 | applied |
+| 26 | Cycle BC Vancouver | Vancouver, BC | mountain-bikes | 2 | applied |
+| 27 | Trail Bicycles | Courtenay, BC | mountain-bikes | 5 | applied |
+| 28 | Mont-Sainte-Anne Sports Alpins | Beaupre, QC | mountain-bikes | 6 | applied |
+| 29 | Vallee Bras-du-Nord Shannahan | Saint-Raymond, QC | mountain-bikes | 3 | applied |
+| 30 | The Wax Bench | Revelstoke, BC | skis + snowboards | 48 | existing profile retargeted; applied |
+| | **Total** | | | **244** | |
 
 Do not re-seed any shop already in this table. Do not seed Hawaii Surfboard Rentals under any Hawaii discovery task.
 

--- a/supabase/migrations/20260524000000_seed_canada_ski_snowboard_surf_mtb_shops.sql
+++ b/supabase/migrations/20260524000000_seed_canada_ski_snowboard_surf_mtb_shops.sql
@@ -1,0 +1,224 @@
+-- Seed migration: Canada ski, snowboard, surf, and mountain-bike shops
+-- Batch: canada_ski_snowboard_surf_mtb
+-- Created: 2026-05-24
+-- Apply to remote (human approval required):
+--   supabase db query --linked -f "/Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260524000000_seed_canada_ski_snowboard_surf_mtb_shops.sql"
+-- Do NOT use supabase db push or supabase migration up.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- =============================================
+-- CANADA SHOPS
+-- Shop/user inserts (auth.users + auth.identities + public.profiles + public.user_roles)
+-- The Wax Bench is intentionally excluded here because it already exists as profile 60877048-53da-4efb-842f-2d22e98caef0.
+-- Password: $uO9RX^1P%bd#8crEAM!
+-- NOTE: auth.users insert is guarded by email lookup for idempotent local testing.
+-- NOTE: user_roles upsert uses UPDATE...IF NOT FOUND THEN INSERT.
+-- NOTE: profile upsert uses UPDATE...IF NOT FOUND THEN INSERT.
+-- =============================================
+
+DO $$
+DECLARE
+  shop record;
+  new_user_id uuid;
+  v_avatar_url text;
+  v_hero_image_url text;
+  v_display_role text := 'retail-store';
+BEGIN
+  FOR shop IN
+    SELECT *
+    FROM (
+      VALUES
+        (
+          E'GearHub Sports',
+          E'Fernie, BC',
+          E'michaelzick+gearhubsportsfernie@gmail.com',
+          E'mountain-bikes',
+          E'https://gearhub.ca/rentals/summer-adventure-rentals/',
+          E'250-423-5555',
+          E'401 1st Ave, Fernie, BC V0B 1M0',
+          E'Fernie outdoor shop with public winter snowboard rentals and summer mountain-bike rental fleets. GearHub publishes source-backed model names and prices for its K2 snowboard, Rocky Mountain bikes, Devinci bikes, and e-mountain-bikes.',
+          49.5020785,
+          -115.0616403
+        ),
+        (
+          E'Coastal Culture Sports',
+          E'Whistler, BC',
+          E'michaelzick+coastalculturesportswhistler@gmail.com',
+          E'mountain-bikes',
+          E'https://coastalculturesports.com/pages/rental-bikes',
+          E'604-932-2224',
+          E'2010 London Lane, Whistler, BC V8E 0A6',
+          E'Whistler Creekside rental and retail shop with public bike rental listings. Coastal Culture Sports publishes Santa Cruz and Rocky Mountain rental models with current starting day prices.',
+          50.0951007,
+          -122.9894654
+        ),
+        (
+          E'Whistler Sports Rentals',
+          E'Whistler, BC',
+          E'michaelzick+whistlersportsrentals@gmail.com',
+          E'mountain-bikes',
+          E'https://whistlersports.com/equipment',
+          E'604-938-9700',
+          E'4205 Village Square, Whistler, BC V8E 1H4',
+          E'Whistler village rental operator with model-level mountain-bike, downhill, and e-mountain-bike rental listings. Whistler Sports publishes Norco and Giant bike models with online CAD rates.',
+          50.1151411,
+          -122.9567290
+        ),
+        (
+          E'Cross Country Connection',
+          E'Whistler, BC',
+          E'michaelzick+crosscountryconnectionwhistler@gmail.com',
+          E'mountain-bikes',
+          E'https://www.crosscountryconnection.ca/',
+          E'604-905-0071',
+          E'Lost Lake PassivHaus, 7400 Fitzsimmons Rd S, Whistler, BC V8E 0E8',
+          E'Whistler Lost Lake rental shop with public summer bike and winter Nordic rental rate sheets. Cross Country Connection publishes specific Norco mountain-bike models and Rossignol ski model families with full-day prices.',
+          50.1232691,
+          -122.9506367
+        ),
+        (
+          E'Big White Bike Park',
+          E'Big White, BC',
+          E'michaelzick+bigwhitebikepark@gmail.com',
+          E'mountain-bikes',
+          E'https://m.bigwhite.com/summer/mountain-biking/rentals-repairs',
+          E'250-765-3101',
+          E'5315 Big White Road, Big White Mountain, BC V1P 1P3',
+          E'Big White Bike Park rental operation with public downhill and enduro mountain-bike rental pricing. The resort publishes Trek model-level rentals for lift-served and enduro riding.',
+          49.7379086,
+          -118.9459084
+        ),
+        (
+          E'Dialed In Cycling',
+          E'Squamish, BC',
+          E'michaelzick+dialedincyclingsquamish@gmail.com',
+          E'mountain-bikes',
+          E'https://dialedincycling.com/rentals/',
+          E'604-390-4303',
+          E'1796 Depot Rd, Squamish, BC V8B 0P6',
+          E'Squamish bike rental and service shop with public mountain-bike rental listings. Dialed In Cycling publishes Marin, Cube, and Kona models with clear day prices for local trail riding.',
+          49.7680282,
+          -123.1363713
+        ),
+        (
+          E'Essential Cycles',
+          E'North Vancouver, BC',
+          E'michaelzick+essentialcyclesnorthvancouver@gmail.com',
+          E'mountain-bikes',
+          E'https://www.essentialcycles.com/collections/all-bike-rentals',
+          E'778-861-2453',
+          E'305 Mansfield Place, North Vancouver, BC V7J 1E4',
+          E'North Vancouver bike shop near the North Shore trail network with public model-level bike rental products. Essential Cycles publishes Ibis and Marin mountain-bike rental models with daily prices.',
+          49.3072818,
+          -123.0373803
+        ),
+        (
+          E'Lynn Valley Bikes',
+          E'North Vancouver, BC',
+          E'michaelzick+lynnvalleybikesnorthvancouver@gmail.com',
+          E'mountain-bikes',
+          E'https://www.lynnvalleybikes.com/articles/rentals-pg209.htm',
+          E'604-985-9311',
+          E'3028 Mountain Hwy, North Vancouver, BC V7J 2P1',
+          E'North Vancouver bike shop close to Mount Fromme with public mountain-bike and e-mountain-bike rental listings. Lynn Valley Bikes publishes Rocky Mountain and Marin models with four-hour and day rates.',
+          49.3366003,
+          -123.0377266
+        ),
+        (
+          E'Cycle BC Vancouver',
+          E'Vancouver, BC',
+          E'michaelzick+cyclebcvancouver@gmail.com',
+          E'mountain-bikes',
+          E'https://cyclebc.ca/vancouver/bicycles/vancouver-mountain-bike-rentals/',
+          E'604-709-5663',
+          E'73 East 6th Avenue, Vancouver, BC V5T 1J3',
+          E'Vancouver bicycle rental shop with public Norco mountain-bike rental listings. Cycle BC publishes full-day and multi-day mountain-bike and e-mountain-bike prices for North Shore trips.',
+          49.2658963,
+          -123.1030648
+        ),
+        (
+          E'Trail Bicycles',
+          E'Courtenay, BC',
+          E'michaelzick+trailbicyclescourtenay@gmail.com',
+          E'mountain-bikes',
+          E'https://www.trailbicycles.ca/articles/bike-rentals-pg191.htm',
+          E'250-334-2456',
+          E'1170 Cliffe Ave, Courtenay, BC V9N 2K1',
+          E'Courtenay bike shop with a public Comox Valley rental fleet. Trail Bicycles publishes current Norco, Trek, Mondraker, and Ibis mountain-bike models with full-day pricing.',
+          49.6877188,
+          -124.9938260
+        ),
+        (
+          E'Mont-Sainte-Anne Sports Alpins',
+          E'Beaupre, QC',
+          E'michaelzick+montsainteannesportsalpins@gmail.com',
+          E'mountain-bikes',
+          E'https://mont-sainte-anne.com/en/biking/rental/',
+          E'418-827-4561',
+          E'2000 Boulevard du Beau-Pre, Beaupre, QC G0A 1E0',
+          E'Mont-Sainte-Anne resort rental center with public downhill, cross-country, and electric mountain-bike rental pricing. Sports Alpins publishes Scott model families with full-day rental prices.',
+          47.0734625,
+          -70.9049340
+        ),
+        (
+          E'Vallee Bras-du-Nord Shannahan',
+          E'Saint-Raymond, QC',
+          E'michaelzick+valleebrasdunordshannahan@gmail.com',
+          E'mountain-bikes',
+          E'https://valleebrasdunord.com/en/pricing/bike-rentals/',
+          E'418-337-3635',
+          E'2180 Rang Saguenay, Saint-Raymond, QC G3L 3G3',
+          E'Vallee Bras-du-Nord Shannahan sector rental operation with public mountain-bike pricing. The official rental page publishes current Devinci model-level rentals with starting day prices.',
+          47.0748395,
+          -71.8903263
+        )
+    ) AS s(name, city, email, category, website, phone, address, about, lat, lng)
+  LOOP
+    IF v_display_role IN ('retail-store', 'builder') THEN
+      CASE shop.category
+        WHEN 'surfboards' THEN
+          v_avatar_url := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/73de4049-7ffd-45cd-868b-c2d0076107b3/profile-1752863282257.png';
+          v_hero_image_url := 'https://images.unsplash.com/photo-1502680390469-be75c86b636f?q=80&w=3540&auto=format&fit=crop&ixlib=rb-4.0.3';
+        WHEN 'snowboards' THEN
+          v_avatar_url := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/c5b450a8-7414-463b-b863-d78698fd0f95/profile-1752636842828.png';
+          v_hero_image_url := 'https://images.unsplash.com/photo-1590461283969-47fedf408cfd?q=80&w=2670&auto=format&fit=crop&ixlib=rb-4.1.0';
+        WHEN 'skis' THEN
+          v_avatar_url := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/7ef925ac-4b8f-496c-b4d9-10895164f03c/profile-1769637319540.png';
+          v_hero_image_url := 'https://images.unsplash.com/photo-1509791413599-93ba127a66b7?q=80&w=3540&auto=format&fit=crop&ixlib=rb-4.0.3';
+        WHEN 'mountain-bikes' THEN
+          v_avatar_url := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/ad2ad153-bb35-4e88-bfb0-d0d4f85ba62f/profile-1752637760487.png';
+          v_hero_image_url := 'https://images.unsplash.com/photo-1506316940527-4d1c138978a0?q=80&w=3512&auto=format&fit=crop&ixlib=rb-4.0.3';
+        ELSE
+          v_avatar_url := NULL;
+          v_hero_image_url := NULL;
+      END CASE;
+    ELSE
+      v_avatar_url := NULL;
+      v_hero_image_url := NULL;
+    END IF;
+
+    SELECT id INTO new_user_id FROM auth.users WHERE email = shop.email LIMIT 1;
+
+    IF new_user_id IS NULL THEN
+      new_user_id := gen_random_uuid();
+      INSERT INTO auth.users (id, instance_id, aud, role, email, encrypted_password, email_confirmed_at, raw_user_meta_data, raw_app_meta_data, created_at, updated_at, confirmation_token, recovery_token, email_change, email_change_token_current, email_change_token_new, email_change_confirm_status, phone_change, phone_change_token, reauthentication_token)
+      VALUES (new_user_id, '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', shop.email, crypt('$uO9RX^1P%bd#8crEAM!', gen_salt('bf')), now(), jsonb_build_object('name', shop.name), jsonb_build_object('provider', 'email', 'providers', ARRAY['email']), now(), now(), '', '', '', '', '', 0, '', '', '');
+      INSERT INTO auth.identities (id, user_id, identity_data, provider, provider_id, last_sign_in_at, created_at, updated_at)
+      VALUES (gen_random_uuid(), new_user_id, jsonb_build_object('sub', new_user_id::text, 'email', shop.email), 'email', new_user_id::text, now(), now(), now());
+    END IF;
+
+    UPDATE public.profiles SET name = shop.name, website = shop.website, phone = shop.phone, address = shop.address, about = shop.about, location_lat = shop.lat, location_lng = shop.lng, avatar_url = COALESCE(v_avatar_url, avatar_url), hero_image_url = COALESCE(v_hero_image_url, hero_image_url) WHERE id = new_user_id;
+    IF NOT FOUND THEN
+      INSERT INTO public.profiles (id, name, website, phone, address, about, location_lat, location_lng, avatar_url, hero_image_url)
+      VALUES (new_user_id, shop.name, shop.website, shop.phone, shop.address, shop.about, shop.lat, shop.lng, v_avatar_url, v_hero_image_url);
+    END IF;
+
+    UPDATE public.user_roles SET display_role = v_display_role WHERE user_id = new_user_id;
+    IF NOT FOUND THEN
+      INSERT INTO public.user_roles (user_id, display_role) VALUES (new_user_id, v_display_role);
+    END IF;
+
+    RAISE NOTICE 'User upserted successfully: id=%, email=%, role=%', new_user_id, shop.email, v_display_role;
+  END LOOP;
+END $$;

--- a/supabase/migrations/20260524000100_seed_canada_skis_gear.sql
+++ b/supabase/migrations/20260524000100_seed_canada_skis_gear.sql
@@ -1,0 +1,461 @@
+-- Seed migration: Canada skis gear
+-- Batch: canada_ski_snowboard_surf_mtb
+-- Created: 2026-05-24
+-- Depends on: 20260524000000_seed_canada_ski_snowboard_surf_mtb_shops.sql (apply shops first)
+-- Apply to remote (human approval required):
+--   supabase db query --linked -f "/Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260524000100_seed_canada_skis_gear.sql"
+-- Do NOT use supabase db push or supabase migration up.
+--
+-- Gear batches are category-homogeneous.
+-- Skis primary image:   https://images.pexels.com/photos/848699/pexels-photo-848699.jpeg
+-- Skis secondary image: https://images.pexels.com/photos/36084973/pexels-photo-36084973.jpeg
+
+-- =============================================
+-- EQUIPMENT: Canada accepted skis shops
+-- Price basis: official Canada rental pages retrieved 2026-05-24.
+-- Coordinates sourced from Nominatim street-level geocodes for each shop address.
+-- Wax Bench rows retarget existing profile 60877048-53da-4efb-842f-2d22e98caef0; no duplicate shop/user is created.
+-- =============================================
+DO $$
+DECLARE
+  missing_email text;
+  v_equipment_updated int := 0;
+  v_equipment_inserted int := 0;
+  v_primary_images_added int := 0;
+  v_secondary_images_added int := 0;
+BEGIN
+  SELECT seed_email INTO missing_email
+  FROM (
+    VALUES
+      (E'michaelzick+crosscountryconnectionwhistler@gmail.com'),
+      (E'michaelzick+thewaxbench@gmail.com')
+  ) AS planned(seed_email)
+  WHERE NOT EXISTS (SELECT 1 FROM auth.users au WHERE au.email = planned.seed_email)
+  LIMIT 1;
+
+  IF missing_email IS NOT NULL THEN
+    RAISE EXCEPTION 'User not found for email: %', missing_email;
+  END IF;
+
+  WITH seed_equipment (seed_email, name, category, description, price_per_day, price_per_hour, price_per_week, size, weight, material, suitable_skill_level, status, location_lat, location_lng, location_address, subcategory, damage_deposit, visible_on_map) AS (
+    VALUES
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Dynastar M-Cross',
+        E'skis',
+        E'The Dynastar M-Cross is a model-level ski rental listed by The Wax Bench for Revelstoke resort conditions. It gives visitors a source-backed option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'all-mountain', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Atomic Maverick 88 CTI',
+        E'skis',
+        E'The Atomic Maverick 88 CTI is a model-level ski rental listed by The Wax Bench for Revelstoke resort conditions. It gives visitors a source-backed option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'all-mountain', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Volkl Mantra 88',
+        E'skis',
+        E'The Volkl Mantra 88 is a model-level ski rental listed by The Wax Bench for Revelstoke resort conditions. It gives visitors a source-backed option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'all-mountain', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Head Kore 94 Ti',
+        E'skis',
+        E'The Head Kore 94 Ti is a model-level ski rental listed by The Wax Bench for Revelstoke resort conditions. It gives visitors a source-backed option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'all-mountain', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Nordica Enforcer 94',
+        E'skis',
+        E'The Nordica Enforcer 94 is a model-level ski rental listed by The Wax Bench for Revelstoke resort conditions. It gives visitors a source-backed option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'all-mountain', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Fischer Ranger 96',
+        E'skis',
+        E'The Fischer Ranger 96 is a model-level ski rental listed by The Wax Bench for Revelstoke resort conditions. It gives visitors a source-backed option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'all-mountain', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Atomic Bent Chetler 100',
+        E'skis',
+        E'The Atomic Bent Chetler 100 is a model-level ski rental listed by The Wax Bench for Revelstoke resort conditions. It gives visitors a source-backed option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'freeride', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Elan Playmaker 101',
+        E'skis',
+        E'The Elan Playmaker 101 is a model-level ski rental listed by The Wax Bench for Revelstoke resort conditions. It gives visitors a source-backed option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'freeride', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'K2 Reckoner 102',
+        E'skis',
+        E'The K2 Reckoner 102 is a model-level ski rental listed by The Wax Bench for Revelstoke resort conditions. It gives visitors a source-backed option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'freeride', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Nordica Enforcer 104',
+        E'skis',
+        E'The Nordica Enforcer 104 is a model-level ski rental listed by The Wax Bench for Revelstoke resort conditions. It gives visitors a source-backed option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'freeride', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Ferreol Pionnier 104',
+        E'skis',
+        E'The Ferreol Pionnier 104 is a model-level ski rental listed by The Wax Bench for Revelstoke resort conditions. It gives visitors a source-backed option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'freeride', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Fischer Ranger 108',
+        E'skis',
+        E'The Fischer Ranger 108 is a model-level ski rental listed by The Wax Bench for Revelstoke resort conditions. It gives visitors a source-backed option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'freeride', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Atomic Bent Chetler 110',
+        E'skis',
+        E'The Atomic Bent Chetler 110 is a model-level ski rental listed by The Wax Bench for Revelstoke resort conditions. It gives visitors a source-backed option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'powder', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'K2 Reckoner 110',
+        E'skis',
+        E'The K2 Reckoner 110 is a model-level ski rental listed by The Wax Bench for Revelstoke resort conditions. It gives visitors a source-backed option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'powder', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Head Kore 112 Ti',
+        E'skis',
+        E'The Head Kore 112 Ti is a model-level ski rental listed by The Wax Bench for Revelstoke resort conditions. It gives visitors a source-backed option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'powder', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Volkl Revolt 114',
+        E'skis',
+        E'The Volkl Revolt 114 is a model-level ski rental listed by The Wax Bench for Revelstoke resort conditions. It gives visitors a source-backed option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'powder', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Fischer Ranger 116',
+        E'skis',
+        E'The Fischer Ranger 116 is a model-level ski rental listed by The Wax Bench for Revelstoke resort conditions. It gives visitors a source-backed option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'powder', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Atomic Bent Chetler 120',
+        E'skis',
+        E'The Atomic Bent Chetler 120 is a model-level ski rental listed by The Wax Bench for Revelstoke resort conditions. It gives visitors a source-backed option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'powder', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Head Instinct 83',
+        E'skis',
+        E'The Head Instinct 83 is a model-level ski rental listed by The Wax Bench for Revelstoke resort conditions. It gives visitors a source-backed option with official day pricing tied to the shop rental program.',
+        42.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'frontside', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Head Kore 80',
+        E'skis',
+        E'The Head Kore 80 is a model-level ski rental listed by The Wax Bench for Revelstoke resort conditions. It gives visitors a source-backed option with official day pricing tied to the shop rental program.',
+        42.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'frontside', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+crosscountryconnectionwhistler@gmail.com',
+        E'Rossignol X5 Classic',
+        E'skis',
+        E'The Rossignol X5 Classic is a model-level Nordic ski rental listed by Cross Country Connection for Whistler Lost Lake terrain. It gives visitors a source-backed option with official full-day pricing tied to the rental program.',
+        35.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        50.1232691, -122.9506367,
+        E'Lost Lake PassivHaus, 7400 Fitzsimmons Rd S, Whistler, BC V8E 0E8',
+        E'cross-country', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+crosscountryconnectionwhistler@gmail.com',
+        E'Rossignol X8 Classic',
+        E'skis',
+        E'The Rossignol X8 Classic is a model-level Nordic ski rental listed by Cross Country Connection for Whistler Lost Lake terrain. It gives visitors a source-backed option with official full-day pricing tied to the rental program.',
+        35.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        50.1232691, -122.9506367,
+        E'Lost Lake PassivHaus, 7400 Fitzsimmons Rd S, Whistler, BC V8E 0E8',
+        E'cross-country', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+crosscountryconnectionwhistler@gmail.com',
+        E'Rossignol X10 Skate',
+        E'skis',
+        E'The Rossignol X10 Skate is a model-level Nordic ski rental listed by Cross Country Connection for Whistler Lost Lake terrain. It gives visitors a source-backed option with official full-day pricing tied to the rental program.',
+        35.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        50.1232691, -122.9506367,
+        E'Lost Lake PassivHaus, 7400 Fitzsimmons Rd S, Whistler, BC V8E 0E8',
+        E'cross-country', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+crosscountryconnectionwhistler@gmail.com',
+        E'Rossignol Xium Skate',
+        E'skis',
+        E'The Rossignol Xium Skate is a model-level Nordic ski rental listed by Cross Country Connection for Whistler Lost Lake terrain. It gives visitors a source-backed option with official full-day pricing tied to the rental program.',
+        35.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        50.1232691, -122.9506367,
+        E'Lost Lake PassivHaus, 7400 Fitzsimmons Rd S, Whistler, BC V8E 0E8',
+        E'cross-country', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+crosscountryconnectionwhistler@gmail.com',
+        E'Rossignol R-Skin Sport',
+        E'skis',
+        E'The Rossignol R-Skin Sport is a model-level Nordic ski rental listed by Cross Country Connection for Whistler Lost Lake terrain. It gives visitors a source-backed option with official full-day pricing tied to the rental program.',
+        35.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        50.1232691, -122.9506367,
+        E'Lost Lake PassivHaus, 7400 Fitzsimmons Rd S, Whistler, BC V8E 0E8',
+        E'cross-country', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+crosscountryconnectionwhistler@gmail.com',
+        E'Rossignol Evo Positrack',
+        E'skis',
+        E'The Rossignol Evo Positrack is a model-level Nordic ski rental listed by Cross Country Connection for Whistler Lost Lake terrain. It gives visitors a source-backed option with official full-day pricing tied to the rental program.',
+        35.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        50.1232691, -122.9506367,
+        E'Lost Lake PassivHaus, 7400 Fitzsimmons Rd S, Whistler, BC V8E 0E8',
+        E'cross-country', NULL::numeric, true
+      )
+  ),
+  resolved AS (
+    SELECT au.id AS user_id, s.* FROM seed_equipment s JOIN auth.users au ON au.email = s.seed_email
+  ),
+  wax_bench_matches (seed_name, existing_name, target_name) AS (
+    VALUES
+      (E'Dynastar M-Cross', E'Dynastar M-Cross', E'Dynastar M-Cross'),
+      (E'Atomic Maverick 88 CTI', E'Atomic Maverick 88 CTI', E'Atomic Maverick 88 CTI'),
+      (E'Volkl Mantra 88', E'Volkl Mantra 88', E'Volkl Mantra 88'),
+      (E'Head Kore 94 Ti', E'Head Kore 93/94ti', E'Head Kore 93/94ti'),
+      (E'Nordica Enforcer 94', E'Nordica Enforcer 94', E'Nordica Enforcer 94'),
+      (E'Fischer Ranger 96', E'Fischer Ranger 96', E'Fischer Ranger 96'),
+      (E'Atomic Bent Chetler 100', E'Atomic Bent 100', E'Atomic Bent Chetler 100'),
+      (E'Elan Playmaker 101', E'Elan Playmaker 101', E'Elan Playmaker 101'),
+      (E'K2 Reckoner 102', E'K2 Reckoner 102', E'K2 Reckoner 102'),
+      (E'Nordica Enforcer 104', E'Nordica Enforcer 104', E'Nordica Enforcer 104'),
+      (E'Ferreol Pionnier 104', E'Ferrol Pionnier 104', E'Ferreol Pionnier 104')
+  ),
+  matched_updates AS (
+    UPDATE public.equipment e
+      SET name = m.target_name,
+          price_per_day = r.price_per_day,
+          updated_at = now()
+    FROM resolved r
+    JOIN wax_bench_matches m ON m.seed_name = r.name
+    WHERE r.seed_email = E'michaelzick+thewaxbench@gmail.com'
+      AND e.user_id = r.user_id
+      AND e.category = r.category
+      AND e.name IN (m.existing_name, m.target_name)
+    RETURNING e.id
+  ),
+  inserted AS (
+    INSERT INTO public.equipment (id, user_id, name, category, description, price_per_day, price_per_hour, price_per_week, size, weight, material, suitable_skill_level, status, location_lat, location_lng, location_address, subcategory, damage_deposit, visible_on_map)
+    SELECT gen_random_uuid(), r.user_id, r.name, r.category, r.description, r.price_per_day, r.price_per_hour, r.price_per_week, r.size, r.weight, r.material, r.suitable_skill_level, r.status, r.location_lat, r.location_lng, r.location_address, r.subcategory, r.damage_deposit, r.visible_on_map
+    FROM resolved r
+    WHERE NOT EXISTS (SELECT 1 FROM public.equipment e WHERE e.user_id = r.user_id AND e.name = r.name)
+      AND NOT EXISTS (SELECT 1 FROM wax_bench_matches m WHERE r.seed_email = E'michaelzick+thewaxbench@gmail.com' AND m.seed_name = r.name)
+    RETURNING id
+  ),
+  ins1 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT i.id, 'https://images.pexels.com/photos/848699/pexels-photo-848699.jpeg', 0, true FROM inserted i
+    WHERE NOT EXISTS (SELECT 1 FROM public.equipment_images ei WHERE ei.equipment_id = i.id AND ei.display_order = 0)
+    RETURNING equipment_id
+  ),
+  ins2 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT i.id, 'https://images.pexels.com/photos/36084973/pexels-photo-36084973.jpeg', 1, false FROM inserted i
+    WHERE NOT EXISTS (SELECT 1 FROM public.equipment_images ei WHERE ei.equipment_id = i.id AND ei.display_order = 1)
+    RETURNING equipment_id
+  )
+  SELECT (SELECT count(*) FROM matched_updates), (SELECT count(*) FROM inserted), (SELECT count(*) FROM ins1), (SELECT count(*) FROM ins2)
+  INTO v_equipment_updated, v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+
+  RAISE NOTICE 'Canada skis updated=%, inserted=%, primary_images_added=%, secondary_images_added=%', v_equipment_updated, v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+END $$;

--- a/supabase/migrations/20260524000200_seed_canada_snowboards_gear.sql
+++ b/supabase/migrations/20260524000200_seed_canada_snowboards_gear.sql
@@ -1,0 +1,194 @@
+-- Seed migration: Canada snowboards gear
+-- Batch: canada_ski_snowboard_surf_mtb
+-- Created: 2026-05-24
+-- Depends on: 20260524000000_seed_canada_ski_snowboard_surf_mtb_shops.sql (apply shops first)
+-- Apply to remote (human approval required):
+--   supabase db query --linked -f "/Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260524000200_seed_canada_snowboards_gear.sql"
+-- Do NOT use supabase db push or supabase migration up.
+--
+-- Gear batches are category-homogeneous.
+-- Snowboards primary image:   https://images.pexels.com/photos/7406683/pexels-photo-7406683.jpeg
+-- Snowboards secondary image: https://images.pexels.com/photos/7166118/pexels-photo-7166118.jpeg
+
+-- =============================================
+-- EQUIPMENT: Canada accepted snowboards shops
+-- Price basis: official Canada rental pages retrieved 2026-05-24.
+-- Coordinates sourced from Nominatim street-level geocodes for each shop address.
+-- Wax Bench rows retarget existing profile 60877048-53da-4efb-842f-2d22e98caef0; no duplicate shop/user is created.
+-- =============================================
+DO $$
+DECLARE
+  missing_email text;
+  v_equipment_inserted int := 0;
+  v_primary_images_added int := 0;
+  v_secondary_images_added int := 0;
+BEGIN
+  SELECT seed_email INTO missing_email
+  FROM (
+    VALUES
+      (E'michaelzick+gearhubsportsfernie@gmail.com'),
+      (E'michaelzick+thewaxbench@gmail.com')
+  ) AS planned(seed_email)
+  WHERE NOT EXISTS (SELECT 1 FROM auth.users au WHERE au.email = planned.seed_email)
+  LIMIT 1;
+
+  IF missing_email IS NOT NULL THEN
+    RAISE EXCEPTION 'User not found for email: %', missing_email;
+  END IF;
+
+  WITH seed_equipment (seed_email, name, category, description, price_per_day, price_per_hour, price_per_week, size, weight, material, suitable_skill_level, status, location_lat, location_lng, location_address, subcategory, damage_deposit, visible_on_map) AS (
+    VALUES
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Jones Frontier',
+        E'snowboards',
+        E'The Jones Frontier is a model-level snowboard rental listed by The Wax Bench. It gives riders a source-backed board option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'all-mountain', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Burton Deep Thinker',
+        E'snowboards',
+        E'The Burton Deep Thinker is a model-level snowboard rental listed by The Wax Bench. It gives riders a source-backed board option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'freeride', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Jones Flagship',
+        E'snowboards',
+        E'The Jones Flagship is a model-level snowboard rental listed by The Wax Bench. It gives riders a source-backed board option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'freeride', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Jones Dream Weaver',
+        E'snowboards',
+        E'The Jones Dream Weaver is a model-level snowboard rental listed by The Wax Bench. It gives riders a source-backed board option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'all-mountain', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Lib Tech Orca',
+        E'snowboards',
+        E'The Lib Tech Orca is a model-level snowboard rental listed by The Wax Bench. It gives riders a source-backed board option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'freeride', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Jones Stratos',
+        E'snowboards',
+        E'The Jones Stratos is a model-level snowboard rental listed by The Wax Bench. It gives riders a source-backed board option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'freeride', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Burton Custom Camber',
+        E'snowboards',
+        E'The Burton Custom Camber is a model-level snowboard rental listed by The Wax Bench. It gives riders a source-backed board option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'all-mountain', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thewaxbench@gmail.com',
+        E'Burton Custom Flying V',
+        E'snowboards',
+        E'The Burton Custom Flying V is a model-level snowboard rental listed by The Wax Bench. It gives riders a source-backed board option with official day pricing tied to the shop rental program.',
+        58.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        50.9982632, -118.1934102,
+        E'106 Orton Avenue, Revelstoke, BC V0E 2S0, Canada',
+        E'all-mountain', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+gearhubsportsfernie@gmail.com',
+        E'K2 Raygun',
+        E'snowboards',
+        E'The K2 Raygun is a model-level snowboard rental listed by GearHub Sports. It gives riders a source-backed board option with official day pricing tied to the shop rental program.',
+        49.99::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        49.5020785, -115.0616403,
+        E'401 1st Ave, Fernie, BC V0B 1M0',
+        E'all-mountain', NULL::numeric, true
+      )
+  ),
+  resolved AS (
+    SELECT au.id AS user_id, s.* FROM seed_equipment s JOIN auth.users au ON au.email = s.seed_email
+  ),
+  inserted AS (
+    INSERT INTO public.equipment (id, user_id, name, category, description, price_per_day, price_per_hour, price_per_week, size, weight, material, suitable_skill_level, status, location_lat, location_lng, location_address, subcategory, damage_deposit, visible_on_map)
+    SELECT gen_random_uuid(), r.user_id, r.name, r.category, r.description, r.price_per_day, r.price_per_hour, r.price_per_week, r.size, r.weight, r.material, r.suitable_skill_level, r.status, r.location_lat, r.location_lng, r.location_address, r.subcategory, r.damage_deposit, r.visible_on_map
+    FROM resolved r
+    WHERE NOT EXISTS (SELECT 1 FROM public.equipment e WHERE e.user_id = r.user_id AND e.name = r.name)
+    RETURNING id
+  ),
+  ins1 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT i.id, 'https://images.pexels.com/photos/7406683/pexels-photo-7406683.jpeg', 0, true FROM inserted i
+    WHERE NOT EXISTS (SELECT 1 FROM public.equipment_images ei WHERE ei.equipment_id = i.id AND ei.display_order = 0)
+    RETURNING equipment_id
+  ),
+  ins2 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT i.id, 'https://images.pexels.com/photos/7166118/pexels-photo-7166118.jpeg', 1, false FROM inserted i
+    WHERE NOT EXISTS (SELECT 1 FROM public.equipment_images ei WHERE ei.equipment_id = i.id AND ei.display_order = 1)
+    RETURNING equipment_id
+  )
+  SELECT (SELECT count(*) FROM inserted), (SELECT count(*) FROM ins1), (SELECT count(*) FROM ins2)
+  INTO v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+
+  RAISE NOTICE 'Canada snowboards inserted=%, primary_images_added=%, secondary_images_added=%', v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+END $$;

--- a/supabase/migrations/20260524000300_seed_canada_mountain_bikes_gear.sql
+++ b/supabase/migrations/20260524000300_seed_canada_mountain_bikes_gear.sql
@@ -1,0 +1,749 @@
+-- Seed migration: Canada mountain-bike gear
+-- Batch: canada_ski_snowboard_surf_mtb
+-- Created: 2026-05-24
+-- Depends on: 20260524000000_seed_canada_ski_snowboard_surf_mtb_shops.sql (apply shops first)
+-- Apply to remote (human approval required):
+--   supabase db query --linked -f "/Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260524000300_seed_canada_mountain_bikes_gear.sql"
+-- Do NOT use supabase db push or supabase migration up.
+--
+-- Gear batches are category-homogeneous.
+-- Mountain-bike primary image:   https://images.pexels.com/photos/30447388/pexels-photo-30447388.jpeg
+-- Mountain-bike secondary image: https://images.pexels.com/photos/25753440/pexels-photo-25753440.jpeg
+
+-- =============================================
+-- EQUIPMENT: Canada accepted mountain-bike shops
+-- Price basis: official Canada rental pages retrieved 2026-05-24.
+-- Coordinates sourced from Nominatim street-level geocodes for each shop address.
+-- =============================================
+DO $$
+DECLARE
+  missing_email text;
+  v_equipment_inserted int := 0;
+  v_primary_images_added int := 0;
+  v_secondary_images_added int := 0;
+BEGIN
+  SELECT seed_email INTO missing_email
+  FROM (
+    VALUES
+      (E'michaelzick+bigwhitebikepark@gmail.com'),
+      (E'michaelzick+coastalculturesportswhistler@gmail.com'),
+      (E'michaelzick+crosscountryconnectionwhistler@gmail.com'),
+      (E'michaelzick+cyclebcvancouver@gmail.com'),
+      (E'michaelzick+dialedincyclingsquamish@gmail.com'),
+      (E'michaelzick+essentialcyclesnorthvancouver@gmail.com'),
+      (E'michaelzick+gearhubsportsfernie@gmail.com'),
+      (E'michaelzick+lynnvalleybikesnorthvancouver@gmail.com'),
+      (E'michaelzick+montsainteannesportsalpins@gmail.com'),
+      (E'michaelzick+trailbicyclescourtenay@gmail.com'),
+      (E'michaelzick+valleebrasdunordshannahan@gmail.com'),
+      (E'michaelzick+whistlersportsrentals@gmail.com')
+  ) AS planned(seed_email)
+  WHERE NOT EXISTS (SELECT 1 FROM auth.users au WHERE au.email = planned.seed_email)
+  LIMIT 1;
+
+  IF missing_email IS NOT NULL THEN
+    RAISE EXCEPTION 'User not found for email: %', missing_email;
+  END IF;
+
+  WITH seed_equipment (seed_email, name, category, description, price_per_day, price_per_hour, price_per_week, size, weight, material, suitable_skill_level, status, location_lat, location_lng, location_address, subcategory, damage_deposit, visible_on_map) AS (
+    VALUES
+      (
+        E'michaelzick+gearhubsportsfernie@gmail.com',
+        E'Rocky Mountain Altitude',
+        E'mountain-bikes',
+        E'The Rocky Mountain Altitude is a model-level enduro rental listed by GearHub Sports. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        89.99::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        49.5020785, -115.0616403,
+        E'401 1st Ave, Fernie, BC V0B 1M0',
+        E'enduro', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+gearhubsportsfernie@gmail.com',
+        E'Rocky Mountain Element',
+        E'mountain-bikes',
+        E'The Rocky Mountain Element is a model-level trail rental listed by GearHub Sports. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        89.99::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        49.5020785, -115.0616403,
+        E'401 1st Ave, Fernie, BC V0B 1M0',
+        E'trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+gearhubsportsfernie@gmail.com',
+        E'Rocky Mountain Instinct',
+        E'mountain-bikes',
+        E'The Rocky Mountain Instinct is a model-level trail rental listed by GearHub Sports. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        89.99::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        49.5020785, -115.0616403,
+        E'401 1st Ave, Fernie, BC V0B 1M0',
+        E'trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+gearhubsportsfernie@gmail.com',
+        E'Rocky Mountain Slayer',
+        E'mountain-bikes',
+        E'The Rocky Mountain Slayer is a model-level downhill rental listed by GearHub Sports. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        89.99::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        49.5020785, -115.0616403,
+        E'401 1st Ave, Fernie, BC V0B 1M0',
+        E'downhill', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+gearhubsportsfernie@gmail.com',
+        E'Devinci Chainsaw',
+        E'mountain-bikes',
+        E'The Devinci Chainsaw is a model-level downhill rental listed by GearHub Sports. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        89.99::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        49.5020785, -115.0616403,
+        E'401 1st Ave, Fernie, BC V0B 1M0',
+        E'downhill', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+gearhubsportsfernie@gmail.com',
+        E'Rocky Mountain Instinct Powerplay',
+        E'mountain-bikes',
+        E'The Rocky Mountain Instinct Powerplay is a model-level e-mountain-bike rental listed by GearHub Sports. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        129.99::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        49.5020785, -115.0616403,
+        E'401 1st Ave, Fernie, BC V0B 1M0',
+        E'e-mountain-bike', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+gearhubsportsfernie@gmail.com',
+        E'Rocky Mountain Fusion Powerplay',
+        E'mountain-bikes',
+        E'The Rocky Mountain Fusion Powerplay is a model-level e-mountain-bike rental listed by GearHub Sports. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        99.99::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        49.5020785, -115.0616403,
+        E'401 1st Ave, Fernie, BC V0B 1M0',
+        E'e-mountain-bike', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+coastalculturesportswhistler@gmail.com',
+        E'Santa Cruz Nomad',
+        E'mountain-bikes',
+        E'The Santa Cruz Nomad is a model-level enduro rental listed by Coastal Culture Sports. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        107.10::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        50.0951007, -122.9894654,
+        E'2010 London Lane, Whistler, BC V8E 0A6',
+        E'enduro', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+coastalculturesportswhistler@gmail.com',
+        E'Santa Cruz V10',
+        E'mountain-bikes',
+        E'The Santa Cruz V10 is a model-level downhill rental listed by Coastal Culture Sports. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        190.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        50.0951007, -122.9894654,
+        E'2010 London Lane, Whistler, BC V8E 0A6',
+        E'downhill', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+coastalculturesportswhistler@gmail.com',
+        E'Rocky Mountain Instinct BC Alloy',
+        E'mountain-bikes',
+        E'The Rocky Mountain Instinct BC Alloy is a model-level all-mountain rental listed by Coastal Culture Sports. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        71.10::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        50.0951007, -122.9894654,
+        E'2010 London Lane, Whistler, BC V8E 0A6',
+        E'all-mountain', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+whistlersportsrentals@gmail.com',
+        E'Norco Sight Gen 5',
+        E'mountain-bikes',
+        E'The Norco Sight Gen 5 is a model-level enduro rental listed by Whistler Sports Rentals. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        111.60::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        50.1151411, -122.9567290,
+        E'4205 Village Square, Whistler, BC V8E 1H4',
+        E'enduro', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+whistlersportsrentals@gmail.com',
+        E'Giant Reign SE Custom',
+        E'mountain-bikes',
+        E'The Giant Reign SE Custom is a model-level enduro rental listed by Whistler Sports Rentals. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        111.60::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        50.1151411, -122.9567290,
+        E'4205 Village Square, Whistler, BC V8E 1H4',
+        E'enduro', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+whistlersportsrentals@gmail.com',
+        E'Norco Shore Standard Downhill',
+        E'mountain-bikes',
+        E'The Norco Shore Standard Downhill is a model-level downhill rental listed by Whistler Sports Rentals. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        129.60::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        50.1151411, -122.9567290,
+        E'4205 Village Square, Whistler, BC V8E 1H4',
+        E'downhill', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+whistlersportsrentals@gmail.com',
+        E'Norco Shore Performance Downhill',
+        E'mountain-bikes',
+        E'The Norco Shore Performance Downhill is a model-level downhill rental listed by Whistler Sports Rentals. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        158.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        50.1151411, -122.9567290,
+        E'4205 Village Square, Whistler, BC V8E 1H4',
+        E'downhill', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+whistlersportsrentals@gmail.com',
+        E'Giant Glory Advanced Custom',
+        E'mountain-bikes',
+        E'The Giant Glory Advanced Custom is a model-level downhill rental listed by Whistler Sports Rentals. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        177.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        50.1151411, -122.9567290,
+        E'4205 Village Square, Whistler, BC V8E 1H4',
+        E'downhill', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+crosscountryconnectionwhistler@gmail.com',
+        E'Norco Sight C',
+        E'mountain-bikes',
+        E'The Norco Sight C is a model-level trail rental listed by Cross Country Connection. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        129.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        50.1232691, -122.9506367,
+        E'Lost Lake PassivHaus, 7400 Fitzsimmons Rd S, Whistler, BC V8E 0E8',
+        E'trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+crosscountryconnectionwhistler@gmail.com',
+        E'Norco Sight C VLT',
+        E'mountain-bikes',
+        E'The Norco Sight C VLT is a model-level e-mountain-bike rental listed by Cross Country Connection. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        159.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        50.1232691, -122.9506367,
+        E'Lost Lake PassivHaus, 7400 Fitzsimmons Rd S, Whistler, BC V8E 0E8',
+        E'e-mountain-bike', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+crosscountryconnectionwhistler@gmail.com',
+        E'Norco Aurum A7.1',
+        E'mountain-bikes',
+        E'The Norco Aurum A7.1 is a model-level downhill rental listed by Cross Country Connection. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        159.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        50.1232691, -122.9506367,
+        E'Lost Lake PassivHaus, 7400 Fitzsimmons Rd S, Whistler, BC V8E 0E8',
+        E'downhill', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+bigwhitebikepark@gmail.com',
+        E'Trek Session 8',
+        E'mountain-bikes',
+        E'The Trek Session 8 is a model-level downhill rental listed by Big White Bike Park. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        160.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        49.7379086, -118.9459084,
+        E'5315 Big White Road, Big White Mountain, BC V1P 1P3',
+        E'downhill', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+bigwhitebikepark@gmail.com',
+        E'Trek Remedy 8',
+        E'mountain-bikes',
+        E'The Trek Remedy 8 is a model-level enduro rental listed by Big White Bike Park. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        140.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        49.7379086, -118.9459084,
+        E'5315 Big White Road, Big White Mountain, BC V1P 1P3',
+        E'enduro', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+dialedincyclingsquamish@gmail.com',
+        E'Marin Alpine Trail E1 Bosch',
+        E'mountain-bikes',
+        E'The Marin Alpine Trail E1 Bosch is a model-level e-mountain-bike rental listed by Dialed In Cycling. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        140.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        49.7680282, -123.1363713,
+        E'1796 Depot Rd, Squamish, BC V8B 0P6',
+        E'e-mountain-bike', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+dialedincyclingsquamish@gmail.com',
+        E'Marin Rift Zone EL1',
+        E'mountain-bikes',
+        E'The Marin Rift Zone EL1 is a model-level e-mountain-bike rental listed by Dialed In Cycling. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        140.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        49.7680282, -123.1363713,
+        E'1796 Depot Rd, Squamish, BC V8B 0P6',
+        E'e-mountain-bike', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+dialedincyclingsquamish@gmail.com',
+        E'Marin Alpine Trail XR',
+        E'mountain-bikes',
+        E'The Marin Alpine Trail XR is a model-level enduro rental listed by Dialed In Cycling. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        130.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        49.7680282, -123.1363713,
+        E'1796 Depot Rd, Squamish, BC V8B 0P6',
+        E'enduro', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+dialedincyclingsquamish@gmail.com',
+        E'Marin Rift Zone',
+        E'mountain-bikes',
+        E'The Marin Rift Zone is a model-level trail rental listed by Dialed In Cycling. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        110.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        49.7680282, -123.1363713,
+        E'1796 Depot Rd, Squamish, BC V8B 0P6',
+        E'trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+dialedincyclingsquamish@gmail.com',
+        E'Cube Stereo 177 Bosch',
+        E'mountain-bikes',
+        E'The Cube Stereo 177 Bosch is a model-level e-mountain-bike rental listed by Dialed In Cycling. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        199.00::numeric, NULL::numeric, NULL::numeric,
+        E'Medium, Large',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        49.7680282, -123.1363713,
+        E'1796 Depot Rd, Squamish, BC V8B 0P6',
+        E'e-mountain-bike', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+dialedincyclingsquamish@gmail.com',
+        E'Kona Mahuna',
+        E'mountain-bikes',
+        E'The Kona Mahuna is a model-level hardtail rental listed by Dialed In Cycling. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        75.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        49.7680282, -123.1363713,
+        E'1796 Depot Rd, Squamish, BC V8B 0P6',
+        E'hardtail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+essentialcyclesnorthvancouver@gmail.com',
+        E'Ibis Ripmo V3',
+        E'mountain-bikes',
+        E'The Ibis Ripmo V3 is a model-level enduro rental listed by Essential Cycles. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        115.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        49.3072818, -123.0373803,
+        E'305 Mansfield Place, North Vancouver, BC V7J 1E4',
+        E'enduro', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+essentialcyclesnorthvancouver@gmail.com',
+        E'Marin Alpine Trail',
+        E'mountain-bikes',
+        E'The Marin Alpine Trail is a model-level enduro rental listed by Essential Cycles. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        95.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        49.3072818, -123.0373803,
+        E'305 Mansfield Place, North Vancouver, BC V7J 1E4',
+        E'enduro', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+essentialcyclesnorthvancouver@gmail.com',
+        E'Ibis Ripmo AF',
+        E'mountain-bikes',
+        E'The Ibis Ripmo AF is a model-level enduro rental listed by Essential Cycles. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        95.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        49.3072818, -123.0373803,
+        E'305 Mansfield Place, North Vancouver, BC V7J 1E4',
+        E'enduro', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+essentialcyclesnorthvancouver@gmail.com',
+        E'Marin Rift Zone EL1',
+        E'mountain-bikes',
+        E'The Marin Rift Zone EL1 is a model-level e-mountain-bike rental listed by Essential Cycles. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        165.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        49.3072818, -123.0373803,
+        E'305 Mansfield Place, North Vancouver, BC V7J 1E4',
+        E'e-mountain-bike', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+lynnvalleybikesnorthvancouver@gmail.com',
+        E'Rocky Mountain Altitude',
+        E'mountain-bikes',
+        E'The Rocky Mountain Altitude is a model-level enduro rental listed by Lynn Valley Bikes. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        125.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        49.3366003, -123.0377266,
+        E'3028 Mountain Hwy, North Vancouver, BC V7J 2P1',
+        E'enduro', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+lynnvalleybikesnorthvancouver@gmail.com',
+        E'Marin Bobcat Trail',
+        E'mountain-bikes',
+        E'The Marin Bobcat Trail is a model-level hardtail rental listed by Lynn Valley Bikes. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        75.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        49.3366003, -123.0377266,
+        E'3028 Mountain Hwy, North Vancouver, BC V7J 2P1',
+        E'hardtail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+cyclebcvancouver@gmail.com',
+        E'Norco Sight',
+        E'mountain-bikes',
+        E'The Norco Sight is a model-level trail rental listed by Cycle BC Vancouver. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        90.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        49.2658963, -123.1030648,
+        E'73 East 6th Avenue, Vancouver, BC V5T 1J3',
+        E'trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+cyclebcvancouver@gmail.com',
+        E'Norco Sight VLT',
+        E'mountain-bikes',
+        E'The Norco Sight VLT is a model-level e-mountain-bike rental listed by Cycle BC Vancouver. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        125.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        49.2658963, -123.1030648,
+        E'73 East 6th Avenue, Vancouver, BC V5T 1J3',
+        E'e-mountain-bike', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+trailbicyclescourtenay@gmail.com',
+        E'Norco Sight VLT TQ C2',
+        E'mountain-bikes',
+        E'The Norco Sight VLT TQ C2 is a model-level e-mountain-bike rental listed by Trail Bicycles. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        125.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        49.6877188, -124.9938260,
+        E'1170 Cliffe Ave, Courtenay, BC V9N 2K1',
+        E'e-mountain-bike', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+trailbicyclescourtenay@gmail.com',
+        E'Trek Fuel+ EX 9.8 XT',
+        E'mountain-bikes',
+        E'The Trek Fuel+ EX 9.8 XT is a model-level e-mountain-bike rental listed by Trail Bicycles. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        125.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        49.6877188, -124.9938260,
+        E'1170 Cliffe Ave, Courtenay, BC V9N 2K1',
+        E'e-mountain-bike', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+trailbicyclescourtenay@gmail.com',
+        E'Mondraker Dune RR',
+        E'mountain-bikes',
+        E'The Mondraker Dune RR is a model-level e-mountain-bike rental listed by Trail Bicycles. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        125.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        49.6877188, -124.9938260,
+        E'1170 Cliffe Ave, Courtenay, BC V9N 2K1',
+        E'e-mountain-bike', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+trailbicyclescourtenay@gmail.com',
+        E'Trek Fuel EX 9.8 XT',
+        E'mountain-bikes',
+        E'The Trek Fuel EX 9.8 XT is a model-level trail rental listed by Trail Bicycles. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        100.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        49.6877188, -124.9938260,
+        E'1170 Cliffe Ave, Courtenay, BC V9N 2K1',
+        E'trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+trailbicyclescourtenay@gmail.com',
+        E'Ibis Ripmo V3',
+        E'mountain-bikes',
+        E'The Ibis Ripmo V3 is a model-level enduro rental listed by Trail Bicycles. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        100.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        49.6877188, -124.9938260,
+        E'1170 Cliffe Ave, Courtenay, BC V9N 2K1',
+        E'enduro', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+montsainteannesportsalpins@gmail.com',
+        E'Scott Genius E-Ride',
+        E'mountain-bikes',
+        E'The Scott Genius E-Ride is a model-level e-mountain-bike rental listed by Mont-Sainte-Anne Sports Alpins. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        190.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        47.0734625, -70.9049340,
+        E'2000 Boulevard du Beau-Pre, Beaupre, QC G0A 1E0',
+        E'e-mountain-bike', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+montsainteannesportsalpins@gmail.com',
+        E'Scott Strike E-Ride',
+        E'mountain-bikes',
+        E'The Scott Strike E-Ride is a model-level e-mountain-bike rental listed by Mont-Sainte-Anne Sports Alpins. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        190.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        47.0734625, -70.9049340,
+        E'2000 Boulevard du Beau-Pre, Beaupre, QC G0A 1E0',
+        E'e-mountain-bike', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+montsainteannesportsalpins@gmail.com',
+        E'Scott Gambler',
+        E'mountain-bikes',
+        E'The Scott Gambler is a model-level downhill rental listed by Mont-Sainte-Anne Sports Alpins. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        265.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        47.0734625, -70.9049340,
+        E'2000 Boulevard du Beau-Pre, Beaupre, QC G0A 1E0',
+        E'downhill', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+montsainteannesportsalpins@gmail.com',
+        E'Scott Ransom',
+        E'mountain-bikes',
+        E'The Scott Ransom is a model-level downhill rental listed by Mont-Sainte-Anne Sports Alpins. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        265.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        47.0734625, -70.9049340,
+        E'2000 Boulevard du Beau-Pre, Beaupre, QC G0A 1E0',
+        E'downhill', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+montsainteannesportsalpins@gmail.com',
+        E'Scott Genius',
+        E'mountain-bikes',
+        E'The Scott Genius is a model-level trail rental listed by Mont-Sainte-Anne Sports Alpins. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        150.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        47.0734625, -70.9049340,
+        E'2000 Boulevard du Beau-Pre, Beaupre, QC G0A 1E0',
+        E'trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+montsainteannesportsalpins@gmail.com',
+        E'Scott Scale',
+        E'mountain-bikes',
+        E'The Scott Scale is a model-level hardtail rental listed by Mont-Sainte-Anne Sports Alpins. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        120.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        47.0734625, -70.9049340,
+        E'2000 Boulevard du Beau-Pre, Beaupre, QC G0A 1E0',
+        E'hardtail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+valleebrasdunordshannahan@gmail.com',
+        E'Devinci E-Troy',
+        E'mountain-bikes',
+        E'The Devinci E-Troy is a model-level e-mountain-bike rental listed by Vallee Bras-du-Nord Shannahan. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        135.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        47.0748395, -71.8903263,
+        E'2180 Rang Saguenay, Saint-Raymond, QC G3L 3G3',
+        E'e-mountain-bike', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+valleebrasdunordshannahan@gmail.com',
+        E'Devinci E-Troy Lite',
+        E'mountain-bikes',
+        E'The Devinci E-Troy Lite is a model-level e-mountain-bike rental listed by Vallee Bras-du-Nord Shannahan. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        135.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        47.0748395, -71.8903263,
+        E'2180 Rang Saguenay, Saint-Raymond, QC G3L 3G3',
+        E'e-mountain-bike', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+valleebrasdunordshannahan@gmail.com',
+        E'Devinci Troy',
+        E'mountain-bikes',
+        E'The Devinci Troy is a model-level trail rental listed by Vallee Bras-du-Nord Shannahan. It is a source-backed mountain-bike option with official day pricing for Canadian trail, bike-park, or guided rental use.',
+        75.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        47.0748395, -71.8903263,
+        E'2180 Rang Saguenay, Saint-Raymond, QC G3L 3G3',
+        E'trail', NULL::numeric, true
+      )
+  ),
+  resolved AS (
+    SELECT au.id AS user_id, s.* FROM seed_equipment s JOIN auth.users au ON au.email = s.seed_email
+  ),
+  inserted AS (
+    INSERT INTO public.equipment (id, user_id, name, category, description, price_per_day, price_per_hour, price_per_week, size, weight, material, suitable_skill_level, status, location_lat, location_lng, location_address, subcategory, damage_deposit, visible_on_map)
+    SELECT gen_random_uuid(), r.user_id, r.name, r.category, r.description, r.price_per_day, r.price_per_hour, r.price_per_week, r.size, r.weight, r.material, r.suitable_skill_level, r.status, r.location_lat, r.location_lng, r.location_address, r.subcategory, r.damage_deposit, r.visible_on_map
+    FROM resolved r
+    WHERE NOT EXISTS (SELECT 1 FROM public.equipment e WHERE e.user_id = r.user_id AND e.name = r.name)
+    RETURNING id
+  ),
+  ins1 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT i.id, 'https://images.pexels.com/photos/30447388/pexels-photo-30447388.jpeg', 0, true FROM inserted i
+    WHERE NOT EXISTS (SELECT 1 FROM public.equipment_images ei WHERE ei.equipment_id = i.id AND ei.display_order = 0)
+    RETURNING equipment_id
+  ),
+  ins2 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT i.id, 'https://images.pexels.com/photos/25753440/pexels-photo-25753440.jpeg', 1, false FROM inserted i
+    WHERE NOT EXISTS (SELECT 1 FROM public.equipment_images ei WHERE ei.equipment_id = i.id AND ei.display_order = 1)
+    RETURNING equipment_id
+  )
+  SELECT (SELECT count(*) FROM inserted), (SELECT count(*) FROM ins1), (SELECT count(*) FROM ins2)
+  INTO v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+
+  RAISE NOTICE 'Canada mountain-bike inserted=%, primary_images_added=%, secondary_images_added=%', v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+END $$;


### PR DESCRIPTION
## Summary

Seeds the Canada ski/snowboard/MTB rental batch into DemoStoke with four Supabase data migrations and updates the repo seed registry. The migrations have already been applied to linked Supabase project `qtlhqsqanbxgfbcjigrl` after rollback-first validation and migration-history repair.

- **12 new Canada shop profiles**: GearHub Sports, Coastal Culture Sports, Whistler Sports Rentals, Cross Country Connection, Big White Bike Park, Dialed In Cycling, Essential Cycles, Lynn Valley Bikes, Cycle BC Vancouver, Trail Bicycles, Mont-Sainte-Anne Sports Alpins, Vallee Bras-du-Nord Shannahan.
- **72 new gear inserts** across skis, snowboards, and mountain-bikes, using the canonical category placeholder images for `equipment_images`.
- **Wax Bench retargeting** keeps the existing live profile (`michaelzick+thewaxbench@gmail.com`, `/user-profile/the-wax-bench`) as canonical, updates 11 matched gear rows, and inserts 17 genuinely missing rows without creating a duplicate shop/auth user.
- **No surfboard rows were added** because reviewed Canada surf candidates did not expose official brand-plus-model-plus-price evidence.
- **Remote migration history was repaired** so the four Canada migration versions are marked applied and local/remote history is aligned.

## Changes

- `AGENTS.md` — updates the current seeded-shop registry summary with the applied Canada shops and the existing/retargeted Wax Bench profile.
- `20260524000000_seed_canada_ski_snowboard_surf_mtb_shops.sql` — seeds the 12 new Canada shop/auth/profile rows and deliberately excludes Wax Bench as a new user.
- `20260524000100_seed_canada_skis_gear.sql` — adds Canada ski gear rows, retargets Wax Bench ski changes to the existing profile, updates source-backed prices, and normalizes only the approved Wax Bench names.
- `20260524000200_seed_canada_snowboards_gear.sql` — adds Canada snowboard gear rows and inserts the missing Wax Bench snowboard rows against the existing profile.
- `20260524000300_seed_canada_mountain_bikes_gear.sql` — adds Canada mountain-bike gear rows for the 12 new shop profiles.

## Test plan

- [x] Static forbidden-token scan on all Canada migration files: no `DELETE FROM`, `TRUNCATE`, `DROP`, `ALTER TABLE`, `ON CONFLICT`, or `specs` hits.
- [x] `git diff --check`.
- [x] `supabase db push --linked --dry-run` listed exactly the four Canada migrations.
- [x] Linked rollback transaction dry run ran the exact four migration files with `BEGIN`, bounded timeouts, advisory lock, and `ROLLBACK`.
- [x] Pre-apply linked validation: 12 planned shops, 72 planned gear inserts, Wax Bench profile found, 11 matched Wax Bench update rows, 17 missing Wax Bench insert rows.
- [x] Post-apply linked validation: 12 existing seed users, 72 existing matching gear rows, 0 insert rows without seed users, 11 matched Wax Bench update rows.
- [x] Spot-checked Wax Bench rows: `Atomic Bent Chetler 100`, `Ferreol Pionnier 104`, and `Head Kore 93/94ti` all at `$58/day`.
- [x] Post-apply idempotency rollback rerun returned user/equipment/image deltas of `0`.
- [x] `supabase migration list --linked` confirmed `20260524000000`, `20260524000100`, `20260524000200`, and `20260524000300` aligned as applied.
