### PR TITLE
Seed Florida surf shop gear

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,7 +230,7 @@ Use these URLs when seeding equipment_images rows. Primary = display_order 0, is
 | snowboards     | secondary | https://images.pexels.com/photos/7166118/pexels-photo-7166118.jpeg |
 | mountain-bikes | primary   | https://images.pexels.com/photos/30447388/pexels-photo-30447388.jpeg |
 | mountain-bikes | secondary | https://images.pexels.com/photos/25753440/pexels-photo-25753440.jpeg |
-| surfboards     | primary   | https://images.pexels.com/photos/36084973/pexels-photo-36084973.jpeg |
+| surfboards     | primary   | https://images.pexels.com/photos/2370006/pexels-photo-2370006.jpeg |
 | surfboards     | secondary | https://images.pexels.com/photos/8907535/pexels-photo-8907535.jpeg |
 
 Do not substitute other image sources for seed data. If new categories are added, append rows here before writing SQL.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,7 +230,7 @@ Use these URLs when seeding equipment_images rows. Primary = display_order 0, is
 | snowboards     | secondary | https://images.pexels.com/photos/7166118/pexels-photo-7166118.jpeg |
 | mountain-bikes | primary   | https://images.pexels.com/photos/30447388/pexels-photo-30447388.jpeg |
 | mountain-bikes | secondary | https://images.pexels.com/photos/25753440/pexels-photo-25753440.jpeg |
-| surfboards     | primary   | https://images.pexels.com/photos/36084973/pexels-photo-36084973.jpeg |
+| surfboards     | primary   | https://images.pexels.com/photos/2370006/pexels-photo-2370006.jpeg |
 | surfboards     | secondary | https://images.pexels.com/photos/8907535/pexels-photo-8907535.jpeg |
 
 Do not substitute other image sources for seed data. If new categories are added, append rows here before writing SQL.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -230,7 +230,7 @@ Use these URLs when seeding equipment_images rows. Primary = display_order 0, is
 | snowboards     | secondary | https://images.pexels.com/photos/7166118/pexels-photo-7166118.jpeg |
 | mountain-bikes | primary   | https://images.pexels.com/photos/30447388/pexels-photo-30447388.jpeg |
 | mountain-bikes | secondary | https://images.pexels.com/photos/25753440/pexels-photo-25753440.jpeg |
-| surfboards     | primary   | https://images.pexels.com/photos/36084973/pexels-photo-36084973.jpeg |
+| surfboards     | primary   | https://images.pexels.com/photos/2370006/pexels-photo-2370006.jpeg |
 | surfboards     | secondary | https://images.pexels.com/photos/8907535/pexels-photo-8907535.jpeg |
 
 Do not substitute other image sources for seed data. If new categories are added, append rows here before writing SQL.

--- a/supabase/migrations/20260525110000_seed_florida_surf_shops_shops.sql
+++ b/supabase/migrations/20260525110000_seed_florida_surf_shops_shops.sql
@@ -1,0 +1,182 @@
+-- Seed migration: Florida surf shops
+-- Batch: florida_surf_shops
+-- Created: 2026-05-25
+-- Apply to remote (human approval required):
+--   supabase db query --linked -f "/Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260525110000_seed_florida_surf_shops_shops.sql"
+-- Do NOT use supabase db push or supabase migration up.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- =============================================
+-- FLORIDA SURF SHOPS
+-- Shop/user inserts (auth.users + auth.identities + public.profiles + public.user_roles)
+-- Password: $uO9RX^1P%bd#8crEAM!
+-- NOTE: auth.users insert is guarded by email lookup for idempotent local testing.
+-- NOTE: user_roles upsert uses UPDATE...IF NOT FOUND THEN INSERT
+-- NOTE: profile upsert uses UPDATE...IF NOT FOUND THEN INSERT
+-- =============================================
+
+DO $$
+DECLARE
+  shop record;
+  new_user_id uuid;
+  v_avatar_url text;
+  v_hero_image_url text;
+  v_display_role text := 'retail-store';
+BEGIN
+  FOR shop IN
+    SELECT *
+    FROM (
+      VALUES
+        (
+          'Spunky''s Surf Shop',
+          'Fort Pierce, FL',
+          'michaelzick+spunkyssurfshopfortpierce@gmail.com',
+          'surfboards',
+          'https://spunkyssurfshop.com/',
+          '772-466-7048',
+          '1403 N US Hwy 1, Fort Pierce, FL 34950',
+          E'Fort Pierce surf shop with a public rental board list and current rental pricing. Spunky''s publishes Torq, Sunova, and Catch Surf rental models with board lengths, volumes, and half-day, full-day, and multi-day rates.',
+          27.4338466,
+          -80.3259843
+        )
+    ) AS s(name, city, email, category, website, phone, address, about, lat, lng)
+  LOOP
+    IF v_display_role IN ('retail-store', 'builder') THEN
+      CASE shop.category
+        WHEN 'surfboards' THEN
+          v_avatar_url := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/73de4049-7ffd-45cd-868b-c2d0076107b3/profile-1752863282257.png';
+          v_hero_image_url := 'https://images.unsplash.com/photo-1502680390469-be75c86b636f?q=80&w=3540&auto=format&fit=crop&ixlib=rb-4.0.3';
+        WHEN 'snowboards' THEN
+          v_avatar_url := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/c5b450a8-7414-463b-b863-d78698fd0f95/profile-1752636842828.png';
+          v_hero_image_url := 'https://images.unsplash.com/photo-1590461283969-47fedf408cfd?q=80&w=2670&auto=format&fit=crop&ixlib=rb-4.1.0';
+        WHEN 'skis' THEN
+          v_avatar_url := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/7ef925ac-4b8f-496c-b4d9-10895164f03c/profile-1769637319540.png';
+          v_hero_image_url := 'https://images.unsplash.com/photo-1509791413599-93ba127a66b7?q=80&w=3540&auto=format&fit=crop&ixlib=rb-4.0.3';
+        WHEN 'mountain-bikes' THEN
+          v_avatar_url := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/ad2ad153-bb35-4e88-bfb0-d0d4f85ba62f/profile-1752637760487.png';
+          v_hero_image_url := 'https://images.unsplash.com/photo-1506316940527-4d1c138978a0?q=80&w=3512&auto=format&fit=crop&ixlib=rb-4.0.3';
+        ELSE
+          v_avatar_url := NULL;
+          v_hero_image_url := NULL;
+      END CASE;
+    ELSE
+      v_avatar_url := NULL;
+      v_hero_image_url := NULL;
+    END IF;
+
+    SELECT id INTO new_user_id
+    FROM auth.users
+    WHERE email = shop.email
+    LIMIT 1;
+
+    IF new_user_id IS NULL THEN
+      new_user_id := gen_random_uuid();
+
+      INSERT INTO auth.users (
+        id,
+        instance_id,
+        aud,
+        role,
+        email,
+        encrypted_password,
+        email_confirmed_at,
+        raw_user_meta_data,
+        raw_app_meta_data,
+        created_at,
+        updated_at,
+        confirmation_token,
+        recovery_token,
+        email_change,
+        email_change_token_current,
+        email_change_token_new,
+        email_change_confirm_status,
+        phone_change,
+        phone_change_token,
+        reauthentication_token
+      ) VALUES (
+        new_user_id,
+        '00000000-0000-0000-0000-000000000000',
+        'authenticated',
+        'authenticated',
+        shop.email,
+        crypt('$uO9RX^1P%bd#8crEAM!', gen_salt('bf')),
+        now(),
+        jsonb_build_object('name', shop.name),
+        jsonb_build_object('provider', 'email', 'providers', ARRAY['email']),
+        now(),
+        now(),
+        '',
+        '',
+        '',
+        '',
+        '',
+        0,
+        '',
+        '',
+        ''
+      );
+
+      INSERT INTO auth.identities (
+        id,
+        user_id,
+        identity_data,
+        provider,
+        provider_id,
+        last_sign_in_at,
+        created_at,
+        updated_at
+      ) VALUES (
+        gen_random_uuid(),
+        new_user_id,
+        jsonb_build_object('sub', new_user_id::text, 'email', shop.email),
+        'email',
+        new_user_id::text,
+        now(),
+        now(),
+        now()
+      );
+    END IF;
+
+    UPDATE public.profiles SET
+      name = shop.name,
+      website = shop.website,
+      phone = shop.phone,
+      address = shop.address,
+      about = shop.about,
+      location_lat = shop.lat,
+      location_lng = shop.lng,
+      avatar_url = COALESCE(v_avatar_url, avatar_url),
+      hero_image_url = COALESCE(v_hero_image_url, hero_image_url)
+    WHERE id = new_user_id;
+
+    IF NOT FOUND THEN
+      INSERT INTO public.profiles (
+        id, name, website, phone, address, about,
+        location_lat, location_lng, avatar_url, hero_image_url
+      ) VALUES (
+        new_user_id,
+        shop.name,
+        shop.website,
+        shop.phone,
+        shop.address,
+        shop.about,
+        shop.lat,
+        shop.lng,
+        v_avatar_url,
+        v_hero_image_url
+      );
+    END IF;
+
+    UPDATE public.user_roles
+      SET display_role = v_display_role
+      WHERE user_id = new_user_id;
+
+    IF NOT FOUND THEN
+      INSERT INTO public.user_roles (user_id, display_role)
+      VALUES (new_user_id, v_display_role);
+    END IF;
+
+    RAISE NOTICE 'User upserted successfully: id=%, email=%, role=%', new_user_id, shop.email, v_display_role;
+  END LOOP;
+END $$;

--- a/supabase/migrations/20260525110100_seed_florida_surf_shops_gear.sql
+++ b/supabase/migrations/20260525110100_seed_florida_surf_shops_gear.sql
@@ -1,0 +1,250 @@
+-- Seed migration: Florida surf-shop gear
+-- Batch: florida_surf_shops
+-- Created: 2026-05-25
+-- Depends on: 20260525110000_seed_florida_surf_shops_shops.sql (apply shops first)
+-- Apply to remote (human approval required):
+--   supabase db query --linked -f "/Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260525110100_seed_florida_surf_shops_gear.sql"
+-- Do NOT use supabase db push or supabase migration up.
+--
+-- Gear batches are category-homogeneous.
+-- Surfboards primary image:   https://images.pexels.com/photos/36084973/pexels-photo-36084973.jpeg
+-- Surfboards secondary image: https://images.pexels.com/photos/8907535/pexels-photo-8907535.jpeg
+
+-- =============================================
+-- EQUIPMENT: Spunky's Surf Shop (Fort Pierce, FL) - surfboards
+-- Email: michaelzick+spunkyssurfshopfortpierce@gmail.com
+-- Price basis: spunkyssurfshop.com/pages/rentals-lessons, full-day surfboard rental, retrieved 2026-05-25.
+-- Coordinates sourced from US Census Geocoder street-address/range match for 1403 N US Hwy 1, Fort Pierce, FL 34950.
+-- =============================================
+DO $$
+DECLARE
+  missing_email text;
+  v_equipment_inserted int := 0;
+  v_primary_images_added int := 0;
+  v_secondary_images_added int := 0;
+BEGIN
+  SELECT seed_email INTO missing_email
+  FROM (
+    VALUES
+      (E'michaelzick+spunkyssurfshopfortpierce@gmail.com')
+  ) AS planned(seed_email)
+  WHERE NOT EXISTS (SELECT 1 FROM auth.users au WHERE au.email = planned.seed_email)
+  LIMIT 1;
+
+  IF missing_email IS NOT NULL THEN
+    RAISE EXCEPTION 'User not found for email: %', missing_email;
+  END IF;
+
+  WITH seed_equipment (seed_email, name, category, description, price_per_day, price_per_hour, price_per_week, size, weight, material, suitable_skill_level, status, location_lat, location_lng, location_address, subcategory, damage_deposit, visible_on_map) AS (
+    VALUES
+      (
+        E'michaelzick+spunkyssurfshopfortpierce@gmail.com',
+        E'Torq Hybrid',
+        E'surfboards',
+        E'The Torq Hybrid is a performance-board rental listed by Spunky''s Surf Shop. The public rental page lists the Hybrid with a compact shortboard length and 30.6 liters of volume, with full-day surfboard pricing.',
+        39.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        27.4338466, -80.3259843,
+        E'1403 N US Hwy 1, Fort Pierce, FL 34950',
+        E'performance shortboard', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+spunkyssurfshopfortpierce@gmail.com',
+        E'Torq Multiplier',
+        E'surfboards',
+        E'The Torq Multiplier is a performance-board rental listed by Spunky''s Surf Shop. The public rental page lists the Multiplier with a compact shortboard length and 28.8 liters of volume, with full-day surfboard pricing.',
+        39.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        27.4338466, -80.3259843,
+        E'1403 N US Hwy 1, Fort Pierce, FL 34950',
+        E'performance shortboard', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+spunkyssurfshopfortpierce@gmail.com',
+        E'Torq Fish',
+        E'surfboards',
+        E'The Torq Fish is a performance-board rental listed by Spunky''s Surf Shop. The public rental page lists the Fish with a 39.6-liter volume and full-day surfboard pricing for Fort Pierce surf rentals.',
+        39.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        27.4338466, -80.3259843,
+        E'1403 N US Hwy 1, Fort Pierce, FL 34950',
+        E'fish', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+spunkyssurfshopfortpierce@gmail.com',
+        E'Torq Big Boy',
+        E'surfboards',
+        E'The Torq Big Boy is a fun-shape rental listed by Spunky''s Surf Shop. The public rental page lists the Big Boy with 43.5 liters of volume and full-day surfboard pricing.',
+        39.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        27.4338466, -80.3259843,
+        E'1403 N US Hwy 1, Fort Pierce, FL 34950',
+        E'funboard', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+spunkyssurfshopfortpierce@gmail.com',
+        E'Sunova Christian Fletcher Loose Juice',
+        E'surfboards',
+        E'The Sunova Christian Fletcher Loose Juice is a fun-shape rental listed by Spunky''s Surf Shop. The public rental page lists it with 36.9 liters of volume and full-day surfboard pricing.',
+        39.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        27.4338466, -80.3259843,
+        E'1403 N US Hwy 1, Fort Pierce, FL 34950',
+        E'funboard', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+spunkyssurfshopfortpierce@gmail.com',
+        E'Sunova Christian Fletcher Doheny',
+        E'surfboards',
+        E'The Sunova Christian Fletcher Doheny is a fun-shape rental listed by Spunky''s Surf Shop. The public rental page lists it with 38.1 liters of volume and full-day surfboard pricing.',
+        39.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        27.4338466, -80.3259843,
+        E'1403 N US Hwy 1, Fort Pierce, FL 34950',
+        E'funboard', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+spunkyssurfshopfortpierce@gmail.com',
+        E'Torq Fun',
+        E'surfboards',
+        E'The Torq Fun is a fun-shape rental listed by Spunky''s Surf Shop. The public rental page lists the Fun with 41.8 liters of volume and full-day surfboard pricing.',
+        39.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        27.4338466, -80.3259843,
+        E'1403 N US Hwy 1, Fort Pierce, FL 34950',
+        E'funboard', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+spunkyssurfshopfortpierce@gmail.com',
+        E'Torq M2 V+',
+        E'surfboards',
+        E'The Torq M2 V+ is a larger fun-shape rental listed by Spunky''s Surf Shop. The public rental page lists the M2 V+ with 56 liters of volume and full-day surfboard pricing.',
+        39.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        27.4338466, -80.3259843,
+        E'1403 N US Hwy 1, Fort Pierce, FL 34950',
+        E'funboard', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+spunkyssurfshopfortpierce@gmail.com',
+        E'Torq Longboard',
+        E'surfboards',
+        E'The Torq Longboard is a longboard rental listed by Spunky''s Surf Shop. The public rental page lists multiple Longboard lengths and volumes with full-day surfboard pricing.',
+        39.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        27.4338466, -80.3259843,
+        E'1403 N US Hwy 1, Fort Pierce, FL 34950',
+        E'longboard', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+spunkyssurfshopfortpierce@gmail.com',
+        E'Catch Surf Soft Top',
+        E'surfboards',
+        E'The Catch Surf Soft Top is a soft-top longboard rental listed by Spunky''s Surf Shop. The public rental page lists multiple soft-top lengths and volumes with full-day surfboard pricing.',
+        39.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner',
+        'available',
+        27.4338466, -80.3259843,
+        E'1403 N US Hwy 1, Fort Pierce, FL 34950',
+        E'soft-top', NULL::numeric, true
+      )
+  ),
+  inserted AS (
+    INSERT INTO public.equipment (
+      id, user_id, name, category, description,
+      price_per_day, price_per_hour, price_per_week,
+      size, weight, material, suitable_skill_level, status,
+      location_lat, location_lng, location_address, subcategory,
+      damage_deposit, visible_on_map
+    )
+    SELECT
+      gen_random_uuid(),
+      su.id,
+      s.name, s.category, s.description,
+      s.price_per_day, s.price_per_hour, s.price_per_week,
+      s.size, s.weight, s.material, s.suitable_skill_level, s.status,
+      s.location_lat, s.location_lng, s.location_address, s.subcategory,
+      s.damage_deposit, s.visible_on_map
+    FROM seed_equipment s
+    JOIN auth.users su ON su.email = s.seed_email
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment e
+      WHERE e.user_id = su.id
+        AND e.name = s.name
+    )
+    RETURNING id
+  ),
+  ins1 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT
+      i.id,
+      'https://images.pexels.com/photos/36084973/pexels-photo-36084973.jpeg',
+      0,
+      true
+    FROM inserted i
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment_images ei
+      WHERE ei.equipment_id = i.id
+        AND ei.display_order = 0
+    )
+    RETURNING equipment_id
+  ),
+  ins2 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT
+      i.id,
+      'https://images.pexels.com/photos/8907535/pexels-photo-8907535.jpeg',
+      1,
+      false
+    FROM inserted i
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment_images ei
+      WHERE ei.equipment_id = i.id
+        AND ei.display_order = 1
+    )
+    RETURNING equipment_id
+  )
+  SELECT
+    (SELECT count(*) FROM inserted),
+    (SELECT count(*) FROM ins1),
+    (SELECT count(*) FROM ins2)
+  INTO
+    v_equipment_inserted,
+    v_primary_images_added,
+    v_secondary_images_added;
+
+  RAISE NOTICE 'Spunky''s Surf Shop surfboards inserted=%, primary_images_added=%, secondary_images_added=%',
+    v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+END $$;

--- a/supabase/migrations/20260525110200_fix_spunkys_surfboard_primary_images.sql
+++ b/supabase/migrations/20260525110200_fix_spunkys_surfboard_primary_images.sql
@@ -1,0 +1,53 @@
+-- Seed correction: Spunky's Surf Shop surfboard primary images
+-- Batch: florida_surf_shops
+-- Created: 2026-05-25
+-- Apply to remote (human approval required):
+--   supabase db query --linked -f "/Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260525110200_fix_spunkys_surfboard_primary_images.sql"
+-- Do NOT use supabase db push or supabase migration up.
+--
+-- Corrects the Spunky's surfboard primary placeholder from the skis secondary image
+-- to the canonical surfboard primary image.
+-- Surfboards primary image: https://images.pexels.com/photos/2370006/pexels-photo-2370006.jpeg
+
+DO $$
+DECLARE
+  v_updated int := 0;
+  v_remaining_bad int := 0;
+BEGIN
+  WITH target_images AS (
+    SELECT ei.id
+    FROM public.equipment_images ei
+    JOIN public.equipment e ON e.id = ei.equipment_id
+    JOIN auth.users au ON au.id = e.user_id
+    WHERE au.email = 'michaelzick+spunkyssurfshopfortpierce@gmail.com'
+      AND e.category = 'surfboards'
+      AND ei.display_order = 0
+      AND ei.is_primary = true
+  ),
+  fixed AS (
+    UPDATE public.equipment_images ei
+    SET image_url = 'https://images.pexels.com/photos/2370006/pexels-photo-2370006.jpeg',
+        updated_at = now()
+    FROM target_images ti
+    WHERE ti.id = ei.id
+      AND ei.image_url IS DISTINCT FROM 'https://images.pexels.com/photos/2370006/pexels-photo-2370006.jpeg'
+    RETURNING ei.id
+  )
+  SELECT count(*) INTO v_updated FROM fixed;
+
+  SELECT count(*) INTO v_remaining_bad
+  FROM public.equipment_images ei
+  JOIN public.equipment e ON e.id = ei.equipment_id
+  JOIN auth.users au ON au.id = e.user_id
+  WHERE au.email = 'michaelzick+spunkyssurfshopfortpierce@gmail.com'
+    AND e.category = 'surfboards'
+    AND ei.display_order = 0
+    AND ei.is_primary = true
+    AND ei.image_url IS DISTINCT FROM 'https://images.pexels.com/photos/2370006/pexels-photo-2370006.jpeg';
+
+  IF v_remaining_bad <> 0 THEN
+    RAISE EXCEPTION 'Spunky surfboard primary image correction incomplete: remaining_bad=%', v_remaining_bad;
+  END IF;
+
+  RAISE NOTICE 'Spunky surfboard primary images fixed=%', v_updated;
+END $$;


### PR DESCRIPTION
## Summary

Seeds a strict-evidence Florida surf-shop batch for Spunky's Surf Shop in Fort Pierce, then corrects the primary surfboard placeholder image that was initially pulled from the mirrored DemoStoke instructions.

- Adds a shop/profile/user seed migration for Spunky's Surf Shop using the official Fort Pierce address, phone, website, and verified coordinates.
- Adds 10 source-backed surfboard equipment rows with full-day rental pricing and two `equipment_images` rows per board.
- Adds a follow-up correction migration that updates all 10 Spunky's primary board images from the skis secondary placeholder to the canonical surfboard primary image.
- Updates `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` so future surfboard seed work uses `https://images.pexels.com/photos/2370006/pexels-photo-2370006.jpeg` as the primary surfboard image.

## Changes

- `20260525110000_seed_florida_surf_shops_shops.sql` - creates the Spunky's retail-store auth/profile/role seed.
- `20260525110100_seed_florida_surf_shops_gear.sql` - adds the 10 surfboard equipment rows and image rows.
- `20260525110200_fix_spunkys_surfboard_primary_images.sql` - fixes the primary board image URL after the mirrored docs mismatch was found.
- `AGENTS.md` / `CLAUDE.md` / `GEMINI.md` - correct the canonical surfboard primary placeholder URL.

## Test plan

- [x] `rg -n "DELETE FROM|TRUNCATE|DROP|ALTER TABLE|ON CONFLICT|specs"` against the seed/fix migrations
- [x] Rollback-first linked transaction for the seed batch, with post-rollback target counts still zero
- [x] Linked commit transaction inserted +1 auth user, +1 auth identity, +1 profile, +1 user role, +10 equipment rows, and +20 equipment images
- [x] `validation.sql` returned only `shop_presence` and `gear_count_by_shop_category` summary rows
- [x] Image fix validation confirmed 0 ski-placeholder primary images and 10 surfboard-primary images for Spunky's boards
- [x] `supabase migration list --linked` shows `20260525110000`, `20260525110100`, and `20260525110200` aligned local/remote
- [x] `git diff --check`

Created by Codex
