### PR TITLE
Fix blog post page crash from TDZ and unguarded Amplitude init

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,15 +148,19 @@
   <!-- Amplitude Analytics & Session Replay -->
   <script src="https://cdn.amplitude.com/script/f8e22b9e6a107073fe8cb51424e63488.js"></script>
   <script>
-    window.amplitude.add(window.sessionReplay.plugin({
-      sampleRate: 1,
-      config: {
-        captureRageClicks: true,
-        captureDeadClicks: true,
-      },
-      logLevel: 3,
-    }));
-    window.amplitude.init('f8e22b9e6a107073fe8cb51424e63488', { "fetchRemoteConfig": true, "autocapture": true });
+    if (window.amplitude) {
+      if (window.sessionReplay) {
+        window.amplitude.add(window.sessionReplay.plugin({
+          sampleRate: 1,
+          config: {
+            captureRageClicks: true,
+            captureDeadClicks: true,
+          },
+          logLevel: 3,
+        }));
+      }
+      window.amplitude.init('f8e22b9e6a107073fe8cb51424e63488', { "fetchRemoteConfig": true, "autocapture": true });
+    }
   </script>
 </head>
 

--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -123,6 +123,12 @@ const BlogPostPage = () => {
     });
   }, [id, isLoading, isPreviewMode, post, slug]);
 
+  // Fetch related gear based on post tags with a category fallback
+  const {
+    data: relatedGear,
+    isLoading: isLoadingRelatedGear,
+  } = useRelatedGear(post?.tags || [], post?.category);
+
   useEffect(() => {
     if (
       isLoading ||
@@ -174,12 +180,6 @@ const BlogPostPage = () => {
       }
       : undefined
   });
-
-  // Fetch related gear based on post tags with a category fallback
-  const {
-    data: relatedGear,
-    isLoading: isLoadingRelatedGear,
-  } = useRelatedGear(post?.tags || [], post?.category);
 
   console.log("Post ID:", slug);
 


### PR DESCRIPTION
## What changed

Fixes two runtime errors that crashed the blog post page (e.g. `/blog/blizzard-zero-g-85-touring-ski-review-lightweight-backcountry-pick`).

### 1. `ReferenceError: can't access lexical declaration 'isLoadingRelatedGear' before initialization`
In `src/pages/BlogPostPage.tsx`, a `useEffect` referenced `relatedGear` and `isLoadingRelatedGear` in its body and dependency array, but the `useRelatedGear()` hook that produces them was declared *below* the effect. Because `const` bindings are in the temporal dead zone until their declaration runs, the effect's dependency array threw on every render, dropping the page into the error boundary ("Post Not Found").

Fix: moved the `useRelatedGear()` call above the effect that consumes it and removed the now-duplicate declaration. Hook ordering relative to the other hooks is preserved.

### 2. `TypeError: can't access property "add", window.amplitude is undefined`
The inline Amplitude bootstrap in `index.html` called `window.amplitude.add(...)` and `.init(...)` unconditionally. When the Amplitude SDK script fails to load (ad blocker, network hiccup, or CSP), `window.amplitude` is `undefined` and the script throws.

Fix: wrapped the calls in `if (window.amplitude)` and additionally guarded the session-replay plugin with `if (window.sessionReplay)`, matching the defensive pattern already used in the error-tracking script just above it.

## Verification
- `npm run type-check` passes
- `npm run lint` passes (0 errors; the one remaining warning is pre-existing in `ContactInfoModal.tsx`)
- Loaded the affected blog post in the dev server: page renders the full post with no console errors; `window.amplitude` resolves and the bootstrap no longer throws.

## Notes for reviewer
- The `index.html` change affects the pre-hydration HTML shell, so it requires a hard refresh (not HMR) to take effect locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)