### PR TITLE
Fix blog draft autosave loop

### DIFF
--- a/src/__tests__/useAutoSave.test.tsx
+++ b/src/__tests__/useAutoSave.test.tsx
@@ -1,0 +1,113 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoSave } from "@/hooks/useAutoSave";
+
+interface DraftPayload {
+  title: string;
+  content?: string;
+  tags?: string[];
+}
+
+async function advanceTimers(ms: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+describe("useAutoSave", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("does not save just because the save callback identity changes", async () => {
+    const save = vi.fn(async (_data: DraftPayload) => undefined);
+
+    const { rerender } = renderHook(
+      ({ data, enabled }: { data: DraftPayload; enabled: boolean }) =>
+        useAutoSave<DraftPayload>({
+          data,
+          delay: 100,
+          enabled,
+          onSave: async (payload) => {
+            await save(payload);
+          },
+        }),
+      { initialProps: { data: { title: "Loaded draft" }, enabled: true } }
+    );
+
+    rerender({ data: { title: "Loaded draft" }, enabled: true });
+    await advanceTimers(500);
+
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("saves once after debounced content changes and does not loop after save state updates", async () => {
+    const save = vi.fn(async (_data: DraftPayload) => undefined);
+
+    const { rerender } = renderHook(
+      ({ data, enabled }: { data: DraftPayload; enabled: boolean }) =>
+        useAutoSave<DraftPayload>({
+          data,
+          delay: 100,
+          enabled,
+          onSave: async (payload) => {
+            await save(payload);
+          },
+        }),
+      { initialProps: { data: { title: "" }, enabled: true } }
+    );
+
+    rerender({ data: { title: "First draft" }, enabled: true });
+    await advanceTimers(99);
+    expect(save).not.toHaveBeenCalled();
+
+    await advanceTimers(1);
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenLastCalledWith({ title: "First draft" });
+
+    rerender({ data: { title: "First draft" }, enabled: true });
+    await advanceTimers(500);
+    expect(save).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not save stale pre-load editor state when autosave is first enabled", async () => {
+    const save = vi.fn(async (_data: DraftPayload) => undefined);
+
+    const { rerender } = renderHook(
+      ({ data, enabled }: { data: DraftPayload; enabled: boolean }) =>
+        useAutoSave<DraftPayload>({
+          data,
+          delay: 100,
+          enabled,
+          onSave: async (payload) => {
+            await save(payload);
+          },
+        }),
+      { initialProps: { data: { title: "", content: "" }, enabled: false } }
+    );
+
+    rerender({
+      data: { title: "Loaded draft", content: "Existing post body" },
+      enabled: true,
+    });
+    await advanceTimers(500);
+    expect(save).not.toHaveBeenCalled();
+
+    rerender({
+      data: { title: "Loaded draft", content: "Existing post body with a local edit" },
+      enabled: true,
+    });
+    await advanceTimers(100);
+
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenLastCalledWith({
+      title: "Loaded draft",
+      content: "Existing post body with a local edit",
+    });
+  });
+});

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useDebounce } from './useDebounce';
 
 interface UseAutoSaveOptions<T> {
@@ -14,6 +14,14 @@ interface UseAutoSaveReturn {
   error: string | null;
 }
 
+function serializeAutoSaveData<T>(data: T): string {
+  try {
+    return JSON.stringify(data) ?? "";
+  } catch (_error) {
+    return String(data);
+  }
+}
+
 export function useAutoSave<T>({
   data,
   onSave,
@@ -23,34 +31,78 @@ export function useAutoSave<T>({
   const [isSaving, setIsSaving] = useState(false);
   const [lastSaved, setLastSaved] = useState<Date | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const debouncedData = useDebounce(data, delay);
-  const initialRender = useRef(true);
+  const dataKey = useMemo(() => serializeAutoSaveData(data), [data]);
+  const debouncedDataKey = useDebounce(dataKey, delay);
+  const initialized = useRef(false);
+  const lastSavedDataKey = useRef<string | null>(null);
+  const savingDataKey = useRef<string | null>(null);
+  const latestData = useRef(data);
+  const latestDataKey = useRef(dataKey);
+  const latestOnSave = useRef(onSave);
+  const mounted = useRef(true);
 
   useEffect(() => {
-    // Skip first render
-    if (initialRender.current) {
-      initialRender.current = false;
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    latestData.current = data;
+    latestDataKey.current = dataKey;
+    latestOnSave.current = onSave;
+  }, [data, dataKey, onSave]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    // Treat the first enabled value as already persisted. This prevents edit
+    // screens from auto-saving their empty pre-load state over the real draft.
+    if (!initialized.current) {
+      initialized.current = true;
+      lastSavedDataKey.current = dataKey;
       return;
     }
 
-    if (!enabled) return;
+    if (dataKey !== debouncedDataKey) return;
+    if (lastSavedDataKey.current === debouncedDataKey) return;
+    if (savingDataKey.current === debouncedDataKey) return;
+
+    const keyToSave = debouncedDataKey;
+    const dataToSave = latestData.current;
+    savingDataKey.current = keyToSave;
 
     const save = async () => {
       try {
-        setIsSaving(true);
-        setError(null);
-        await onSave(debouncedData);
-        setLastSaved(new Date());
+        if (mounted.current) {
+          setIsSaving(true);
+          setError(null);
+        }
+        await latestOnSave.current(dataToSave);
+        if (latestDataKey.current === keyToSave) {
+          lastSavedDataKey.current = keyToSave;
+        }
+        if (mounted.current) {
+          setLastSaved(new Date());
+        }
       } catch (err) {
         console.error('Auto-save failed:', err);
-        setError(err instanceof Error ? err.message : 'Failed to auto-save');
+        if (mounted.current) {
+          setError(err instanceof Error ? err.message : 'Failed to auto-save');
+        }
       } finally {
-        setIsSaving(false);
+        if (savingDataKey.current === keyToSave) {
+          savingDataKey.current = null;
+        }
+        if (mounted.current) {
+          setIsSaving(false);
+        }
       }
     };
 
     save();
-  }, [debouncedData, enabled, onSave]);
+  }, [dataKey, debouncedDataKey, enabled]);
 
   return { isSaving, lastSaved, error };
 }

--- a/src/pages/BlogCreatePage.tsx
+++ b/src/pages/BlogCreatePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Link, useNavigate } from "react-router-dom";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -68,22 +68,7 @@ function BlogCreatePageInner() {
   const [createdSlug, setCreatedSlug] = useState<string | null>(null);
   const [draftId, setDraftId] = useState<string | null>(null);
 
-  // Auto-save functionality
-  const handleAutoSave = async (data: typeof formData) => {
-    if (!user?.id) return;
-    const result = await blogService.saveDraft({
-      id: draftId || undefined,
-      userId: user.id,
-      ...data
-    });
-    
-    // Capture draft ID if this was a new draft
-    if (result.success && result.post && !draftId) {
-      setDraftId(result.post.id);
-    }
-  };
-
-  const formData = {
+  const formData = useMemo(() => ({
     title,
     excerpt,
     content,
@@ -93,7 +78,22 @@ function BlogCreatePageInner() {
     heroImage: imageUrl,
     thumbnail: thumbnailUrl,
     videoEmbed: youtubeUrl
-  };
+  }), [author, category, content, excerpt, imageUrl, tags, thumbnailUrl, title, youtubeUrl]);
+
+  // Auto-save functionality
+  const handleAutoSave = useCallback(async (data: typeof formData) => {
+    if (!user?.id) return;
+    const result = await blogService.saveDraft({
+      id: draftId || undefined,
+      userId: user.id,
+      ...data
+    });
+
+    // Capture draft ID if this was a new draft
+    if (result.success && result.post && !draftId) {
+      setDraftId(result.post.id);
+    }
+  }, [draftId, user?.id]);
 
   const { isSaving: isAutoSaving, lastSaved, error: autoSaveError } = useAutoSave({
     data: formData,

--- a/src/pages/BlogEditPage.tsx
+++ b/src/pages/BlogEditPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useAuth } from "@/contexts/auth";
 import { blogService } from "@/services/blogService";
@@ -59,6 +59,10 @@ function BlogEditPageInner() {
   });
   
   const [tagsString, setTagsString] = useState("");
+  const draftData = useMemo(() => ({
+    ...formData,
+    tags: tagsString.split(",").map(t => t.trim()).filter(Boolean),
+  }), [formData, tagsString]);
 
   const loadDraft = useCallback(async () => {
     if (!id) {
@@ -121,15 +125,14 @@ function BlogEditPageInner() {
     loadDraft();
   }, [isAuthenticated, loadDraft, navigate]);
 
-  const handleSaveDraft = async () => {
+  const handleSaveDraft = useCallback(async (nextData: typeof draftData = draftData) => {
     if (!user?.id || !id) return;
 
     try {
       const result = await blogService.saveDraft({
         id,
         userId: user.id,
-        ...formData,
-        tags: tagsString.split(",").map(t => t.trim()).filter(Boolean),
+        ...nextData,
         authorId: user.id,
         createdFromPostId: createdFromPostId || undefined
       });
@@ -145,7 +148,7 @@ function BlogEditPageInner() {
       toast.error(error instanceof Error ? error.message : "Failed to save draft");
       throw error;
     }
-  };
+  }, [createdFromPostId, draftData, id, user?.id]);
   
   const handleSaveAsNewDraft = async () => {
     if (!user?.id || !id) return;
@@ -304,7 +307,7 @@ function BlogEditPageInner() {
   };
 
   const { isSaving, lastSaved, error: autoSaveError } = useAutoSave({
-    data: formData,
+    data: draftData,
     onSave: handleSaveDraft,
     delay: 30000,
     enabled: !!user?.id && !!id && !loading


### PR DESCRIPTION
## Summary

Fixes the blog draft editor autosave loop where draft save calls could repeatedly fire after a save state update. The root cause was `useAutoSave` depending on a freshly-created `onSave` callback from the editor pages; each save updated hook state, re-rendered the editor, produced a new callback identity, and retriggered the autosave effect.

- **Stable autosave triggering**: `useAutoSave` now keys off the debounced draft payload instead of callback identity, so saves only run when content actually changes.
- **Loaded draft protection**: the first enabled editor value becomes the baseline, preventing edit pages from autosaving an empty pre-load form over an existing draft.
- **Editor payload cleanup**: create/edit pages memoize autosave payloads and callbacks; edit autosave now includes parsed tag changes.
- **Regression coverage**: new hook tests cover callback identity churn, single-save behavior after content changes, and loaded-draft baseline behavior.

## Changes

- `useAutoSave.ts` — serialize draft data into a stable fingerprint, keep latest save callback/data in refs, avoid repeat saves for already-saved payloads, and guard mounted state.
- `BlogCreatePage.tsx` — memoize the autosave form payload and stabilize the autosave callback.
- `BlogEditPage.tsx` — build a memoized draft payload that includes parsed tags and pass the exact payload through manual/autosave saves.
- `useAutoSave.test.tsx` — add focused regression tests for the autosave loop and pre-load overwrite case.

## Test plan

- [x] `npm run test:unit -- src/__tests__/useAutoSave.test.tsx`
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`
