### PR TITLE
Add FleetOps POS inventory seed cron

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,7 @@
   - `profiles`, `public_profiles`, `user_roles`
   - `blog_posts`
   - `gear_review_blog_generation_config`, `gear_review_blog_generation_runs`
+  - `fleetops_pos_inventory_seed_config`
   - `demo_calendar`, `demo_event_candidates`, `demo_event_discovery_config`
   - `app_settings`, `app_privacy_settings`
   - `shop_gear_feed_mappings`, `scraped_retailers`, `downloaded_images`
@@ -201,6 +202,7 @@ If a grant is missing, PostgREST returns error code `42501` with the exact GRANT
 - Theme flicker fix can be disabled with `VITE_ENABLE_THEME_FLICKER_FIX=false`.
 - Edge functions rely on combinations of `SUPABASE_SERVICE_ROLE_KEY`, `OPENAI_API_KEY`, `MAPBOX_TOKEN`, `GOOGLE_API_KEY`, `GOOGLE_CSE_ID`, `GOOGLE_SEARCH_API_KEY`, `GOOGLE_SEARCH_ENGINE_ID`, and `HCAPTCHA_SECRET`.
 - `generate-gear-review-blog-draft` also relies on `SUPABASE_SERVICE_ROLE_KEY`, `OPENAI_API_KEY`, and the Google Custom Search image/web keys. It is protected by the `gear_review_blog_generation_config.cron_secret` value passed as `x-cron-secret`.
+- The FleetOps POS demo inventory cron runs from the main DemoStoke DB via `trigger_fleetops_pos_inventory_seed_cron()` and posts to `https://imdhbnfgrrckwoboodox.supabase.co/functions/v1/seed-pos-inventory`; keep `fleetops_pos_inventory_seed_config.cron_secret` synchronized with the FleetOps `POS_INVENTORY_SEED_CRON_SECRET` function secret.
 - Do not introduce new hardcoded secrets. Keep public browser tokens and service secrets clearly separated.
 
 ## Critical Invariants and Gotchas
@@ -213,6 +215,7 @@ If a grant is missing, PostgREST returns error code `42501` with the exact GRANT
 - Search/explore/profile visibility behavior is tightly coupled to `equipmentDataService`, `searchService`, `useEquipmentWithDynamicDistance`, and advanced filter helpers.
 - Automated gear-review drafts must not create `equipment_reviews` rows or mutate `equipment.rating` / `equipment.review_count`. Hidden factual evidence belongs in `gear_review_blog_generation_runs.hidden_evidence`, not in public blog copy, tags, excerpts, or analytics payloads.
 - Cron-generated gear-review drafts must not put rental/demo prices or dollar amounts in the title or excerpt, must not use em dashes in public copy, must contain at least 1500 body words after stripping HTML tags, and must store a selected gear image URL for the blog thumbnail instead of a small Google `thumbnailLink`.
+- FleetOps POS inventory seeding is queued by `pg_net` from the main DemoStoke project at the daily 9/10 UTC schedule, gated to 2 AM Pacific and a 2-day cadence. The FleetOps `seed-pos-inventory` function performs the actual inserts and read-back verification in the FleetOps DB; use `trigger_fleetops_pos_inventory_seed_cron(true)` for a live forced validation run.
 - Generated gear-review analytics must use safe metadata only: post id/slug, category, source equipment id, gear category, author, generated flag, and preview/published mode. Never send hidden evidence, source snippets, credentials, or raw prompts to Amplitude or Google Analytics.
 - `DemoStokeWidget` is a local-dev artifact right now. Treat it as unfinished unless you intentionally wire it to production.
 - There is a large amount of existing debug logging. Remove or preserve it intentionally, not accidentally.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,7 @@
   - `profiles`, `public_profiles`, `user_roles`
   - `blog_posts`
   - `gear_review_blog_generation_config`, `gear_review_blog_generation_runs`
+  - `fleetops_pos_inventory_seed_config`
   - `demo_calendar`, `demo_event_candidates`, `demo_event_discovery_config`
   - `app_settings`, `app_privacy_settings`
   - `shop_gear_feed_mappings`, `scraped_retailers`, `downloaded_images`
@@ -201,6 +202,7 @@ If a grant is missing, PostgREST returns error code `42501` with the exact GRANT
 - Theme flicker fix can be disabled with `VITE_ENABLE_THEME_FLICKER_FIX=false`.
 - Edge functions rely on combinations of `SUPABASE_SERVICE_ROLE_KEY`, `OPENAI_API_KEY`, `MAPBOX_TOKEN`, `GOOGLE_API_KEY`, `GOOGLE_CSE_ID`, `GOOGLE_SEARCH_API_KEY`, `GOOGLE_SEARCH_ENGINE_ID`, and `HCAPTCHA_SECRET`.
 - `generate-gear-review-blog-draft` also relies on `SUPABASE_SERVICE_ROLE_KEY`, `OPENAI_API_KEY`, and the Google Custom Search image/web keys. It is protected by the `gear_review_blog_generation_config.cron_secret` value passed as `x-cron-secret`.
+- The FleetOps POS demo inventory cron runs from the main DemoStoke DB via `trigger_fleetops_pos_inventory_seed_cron()` and posts to `https://imdhbnfgrrckwoboodox.supabase.co/functions/v1/seed-pos-inventory`; keep `fleetops_pos_inventory_seed_config.cron_secret` synchronized with the FleetOps `POS_INVENTORY_SEED_CRON_SECRET` function secret.
 - Do not introduce new hardcoded secrets. Keep public browser tokens and service secrets clearly separated.
 
 ## Critical Invariants and Gotchas
@@ -213,6 +215,7 @@ If a grant is missing, PostgREST returns error code `42501` with the exact GRANT
 - Search/explore/profile visibility behavior is tightly coupled to `equipmentDataService`, `searchService`, `useEquipmentWithDynamicDistance`, and advanced filter helpers.
 - Automated gear-review drafts must not create `equipment_reviews` rows or mutate `equipment.rating` / `equipment.review_count`. Hidden factual evidence belongs in `gear_review_blog_generation_runs.hidden_evidence`, not in public blog copy, tags, excerpts, or analytics payloads.
 - Cron-generated gear-review drafts must not put rental/demo prices or dollar amounts in the title or excerpt, must not use em dashes in public copy, must contain at least 1500 body words after stripping HTML tags, and must store a selected gear image URL for the blog thumbnail instead of a small Google `thumbnailLink`.
+- FleetOps POS inventory seeding is queued by `pg_net` from the main DemoStoke project at the daily 9/10 UTC schedule, gated to 2 AM Pacific and a 2-day cadence. The FleetOps `seed-pos-inventory` function performs the actual inserts and read-back verification in the FleetOps DB; use `trigger_fleetops_pos_inventory_seed_cron(true)` for a live forced validation run.
 - Generated gear-review analytics must use safe metadata only: post id/slug, category, source equipment id, gear category, author, generated flag, and preview/published mode. Never send hidden evidence, source snippets, credentials, or raw prompts to Amplitude or Google Analytics.
 - `DemoStokeWidget` is a local-dev artifact right now. Treat it as unfinished unless you intentionally wire it to production.
 - There is a large amount of existing debug logging. Remove or preserve it intentionally, not accidentally.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -123,6 +123,7 @@
   - `profiles`, `public_profiles`, `user_roles`
   - `blog_posts`
   - `gear_review_blog_generation_config`, `gear_review_blog_generation_runs`
+  - `fleetops_pos_inventory_seed_config`
   - `demo_calendar`, `demo_event_candidates`, `demo_event_discovery_config`
   - `app_settings`, `app_privacy_settings`
   - `shop_gear_feed_mappings`, `scraped_retailers`, `downloaded_images`
@@ -201,6 +202,7 @@ If a grant is missing, PostgREST returns error code `42501` with the exact GRANT
 - Theme flicker fix can be disabled with `VITE_ENABLE_THEME_FLICKER_FIX=false`.
 - Edge functions rely on combinations of `SUPABASE_SERVICE_ROLE_KEY`, `OPENAI_API_KEY`, `MAPBOX_TOKEN`, `GOOGLE_API_KEY`, `GOOGLE_CSE_ID`, `GOOGLE_SEARCH_API_KEY`, `GOOGLE_SEARCH_ENGINE_ID`, and `HCAPTCHA_SECRET`.
 - `generate-gear-review-blog-draft` also relies on `SUPABASE_SERVICE_ROLE_KEY`, `OPENAI_API_KEY`, and the Google Custom Search image/web keys. It is protected by the `gear_review_blog_generation_config.cron_secret` value passed as `x-cron-secret`.
+- The FleetOps POS demo inventory cron runs from the main DemoStoke DB via `trigger_fleetops_pos_inventory_seed_cron()` and posts to `https://imdhbnfgrrckwoboodox.supabase.co/functions/v1/seed-pos-inventory`; keep `fleetops_pos_inventory_seed_config.cron_secret` synchronized with the FleetOps `POS_INVENTORY_SEED_CRON_SECRET` function secret.
 - Do not introduce new hardcoded secrets. Keep public browser tokens and service secrets clearly separated.
 
 ## Critical Invariants and Gotchas
@@ -213,6 +215,7 @@ If a grant is missing, PostgREST returns error code `42501` with the exact GRANT
 - Search/explore/profile visibility behavior is tightly coupled to `equipmentDataService`, `searchService`, `useEquipmentWithDynamicDistance`, and advanced filter helpers.
 - Automated gear-review drafts must not create `equipment_reviews` rows or mutate `equipment.rating` / `equipment.review_count`. Hidden factual evidence belongs in `gear_review_blog_generation_runs.hidden_evidence`, not in public blog copy, tags, excerpts, or analytics payloads.
 - Cron-generated gear-review drafts must not put rental/demo prices or dollar amounts in the title or excerpt, must not use em dashes in public copy, must contain at least 1500 body words after stripping HTML tags, and must store a selected gear image URL for the blog thumbnail instead of a small Google `thumbnailLink`.
+- FleetOps POS inventory seeding is queued by `pg_net` from the main DemoStoke project at the daily 9/10 UTC schedule, gated to 2 AM Pacific and a 2-day cadence. The FleetOps `seed-pos-inventory` function performs the actual inserts and read-back verification in the FleetOps DB; use `trigger_fleetops_pos_inventory_seed_cron(true)` for a live forced validation run.
 - Generated gear-review analytics must use safe metadata only: post id/slug, category, source equipment id, gear category, author, generated flag, and preview/published mode. Never send hidden evidence, source snippets, credentials, or raw prompts to Amplitude or Google Analytics.
 - `DemoStokeWidget` is a local-dev artifact right now. Treat it as unfinished unless you intentionally wire it to production.
 - There is a large amount of existing debug logging. Remove or preserve it intentionally, not accidentally.

--- a/supabase/migrations/20260527110000_create_fleetops_pos_inventory_seed_cron.sql
+++ b/supabase/migrations/20260527110000_create_fleetops_pos_inventory_seed_cron.sql
@@ -1,0 +1,153 @@
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+CREATE TABLE IF NOT EXISTS public.fleetops_pos_inventory_seed_config (
+  id boolean PRIMARY KEY DEFAULT true CHECK (id = true),
+  enabled boolean NOT NULL DEFAULT true,
+  fleetops_function_url text NOT NULL DEFAULT 'https://imdhbnfgrrckwoboodox.supabase.co/functions/v1/seed-pos-inventory',
+  cron_secret text NOT NULL DEFAULT encode(extensions.gen_random_bytes(32), 'hex'),
+  last_cron_attempt_at timestamp with time zone,
+  last_request_id bigint,
+  last_queued_at timestamp with time zone,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.fleetops_pos_inventory_seed_config ENABLE ROW LEVEL SECURITY;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fleetops_pos_inventory_seed_config TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fleetops_pos_inventory_seed_config TO service_role;
+
+DROP POLICY IF EXISTS "Admins can view fleetops pos inventory seed config"
+ON public.fleetops_pos_inventory_seed_config;
+DROP POLICY IF EXISTS "Admins can manage fleetops pos inventory seed config"
+ON public.fleetops_pos_inventory_seed_config;
+
+CREATE POLICY "Admins can view fleetops pos inventory seed config"
+ON public.fleetops_pos_inventory_seed_config
+FOR SELECT
+USING (is_admin());
+
+CREATE POLICY "Admins can manage fleetops pos inventory seed config"
+ON public.fleetops_pos_inventory_seed_config
+FOR ALL
+USING (is_admin())
+WITH CHECK (is_admin());
+
+DROP TRIGGER IF EXISTS update_fleetops_pos_inventory_seed_config_updated_at
+ON public.fleetops_pos_inventory_seed_config;
+
+CREATE TRIGGER update_fleetops_pos_inventory_seed_config_updated_at
+BEFORE UPDATE ON public.fleetops_pos_inventory_seed_config
+FOR EACH ROW
+EXECUTE FUNCTION public.update_updated_at_column();
+
+INSERT INTO public.fleetops_pos_inventory_seed_config (id)
+VALUES (true)
+ON CONFLICT (id) DO NOTHING;
+
+CREATE OR REPLACE FUNCTION public.trigger_fleetops_pos_inventory_seed_cron(
+  p_force boolean DEFAULT false
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_config public.fleetops_pos_inventory_seed_config%ROWTYPE;
+  v_now timestamp with time zone := now();
+  v_now_pt timestamp := timezone('America/Los_Angeles', v_now);
+  v_request_id bigint;
+  v_source text := CASE WHEN p_force THEN 'manual' ELSE 'cron' END;
+BEGIN
+  SELECT *
+  INTO v_config
+  FROM public.fleetops_pos_inventory_seed_config
+  WHERE id = true;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('status', 'skipped', 'reason', 'missing_config');
+  END IF;
+
+  IF NOT v_config.enabled THEN
+    RETURN jsonb_build_object('status', 'skipped', 'reason', 'disabled');
+  END IF;
+
+  IF NOT p_force AND EXTRACT(HOUR FROM v_now_pt) <> 2 THEN
+    RETURN jsonb_build_object(
+      'status', 'skipped',
+      'reason', 'outside_2am_pt_window',
+      'now_pt', to_char(v_now_pt, 'YYYY-MM-DD HH24:MI:SS')
+    );
+  END IF;
+
+  IF NOT p_force
+    AND v_config.last_queued_at IS NOT NULL
+    AND v_now < v_config.last_queued_at + interval '2 days'
+  THEN
+    RETURN jsonb_build_object(
+      'status', 'skipped',
+      'reason', 'cadence_not_elapsed',
+      'last_queued_at', v_config.last_queued_at,
+      'next_eligible_at', v_config.last_queued_at + interval '2 days'
+    );
+  END IF;
+
+  SELECT net.http_post(
+    url := v_config.fleetops_function_url,
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', v_config.cron_secret
+    ),
+    body := jsonb_build_object(
+      'source', v_source,
+      'force', p_force
+    ),
+    timeout_milliseconds := 120000
+  )
+  INTO v_request_id;
+
+  UPDATE public.fleetops_pos_inventory_seed_config
+  SET
+    last_cron_attempt_at = v_now,
+    last_request_id = v_request_id,
+    last_queued_at = v_now,
+    updated_at = v_now
+  WHERE id = true;
+
+  RETURN jsonb_build_object(
+    'status', 'queued',
+    'source', v_source,
+    'request_id', v_request_id,
+    'attempted_at', v_now,
+    'fleetops_function_url', v_config.fleetops_function_url
+  );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.trigger_fleetops_pos_inventory_seed_cron(boolean) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.trigger_fleetops_pos_inventory_seed_cron(boolean) TO postgres;
+GRANT EXECUTE ON FUNCTION public.trigger_fleetops_pos_inventory_seed_cron(boolean) TO service_role;
+
+DO $$
+DECLARE
+  v_job_id bigint;
+BEGIN
+  SELECT jobid
+  INTO v_job_id
+  FROM cron.job
+  WHERE jobname = 'fleetops-pos-inventory-seed-2am-pt'
+  LIMIT 1;
+
+  IF v_job_id IS NOT NULL THEN
+    PERFORM cron.unschedule(v_job_id);
+  END IF;
+
+  PERFORM cron.schedule(
+    'fleetops-pos-inventory-seed-2am-pt',
+    '0 9,10 * * *',
+    'SELECT public.trigger_fleetops_pos_inventory_seed_cron();'
+  );
+END;
+$$;


### PR DESCRIPTION
## Summary

Adds the main DemoStoke database scheduler that queues FleetOps POS mock inventory seeding against the unpaused FleetOps project every two days. The scheduler posts to `https://imdhbnfgrrckwoboodox.supabase.co/functions/v1/seed-pos-inventory`, stores its shared cron secret in `fleetops_pos_inventory_seed_config`, and follows the existing `pg_cron` + `pg_net` pattern.

- **2-day cadence from main DemoStoke**: the cron job runs at 9/10 UTC, gates to 2 AM Pacific, and only queues when the last seed was at least 2 days ago.
- **Manual validation hook**: `trigger_fleetops_pos_inventory_seed_cron(true)` bypasses scheduler gating for forced live tests.
- **Secret-backed request path**: the config row stores the FleetOps function URL, generated cron secret, last request id, and last queued timestamp.
- **Mirrored agent docs**: `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` now document the FleetOps POS seed invariant and secret synchronization requirement.

## Changes

- `supabase/migrations/20260527110000_create_fleetops_pos_inventory_seed_cron.sql` (new) — creates `fleetops_pos_inventory_seed_config`, the `trigger_fleetops_pos_inventory_seed_cron()` RPC, and the active cron schedule.
- `AGENTS.md` — documents the new scheduler/config table and live-validation invariant.
- `CLAUDE.md` — mirrors the scheduler/config documentation.
- `GEMINI.md` — mirrors the scheduler/config documentation.

## Test plan

- [x] `git diff --check`
- [x] `npx supabase db push --linked --dry-run` confirmed only this migration was pending
- [x] `npx supabase db push --linked --yes` applied the migration to the linked DemoStoke project
- [x] `select public.trigger_fleetops_pos_inventory_seed_cron(true)` queued request `828`
- [x] Verified `cron.job` contains active job `fleetops-pos-inventory-seed-2am-pt`
- [x] Verified FleetOps seed run completed with `verification_counts` of 1 for both Lightspeed and Booqable

Created by Codex