### PR TITLE
Seed Eastern Time Zone shops and gear batches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,6 +290,17 @@ This summary reflects read-only linked DemoStoke data checks after the May 24, 2
 
 Do not re-seed any shop already in this table. Do not seed Hawaii Surfboard Rentals under any Hawaii discovery task.
 
+## Seed Data — Pending Local Seed Batches
+
+These files exist locally but have **not** been pushed/applied to the linked DemoStoke Supabase project. Do not describe these shops as live until the migrations are explicitly applied.
+
+- Eastern Time Zone all-category batch, status `local pending`, created May 30, 2026:
+  - shops migration: `supabase/migrations/20260530120000_seed_eastern_time_zone_all_categories_shops.sql`
+  - gear migrations: `20260530120100_seed_eastern_time_zone_surfboards_gear.sql`, `20260530120200_seed_eastern_time_zone_skis_gear.sql`, `20260530120300_seed_eastern_time_zone_snowboards_gear.sql`, `20260530120400_seed_eastern_time_zone_mountain_bikes_gear.sql`
+  - audit folder: `demostoke_seed_batches/eastern_time_zone_all_categories/`
+  - shops: Belleayre Mountain; Highland Mountain Bike Park; Thunder Mountain Bike Park; Ride Kanuga; REAL Watersports; Warm Winds Surf Shop; Cinnamon Rainbows Surf Co.
+  - planned gear counts: surfboards 14, skis 5, snowboards 2, mountain-bikes 19
+
 ## Seed Data — Historical Hermes Migration Notes
 
 The final-state Hermes seed migrations for Park City/Jans/White Pine, Arizona, Oregon, Colorado, Ventura County, and Texas are now tracked under `supabase/migrations/` and marked applied in linked migration metadata. Do not apply them again to linked data.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,6 +290,17 @@ This summary reflects read-only linked DemoStoke data checks after the May 24, 2
 
 Do not re-seed any shop already in this table. Do not seed Hawaii Surfboard Rentals under any Hawaii discovery task.
 
+## Seed Data — Pending Local Seed Batches
+
+These files exist locally but have **not** been pushed/applied to the linked DemoStoke Supabase project. Do not describe these shops as live until the migrations are explicitly applied.
+
+- Eastern Time Zone all-category batch, status `local pending`, created May 30, 2026:
+  - shops migration: `supabase/migrations/20260530120000_seed_eastern_time_zone_all_categories_shops.sql`
+  - gear migrations: `20260530120100_seed_eastern_time_zone_surfboards_gear.sql`, `20260530120200_seed_eastern_time_zone_skis_gear.sql`, `20260530120300_seed_eastern_time_zone_snowboards_gear.sql`, `20260530120400_seed_eastern_time_zone_mountain_bikes_gear.sql`
+  - audit folder: `demostoke_seed_batches/eastern_time_zone_all_categories/`
+  - shops: Belleayre Mountain; Highland Mountain Bike Park; Thunder Mountain Bike Park; Ride Kanuga; REAL Watersports; Warm Winds Surf Shop; Cinnamon Rainbows Surf Co.
+  - planned gear counts: surfboards 14, skis 5, snowboards 2, mountain-bikes 19
+
 ## Seed Data — Historical Hermes Migration Notes
 
 The final-state Hermes seed migrations for Park City/Jans/White Pine, Arizona, Oregon, Colorado, Ventura County, and Texas are now tracked under `supabase/migrations/` and marked applied in linked migration metadata. Do not apply them again to linked data.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -290,6 +290,17 @@ This summary reflects read-only linked DemoStoke data checks after the May 24, 2
 
 Do not re-seed any shop already in this table. Do not seed Hawaii Surfboard Rentals under any Hawaii discovery task.
 
+## Seed Data — Pending Local Seed Batches
+
+These files exist locally but have **not** been pushed/applied to the linked DemoStoke Supabase project. Do not describe these shops as live until the migrations are explicitly applied.
+
+- Eastern Time Zone all-category batch, status `local pending`, created May 30, 2026:
+  - shops migration: `supabase/migrations/20260530120000_seed_eastern_time_zone_all_categories_shops.sql`
+  - gear migrations: `20260530120100_seed_eastern_time_zone_surfboards_gear.sql`, `20260530120200_seed_eastern_time_zone_skis_gear.sql`, `20260530120300_seed_eastern_time_zone_snowboards_gear.sql`, `20260530120400_seed_eastern_time_zone_mountain_bikes_gear.sql`
+  - audit folder: `demostoke_seed_batches/eastern_time_zone_all_categories/`
+  - shops: Belleayre Mountain; Highland Mountain Bike Park; Thunder Mountain Bike Park; Ride Kanuga; REAL Watersports; Warm Winds Surf Shop; Cinnamon Rainbows Surf Co.
+  - planned gear counts: surfboards 14, skis 5, snowboards 2, mountain-bikes 19
+
 ## Seed Data — Historical Hermes Migration Notes
 
 The final-state Hermes seed migrations for Park City/Jans/White Pine, Arizona, Oregon, Colorado, Ventura County, and Texas are now tracked under `supabase/migrations/` and marked applied in linked migration metadata. Do not apply them again to linked data.

--- a/demostoke_seed_batches/eastern_time_zone_all_categories/discovery_audit.md
+++ b/demostoke_seed_batches/eastern_time_zone_all_categories/discovery_audit.md
@@ -1,0 +1,105 @@
+# Discovery Audit - Eastern Time Zone All Categories
+
+Batch slug: `eastern_time_zone_all_categories`
+Created: 2026-05-30
+Status: local files only, not applied to linked Supabase
+
+## Scope
+
+- Region/market: United States Eastern Time Zone states, across official-source candidates found during this pass.
+- Categories: `surfboards`, `skis`, `snowboards`, `mountain-bikes`.
+- Minimum qualification level: public official rental/demo evidence with model-level brand and model names plus public prices.
+- Duplicate guard: candidate shop names, websites, and seed emails were checked against the linked DB before file creation. No accepted candidate was already present by candidate name or website.
+
+## Accepted Shops
+
+### Belleayre Mountain - Highmount, NY
+
+- Categories: `skis`, `snowboards`
+- Source: https://www.belleayre.com/tickets/high-performance-demos/
+- Address source: https://www.belleayre.com/plan-your-visit/directions/
+- Evidence: official high-performance demos page lists Rossignol ski models, Burton snowboard models, demo prices, and available sizes.
+- Coordinates: OpenStreetMap/Nominatim place match for Belleayre Mountain Ski Center at 181 Galli Curci Road.
+- Seed email: `michaelzick+belleayremountainhighmount@gmail.com`
+- Gear count: 5 skis, 2 snowboards
+
+### Highland Mountain Bike Park - Northfield, NH
+
+- Category: `mountain-bikes`
+- Source: https://highlandmountain.com/explore-highland/rentals-demos/rentals/
+- Evidence: official rental page lists Santa Cruz, Specialized, Giant, and Norco model-level rental bikes with full-day and half-day rates.
+- Coordinates: US Census Geocoder street-address/range match for 75 Ski Hill Drive.
+- Seed email: `michaelzick+highlandmountainbikeparknorthfield@gmail.com`
+- Gear count: 8 mountain bikes
+
+### Thunder Mountain Bike Park - Charlemont, MA
+
+- Category: `mountain-bikes`
+- Source: https://berkshireeast.com/summer/thunder-mountain-bike-park/bike-rentals?id=37
+- Evidence: official Berkshire East / Thunder Mountain page lists Scott, Santa Cruz, Transition, Yeti, and Rocky Mountain model-level bikes with full-day and half-day rates.
+- Coordinates: US Census Geocoder street-address/range match for 66 Thunder Mountain Road.
+- Seed email: `michaelzick+thundermountainbikeparkcharlemont@gmail.com`
+- Gear count: 8 mountain bikes
+
+### Ride Kanuga - Hendersonville, NC
+
+- Category: `mountain-bikes`
+- Source: https://ridekanuga.com/rentals/
+- Evidence: official rental page lists Specialized Turbo Levo e-bike models, prices, and available sizes.
+- Coordinates: US Census Geocoder street-address/range match for 1249 Kanuga Lake Road.
+- Seed email: `michaelzick+ridekanugahendersonville@gmail.com`
+- Gear count: 3 mountain bikes
+
+### REAL Watersports - Waves, NC
+
+- Category: `surfboards`
+- Sources:
+  - https://www.realwatersports.com/blogs/news/firewire-fleets-at-real
+  - https://www.firewiresurfboards.com/pages/prestige-firewire-fleets
+- Evidence: official REAL and Firewire Fleets pages list Firewire model names, size/volume ranges, day and week rates, address, and phone.
+- Coordinates: OpenStreetMap/Nominatim place match for REAL Watersports in Waves.
+- Seed email: `michaelzick+realwatersportswaves@gmail.com`
+- Gear count: 5 surfboards
+
+### Warm Winds Surf Shop - Narragansett, RI
+
+- Category: `surfboards`
+- Source: https://www.warmwinds.com/surfboard-rentals
+- Evidence: official rental page lists Firewire Fleets current stock and day/multi-day rates.
+- Coordinates: US Census Geocoder street-address/range match for 26 Kingstown Road.
+- Seed email: `michaelzick+warmwindssurfshopnarragansett@gmail.com`
+- Gear count: 3 surfboards
+
+### Cinnamon Rainbows Surf Co. - North Hampton, NH
+
+- Category: `surfboards`
+- Sources:
+  - https://www.cinnamonrainbows.com/demos
+  - https://www.firewiresurfboards.com/pages/prestige-firewire-fleets
+- Evidence: official demo page lists model-level demo boards and $50 day demo price; Firewire Fleets locator confirms address and phone.
+- Coordinates: US Census Geocoder street-address/range match for 62 Lafayette Road.
+- Seed email: `michaelzick+cinnamonrainbowsnorthhampton@gmail.com`
+- Gear count: 6 surfboards
+
+## Migration Files
+
+- `supabase/migrations/20260530120000_seed_eastern_time_zone_all_categories_shops.sql`
+- `supabase/migrations/20260530120100_seed_eastern_time_zone_surfboards_gear.sql`
+- `supabase/migrations/20260530120200_seed_eastern_time_zone_skis_gear.sql`
+- `supabase/migrations/20260530120300_seed_eastern_time_zone_snowboards_gear.sql`
+- `supabase/migrations/20260530120400_seed_eastern_time_zone_mountain_bikes_gear.sql`
+
+## Expected Insert Counts
+
+- Shops/users: 7
+- Surfboards: 14
+- Skis: 5
+- Snowboards: 2
+- Mountain bikes: 19
+- Equipment images: 80 total if all gear rows are new
+
+## Notes
+
+- The linked DB already contains Eastern Time Zone shops in Vermont, Florida, New York, and New Jersey. Existing names and websites were treated as exclusions.
+- Some model names were normalized to ASCII-safe SQL text while preserving the public model identity, for example `Rossignol Forza 70 V-Ti`.
+- Surfboard lengths and volumes were kept in descriptions or source evidence, not in the `size` column, to preserve the current seed-data size rule.

--- a/demostoke_seed_batches/eastern_time_zone_all_categories/rejected_candidates.md
+++ b/demostoke_seed_batches/eastern_time_zone_all_categories/rejected_candidates.md
@@ -1,0 +1,17 @@
+# Rejected Candidates - Eastern Time Zone All Categories
+
+Created: 2026-05-30
+
+These candidates were reviewed but not included in executable SQL because they did not meet the model-level public evidence threshold or were already present in the linked DB.
+
+| Candidate | Region | Category | Reason |
+|---|---|---|---|
+| K-Coast Surf Shop | Ocean City, MD | surfboards | Official rental page has soft-top and hard-top day rates but does not name rental board models. |
+| Heritage Surf and Sport | NJ locations | surfboards | Official Awayco rental page lists daily price range and shop locations but does not expose model-level inventory in the crawlable source. |
+| 50 South Surf Shop | Surf City, NC | surfboards | Official page lists generic surfboard size buckets and says Firewire Fleets will update soon for 2025; no current model-level premium board list. |
+| Surfari | Gloucester, MA | surfboards | Official page lists brands and length range but not specific rental model names. |
+| The Startingate | Bondville, VT | skis | Official page lists demo pricing but not model-level public ski inventory. |
+| White Mountain Ski Co. | Lincoln, NH | mountain-bikes/skis | Official Yeti demo and backcountry rental pages show category and price evidence but did not expose current model-level rental inventory in the crawlable source. |
+| Whiteface Mountain | Wilmington, NY | skis/snowboards | Official pages mention high-performance rentals and demos but did not expose a current model-level rental inventory in the crawlable source. |
+| Belleayre generic rental packages | Highmount, NY | skis/snowboards | Generic rental packages were excluded; only the high-performance demo models were seeded. |
+| Existing Eastern Time Zone shops in linked DB | VT, FL, NY, NJ | all | Already present in linked DB and excluded to avoid duplicate shops. |

--- a/demostoke_seed_batches/eastern_time_zone_all_categories/remote_runbook.md
+++ b/demostoke_seed_batches/eastern_time_zone_all_categories/remote_runbook.md
@@ -1,0 +1,90 @@
+# Remote Runbook - Eastern Time Zone All Categories
+
+Status: local preparation only. Do not run these commands until the user explicitly approves remote execution.
+
+## Migration Files
+
+```text
+supabase/migrations/20260530120000_seed_eastern_time_zone_all_categories_shops.sql
+supabase/migrations/20260530120100_seed_eastern_time_zone_surfboards_gear.sql
+supabase/migrations/20260530120200_seed_eastern_time_zone_skis_gear.sql
+supabase/migrations/20260530120300_seed_eastern_time_zone_snowboards_gear.sql
+supabase/migrations/20260530120400_seed_eastern_time_zone_mountain_bikes_gear.sql
+```
+
+## Preconditions
+
+- [ ] `psql` and Supabase CLI are available, or a real Postgres client fallback is prepared outside the repo.
+- [ ] Either `SUPABASE_ACCESS_TOKEN` is configured for linked execution or `SUPABASE_DB_URL` is configured for direct `psql` execution.
+- [ ] The live DemoStoke checkout is current and `supabase migration list --linked` shows no unexpected skipped, remote-only, or local-only versions.
+- [ ] `demostoke_seed_batches/eastern_time_zone_all_categories/validation.sql` is SELECT-only.
+- [ ] Human approved remote execution.
+- [ ] Do not use `supabase db push`, `supabase db push --dry-run`, or `supabase migration up`.
+
+## Static Safety Scan
+
+```bash
+rg -n "DELETE FROM|TRUNCATE|DROP|ALTER TABLE|ON CONFLICT|specs" supabase/migrations/20260530120*.sql
+LC_ALL=C rg -n "[^[:ascii:]]" supabase/migrations/20260530120*.sql
+git diff --check
+```
+
+Expected: no matches from the first two commands and no whitespace errors.
+
+## Remote Dry Run
+
+Use a real Postgres transaction client. This executes the exact files and rolls back.
+
+```bash
+psql "$SUPABASE_DB_URL" --set ON_ERROR_STOP=1 <<'SQL'
+BEGIN;
+SET LOCAL lock_timeout = '10s';
+SET LOCAL statement_timeout = '120s';
+SELECT pg_advisory_xact_lock(20260530120000);
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260530120000_seed_eastern_time_zone_all_categories_shops.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260530120100_seed_eastern_time_zone_surfboards_gear.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260530120200_seed_eastern_time_zone_skis_gear.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260530120300_seed_eastern_time_zone_snowboards_gear.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260530120400_seed_eastern_time_zone_mountain_bikes_gear.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/demostoke_seed_batches/eastern_time_zone_all_categories/validation.sql
+ROLLBACK;
+SQL
+```
+
+## Remote Execution
+
+Only after the dry run passes and the user approves:
+
+```bash
+psql "$SUPABASE_DB_URL" --set ON_ERROR_STOP=1 <<'SQL'
+BEGIN;
+SET LOCAL lock_timeout = '10s';
+SET LOCAL statement_timeout = '120s';
+SELECT pg_advisory_xact_lock(20260530120000);
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260530120000_seed_eastern_time_zone_all_categories_shops.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260530120100_seed_eastern_time_zone_surfboards_gear.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260530120200_seed_eastern_time_zone_skis_gear.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260530120300_seed_eastern_time_zone_snowboards_gear.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260530120400_seed_eastern_time_zone_mountain_bikes_gear.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/demostoke_seed_batches/eastern_time_zone_all_categories/validation.sql
+COMMIT;
+SQL
+```
+
+After commit, mark only the applied versions as applied:
+
+```bash
+supabase migration repair --linked --status applied 20260530120000 20260530120100 20260530120200 20260530120300 20260530120400
+supabase migration list --linked
+```
+
+## Post-Run Checks
+
+- [ ] Expected shops appear in `public.profiles`.
+- [ ] Expected roles appear in `public.user_roles`.
+- [ ] Expected gear appears in `public.equipment`.
+- [ ] Each new equipment row has exactly two images.
+- [ ] Gear appears with the correct shop lat/lng.
+- [ ] `validation.sql` was rerun read-only after commit.
+- [ ] A second rollback transaction proved idempotency and inserted zero new gear/images.
+- [ ] Migration history is aligned after repair.

--- a/demostoke_seed_batches/eastern_time_zone_all_categories/remote_validation_report.md
+++ b/demostoke_seed_batches/eastern_time_zone_all_categories/remote_validation_report.md
@@ -1,0 +1,26 @@
+# Remote Validation Report - Eastern Time Zone All Categories
+
+Status: not run.
+
+No remote dry run, commit, validation, or idempotency check has been executed for this batch. The migration files are local only and await explicit user approval before any linked Supabase write.
+
+## Local Preparation Completed
+
+- Created shop/user migration for 7 Eastern Time Zone shops.
+- Created category-specific gear migrations for surfboards, skis, snowboards, and mountain bikes.
+- Created SELECT-only validation SQL.
+- Created source audit and rejected-candidate notes.
+- Ran linked DB read-only duplicate checks for accepted candidate names/websites before creating the files.
+- Ran `supabase migration list --linked`; local and remote migration history were aligned through `20260527110000` before these pending local files were added.
+
+## Expected Counts After Apply
+
+| Category | Expected gear rows |
+|---|---:|
+| surfboards | 14 |
+| skis | 5 |
+| snowboards | 2 |
+| mountain-bikes | 19 |
+| total | 40 |
+
+Each inserted gear row should receive two `equipment_images` rows.

--- a/demostoke_seed_batches/eastern_time_zone_all_categories/sources.json
+++ b/demostoke_seed_batches/eastern_time_zone_all_categories/sources.json
@@ -1,0 +1,172 @@
+[
+  {
+    "shop_name": "Belleayre Mountain",
+    "source_url": "https://www.belleayre.com/tickets/high-performance-demos/",
+    "source_type": "official_demo_page",
+    "evidence_found": ["prices", "model_names", "sizes", "descriptions"],
+    "fields_extracted": {
+      "address": "181 Galli Curci Road, Highmount, NY 12441",
+      "phone": "(845) 254-5600",
+      "gear": [
+        "Rossignol Hero Elite MT TI C.A.M",
+        "Rossignol Forza 70 V-Ti",
+        "Rossignol Forza 60 Ti",
+        "Rossignol Sender Soul 102",
+        "Rossignol Arcade 84",
+        "Burton Custom",
+        "Burton Feelgood"
+      ]
+    },
+    "confidence": "high"
+  },
+  {
+    "shop_name": "Belleayre Mountain",
+    "source_url": "https://www.belleayre.com/plan-your-visit/directions/",
+    "source_type": "official_address_page",
+    "evidence_found": ["address"],
+    "fields_extracted": {
+      "address": "181 Galli Curci Road, Highmount, NY 12441"
+    },
+    "confidence": "high"
+  },
+  {
+    "shop_name": "Highland Mountain Bike Park",
+    "source_url": "https://highlandmountain.com/explore-highland/rentals-demos/rentals/",
+    "source_type": "official_rental_page",
+    "evidence_found": ["prices", "model_names", "categories"],
+    "fields_extracted": {
+      "address": "75 Ski Hill Drive, Northfield, NH 03276",
+      "phone": "(603) 286-7677",
+      "gear": [
+        "Santa Cruz V10",
+        "Specialized Status 2 170 DH",
+        "Santa Cruz Bronson",
+        "Santa Cruz Megatower",
+        "Santa Cruz Nomad",
+        "Giant Reign",
+        "Norco Fluid",
+        "Norco Sight"
+      ]
+    },
+    "confidence": "high"
+  },
+  {
+    "shop_name": "Thunder Mountain Bike Park",
+    "source_url": "https://berkshireeast.com/summer/thunder-mountain-bike-park/bike-rentals?id=37",
+    "source_type": "official_rental_page",
+    "evidence_found": ["prices", "model_names", "address", "phone"],
+    "fields_extracted": {
+      "address": "66 Thunder Mountain Road, Charlemont, MA 01339",
+      "phone": "413-339-6618",
+      "gear": [
+        "Scott Gambler 920",
+        "Santa Cruz V10 29",
+        "Transition TR11",
+        "Yeti SB160",
+        "Yeti SB165",
+        "Transition Patrol",
+        "Rocky Mountain Instinct",
+        "Rocky Mountain Reaper"
+      ]
+    },
+    "confidence": "high"
+  },
+  {
+    "shop_name": "Ride Kanuga",
+    "source_url": "https://ridekanuga.com/rentals/",
+    "source_type": "official_rental_page",
+    "evidence_found": ["prices", "model_names", "sizes", "address", "phone"],
+    "fields_extracted": {
+      "address": "1249 Kanuga Lake Road, Hendersonville, NC 28739",
+      "phone": "(828)436.2002",
+      "gear": [
+        "Specialized Turbo Levo Gen 4 Premium",
+        "Specialized Turbo Levo",
+        "Specialized Turbo Levo SL Kids"
+      ]
+    },
+    "confidence": "high"
+  },
+  {
+    "shop_name": "REAL Watersports",
+    "source_url": "https://www.realwatersports.com/blogs/news/firewire-fleets-at-real",
+    "source_type": "official_rental_page",
+    "evidence_found": ["prices", "model_names", "sizes", "volumes", "descriptions"],
+    "fields_extracted": {
+      "address": "25706 North Carolina Hwy 12, Waves, NC 27982",
+      "phone": "(252) 987-6000",
+      "gear": [
+        "Firewire Seaside",
+        "Firewire Groove",
+        "Firewire TJ Twinzer",
+        "Firewire Sunday",
+        "Firewire The Gem"
+      ]
+    },
+    "confidence": "high"
+  },
+  {
+    "shop_name": "REAL Watersports",
+    "source_url": "https://www.firewiresurfboards.com/pages/prestige-firewire-fleets",
+    "source_type": "brand_fleet_locator",
+    "evidence_found": ["address", "phone", "model_names", "sizes"],
+    "fields_extracted": {
+      "address": "25706 North Carolina Hwy 12, Waves, NC 27982",
+      "phone": "(252) 987-6000",
+      "gear": [
+        "Seaside",
+        "Sunday",
+        "TJ Twinzer",
+        "The Gem",
+        "Groove"
+      ]
+    },
+    "confidence": "high"
+  },
+  {
+    "shop_name": "Warm Winds Surf Shop",
+    "source_url": "https://www.warmwinds.com/surfboard-rentals",
+    "source_type": "official_rental_page",
+    "evidence_found": ["prices", "model_names", "address", "phone"],
+    "fields_extracted": {
+      "address": "26 Kingstown Road, Narragansett, RI 02882",
+      "phone": "(401) 789-9040",
+      "gear": [
+        "Firewire Seaside",
+        "Firewire Sweet Potato",
+        "Firewire Dominator 2"
+      ]
+    },
+    "confidence": "high"
+  },
+  {
+    "shop_name": "Cinnamon Rainbows Surf Co.",
+    "source_url": "https://www.cinnamonrainbows.com/demos",
+    "source_type": "official_demo_page",
+    "evidence_found": ["prices", "model_names", "address", "phone"],
+    "fields_extracted": {
+      "address": "62 Lafayette Road, North Hampton, NH 03862",
+      "phone": "(603)-929-7467",
+      "gear": [
+        "Firewire Sweet Potato",
+        "Firewire Mashup",
+        "Firewire S Boss",
+        "Firewire Seaside",
+        "Channel Islands G-Skate",
+        "Pyzel White Tiger"
+      ]
+    },
+    "confidence": "high"
+  },
+  {
+    "shop_name": "Cinnamon Rainbows Surf Co.",
+    "source_url": "https://www.firewiresurfboards.com/pages/prestige-firewire-fleets",
+    "source_type": "brand_fleet_locator",
+    "evidence_found": ["address", "phone"],
+    "fields_extracted": {
+      "address": "62 Lafayette Road, North Hampton, NH 03862",
+      "phone": "(603) 929-7467"
+    },
+    "confidence": "high"
+  }
+]

--- a/demostoke_seed_batches/eastern_time_zone_all_categories/validation.sql
+++ b/demostoke_seed_batches/eastern_time_zone_all_categories/validation.sql
@@ -1,0 +1,201 @@
+-- =============================================
+-- DEMOSTOKE BATCH VALIDATION
+-- Batch: eastern_time_zone_all_categories
+-- Expected result: all failure checks return zero rows unless explicitly noted.
+-- This file is SELECT-only and must not be placed in supabase/migrations/.
+-- =============================================
+
+WITH seed_emails(email) AS (
+  VALUES
+    ('michaelzick+belleayremountainhighmount@gmail.com'),
+    ('michaelzick+highlandmountainbikeparknorthfield@gmail.com'),
+    ('michaelzick+thundermountainbikeparkcharlemont@gmail.com'),
+    ('michaelzick+ridekanugahendersonville@gmail.com'),
+    ('michaelzick+realwatersportswaves@gmail.com'),
+    ('michaelzick+warmwindssurfshopnarragansett@gmail.com'),
+    ('michaelzick+cinnamonrainbowsnorthhampton@gmail.com')
+)
+SELECT 'missing_auth_user' AS check_name, se.email
+FROM seed_emails se
+LEFT JOIN auth.users u ON u.email = se.email
+WHERE u.id IS NULL;
+
+WITH seed_emails(email) AS (
+  VALUES
+    ('michaelzick+belleayremountainhighmount@gmail.com'),
+    ('michaelzick+highlandmountainbikeparknorthfield@gmail.com'),
+    ('michaelzick+thundermountainbikeparkcharlemont@gmail.com'),
+    ('michaelzick+ridekanugahendersonville@gmail.com'),
+    ('michaelzick+realwatersportswaves@gmail.com'),
+    ('michaelzick+warmwindssurfshopnarragansett@gmail.com'),
+    ('michaelzick+cinnamonrainbowsnorthhampton@gmail.com')
+),
+seed_users AS (
+  SELECT u.id, u.email
+  FROM auth.users u
+  JOIN seed_emails se ON se.email = u.email
+)
+SELECT 'missing_profile' AS check_name, su.email
+FROM seed_users su
+LEFT JOIN public.profiles p ON p.id = su.id
+WHERE p.id IS NULL;
+
+WITH seed_emails(email) AS (
+  VALUES
+    ('michaelzick+belleayremountainhighmount@gmail.com'),
+    ('michaelzick+highlandmountainbikeparknorthfield@gmail.com'),
+    ('michaelzick+thundermountainbikeparkcharlemont@gmail.com'),
+    ('michaelzick+ridekanugahendersonville@gmail.com'),
+    ('michaelzick+realwatersportswaves@gmail.com'),
+    ('michaelzick+warmwindssurfshopnarragansett@gmail.com'),
+    ('michaelzick+cinnamonrainbowsnorthhampton@gmail.com')
+),
+seed_users AS (
+  SELECT u.id, u.email
+  FROM auth.users u
+  JOIN seed_emails se ON se.email = u.email
+)
+SELECT 'missing_or_wrong_role' AS check_name, su.email, ur.display_role
+FROM seed_users su
+LEFT JOIN public.user_roles ur ON ur.user_id = su.id
+WHERE ur.user_id IS NULL
+   OR ur.display_role <> 'retail-store';
+
+WITH seed_emails(email) AS (
+  VALUES
+    ('michaelzick+belleayremountainhighmount@gmail.com'),
+    ('michaelzick+highlandmountainbikeparknorthfield@gmail.com'),
+    ('michaelzick+thundermountainbikeparkcharlemont@gmail.com'),
+    ('michaelzick+ridekanugahendersonville@gmail.com'),
+    ('michaelzick+realwatersportswaves@gmail.com'),
+    ('michaelzick+warmwindssurfshopnarragansett@gmail.com'),
+    ('michaelzick+cinnamonrainbowsnorthhampton@gmail.com')
+),
+seed_users AS (
+  SELECT u.id, u.email
+  FROM auth.users u
+  JOIN seed_emails se ON se.email = u.email
+)
+SELECT 'bad_equipment_required_fields' AS check_name, su.email, e.name
+FROM seed_users su
+JOIN public.equipment e ON e.user_id = su.id
+WHERE e.category IS NULL
+   OR e.status IS NULL
+   OR e.location_address IS NULL
+   OR e.location_lat IS NULL
+   OR e.location_lng IS NULL
+   OR e.visible_on_map IS DISTINCT FROM true;
+
+WITH seed_emails(email) AS (
+  VALUES
+    ('michaelzick+belleayremountainhighmount@gmail.com'),
+    ('michaelzick+highlandmountainbikeparknorthfield@gmail.com'),
+    ('michaelzick+thundermountainbikeparkcharlemont@gmail.com'),
+    ('michaelzick+ridekanugahendersonville@gmail.com'),
+    ('michaelzick+realwatersportswaves@gmail.com'),
+    ('michaelzick+warmwindssurfshopnarragansett@gmail.com'),
+    ('michaelzick+cinnamonrainbowsnorthhampton@gmail.com')
+),
+seed_users AS (
+  SELECT u.id, u.email
+  FROM auth.users u
+  JOIN seed_emails se ON se.email = u.email
+)
+SELECT 'invalid_skill_level' AS check_name, su.email, e.name, e.suitable_skill_level
+FROM seed_users su
+JOIN public.equipment e ON e.user_id = su.id
+WHERE e.suitable_skill_level NOT IN (
+  'Beginner',
+  'Beginner, Intermediate',
+  'Beginner, Intermediate, Advanced',
+  'Beginner, Intermediate, Advanced, Expert'
+);
+
+WITH seed_emails(email) AS (
+  VALUES
+    ('michaelzick+belleayremountainhighmount@gmail.com'),
+    ('michaelzick+highlandmountainbikeparknorthfield@gmail.com'),
+    ('michaelzick+thundermountainbikeparkcharlemont@gmail.com'),
+    ('michaelzick+ridekanugahendersonville@gmail.com'),
+    ('michaelzick+realwatersportswaves@gmail.com'),
+    ('michaelzick+warmwindssurfshopnarragansett@gmail.com'),
+    ('michaelzick+cinnamonrainbowsnorthhampton@gmail.com')
+),
+seed_users AS (
+  SELECT u.id, u.email
+  FROM auth.users u
+  JOIN seed_emails se ON se.email = u.email
+)
+SELECT 'possible_size_in_name' AS check_name, su.email, e.name
+FROM seed_users su
+JOIN public.equipment e ON e.user_id = su.id
+WHERE e.name ~* '(^|[^a-z0-9])([0-9]{2,3}cm|[0-9]+''[0-9]*|[0-9]+ft|S[1-6]|XS|SM|MD|LG|XL)([^a-z0-9]|$)';
+
+WITH seed_emails(email) AS (
+  VALUES
+    ('michaelzick+belleayremountainhighmount@gmail.com'),
+    ('michaelzick+highlandmountainbikeparknorthfield@gmail.com'),
+    ('michaelzick+thundermountainbikeparkcharlemont@gmail.com'),
+    ('michaelzick+ridekanugahendersonville@gmail.com'),
+    ('michaelzick+realwatersportswaves@gmail.com'),
+    ('michaelzick+warmwindssurfshopnarragansett@gmail.com'),
+    ('michaelzick+cinnamonrainbowsnorthhampton@gmail.com')
+),
+seed_users AS (
+  SELECT u.id, u.email
+  FROM auth.users u
+  JOIN seed_emails se ON se.email = u.email
+)
+SELECT 'duplicate_equipment_name_for_user' AS check_name, su.email, e.name, count(*)
+FROM seed_users su
+JOIN public.equipment e ON e.user_id = su.id
+GROUP BY su.email, e.user_id, e.name
+HAVING count(*) > 1;
+
+WITH seed_emails(email) AS (
+  VALUES
+    ('michaelzick+belleayremountainhighmount@gmail.com'),
+    ('michaelzick+highlandmountainbikeparknorthfield@gmail.com'),
+    ('michaelzick+thundermountainbikeparkcharlemont@gmail.com'),
+    ('michaelzick+ridekanugahendersonville@gmail.com'),
+    ('michaelzick+realwatersportswaves@gmail.com'),
+    ('michaelzick+warmwindssurfshopnarragansett@gmail.com'),
+    ('michaelzick+cinnamonrainbowsnorthhampton@gmail.com')
+),
+seed_users AS (
+  SELECT u.id, u.email
+  FROM auth.users u
+  JOIN seed_emails se ON se.email = u.email
+),
+image_counts AS (
+  SELECT e.id, su.email, e.name, count(ei.id) AS image_count
+  FROM seed_users su
+  JOIN public.equipment e ON e.user_id = su.id
+  LEFT JOIN public.equipment_images ei ON ei.equipment_id = e.id
+  GROUP BY e.id, su.email, e.name
+)
+SELECT 'equipment_image_count_not_two' AS check_name, email, name, image_count
+FROM image_counts
+WHERE image_count <> 2;
+
+WITH seed_emails(email) AS (
+  VALUES
+    ('michaelzick+belleayremountainhighmount@gmail.com'),
+    ('michaelzick+highlandmountainbikeparknorthfield@gmail.com'),
+    ('michaelzick+thundermountainbikeparkcharlemont@gmail.com'),
+    ('michaelzick+ridekanugahendersonville@gmail.com'),
+    ('michaelzick+realwatersportswaves@gmail.com'),
+    ('michaelzick+warmwindssurfshopnarragansett@gmail.com'),
+    ('michaelzick+cinnamonrainbowsnorthhampton@gmail.com')
+),
+seed_users AS (
+  SELECT u.id, u.email
+  FROM auth.users u
+  JOIN seed_emails se ON se.email = u.email
+)
+SELECT su.email, e.category, count(DISTINCT e.id) AS gear_count, count(ei.id) AS image_count
+FROM seed_users su
+JOIN public.equipment e ON e.user_id = su.id
+LEFT JOIN public.equipment_images ei ON ei.equipment_id = e.id
+GROUP BY su.email, e.category
+ORDER BY su.email, e.category;

--- a/supabase/migrations/20260530120000_seed_eastern_time_zone_all_categories_shops.sql
+++ b/supabase/migrations/20260530120000_seed_eastern_time_zone_all_categories_shops.sql
@@ -1,0 +1,254 @@
+-- Seed migration: Eastern Time Zone all-category shops
+-- Batch: eastern_time_zone_all_categories
+-- Created: 2026-05-30
+-- Apply to remote (human approval required):
+--   supabase db query --linked -f "/Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260530120000_seed_eastern_time_zone_all_categories_shops.sql"
+-- Do NOT use supabase db push or supabase migration up.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- =============================================
+-- EASTERN TIME ZONE ALL-CATEGORY SHOPS
+-- Shop/user inserts (auth.users + auth.identities + public.profiles + public.user_roles)
+-- Password: $uO9RX^1P%bd#8crEAM!
+-- NOTE: auth.users insert is guarded by email lookup for idempotent local testing.
+-- NOTE: user_roles upsert uses UPDATE...IF NOT FOUND THEN INSERT
+-- NOTE: profile upsert uses UPDATE...IF NOT FOUND THEN INSERT
+-- =============================================
+
+DO $$
+DECLARE
+  shop record;
+  new_user_id uuid;
+  v_avatar_url text;
+  v_hero_image_url text;
+  v_display_role text := 'retail-store';
+BEGIN
+  FOR shop IN
+    SELECT *
+    FROM (
+      VALUES
+        (
+          'Belleayre Mountain',
+          'Highmount, NY',
+          'michaelzick+belleayremountainhighmount@gmail.com',
+          'skis',
+          'https://www.belleayre.com/tickets/high-performance-demos/',
+          '(845) 254-5600',
+          '181 Galli Curci Road, Highmount, NY 12441',
+          E'Catskills ski area with an official high-performance demo program for Rossignol skis and Burton snowboards. Belleayre publishes model names, available sizes, package prices, and demo descriptions for on-site premium rentals.',
+          42.1299384,
+          -74.5060014
+        ),
+        (
+          'Highland Mountain Bike Park',
+          'Northfield, NH',
+          'michaelzick+highlandmountainbikeparknorthfield@gmail.com',
+          'mountain-bikes',
+          'https://highlandmountain.com/explore-highland/rentals-demos/rentals/',
+          '(603) 286-7677',
+          '75 Ski Hill Drive, Northfield, NH 03276',
+          E'Lift-access New Hampshire bike park with an official rental fleet. Highland publishes Santa Cruz, Specialized, Giant, and Norco rental models with full-day and half-day rates for downhill, enduro, and youth mountain bikes.',
+          43.4071495,
+          -71.5548452
+        ),
+        (
+          'Thunder Mountain Bike Park',
+          'Charlemont, MA',
+          'michaelzick+thundermountainbikeparkcharlemont@gmail.com',
+          'mountain-bikes',
+          'https://berkshireeast.com/summer/thunder-mountain-bike-park/bike-rentals?id=37',
+          '413-339-6618',
+          '66 Thunder Mountain Road, Charlemont, MA 01339',
+          E'Berkshire East mountain-bike park with official Thunder Mountain rental listings. The rental page publishes specific Scott, Santa Cruz, Transition, Yeti, and Rocky Mountain models with full-day and half-day rates.',
+          42.6225361,
+          -72.8782811
+        ),
+        (
+          'Ride Kanuga',
+          'Hendersonville, NC',
+          'michaelzick+ridekanugahendersonville@gmail.com',
+          'mountain-bikes',
+          'https://ridekanuga.com/rentals/',
+          '(828) 436-2002',
+          '1249 Kanuga Lake Road, Hendersonville, NC 28739',
+          E'Hendersonville mountain-bike park and trail center with an official Specialized e-bike rental fleet. Ride Kanuga publishes Turbo Levo model names, available sizes, full-day prices, and rental add-ons.',
+          35.2676542,
+          -82.5140571
+        ),
+        (
+          'REAL Watersports',
+          'Waves, NC',
+          'michaelzick+realwatersportswaves@gmail.com',
+          'surfboards',
+          'https://www.realwatersports.com/blogs/news/firewire-fleets-at-real',
+          '(252) 987-6000',
+          '25706 North Carolina Hwy 12, Waves, NC 27982',
+          E'Cape Hatteras surf and kite shop with an official Firewire Fleets premium surfboard rental program. REAL publishes daily and weekly rates plus Firewire model names, dimensions, and volume ranges for its Outer Banks demo quiver.',
+          35.5659701,
+          -75.4693984
+        ),
+        (
+          'Warm Winds Surf Shop',
+          'Narragansett, RI',
+          'michaelzick+warmwindssurfshopnarragansett@gmail.com',
+          'surfboards',
+          'https://www.warmwinds.com/surfboard-rentals',
+          '(401) 789-9040',
+          '26 Kingstown Road, Narragansett, RI 02882',
+          E'Rhode Island surf shop with official Firewire Fleets premium rentals and softboard rentals. Warm Winds publishes current Firewire stock, full-day and multi-day prices, and board-swap rules for its Narragansett rental program.',
+          41.4308365,
+          -71.4587796
+        ),
+        (
+          'Cinnamon Rainbows Surf Co.',
+          'North Hampton, NH',
+          'michaelzick+cinnamonrainbowsnorthhampton@gmail.com',
+          'surfboards',
+          'https://www.cinnamonrainbows.com/demos',
+          '(603) 929-7467',
+          '62 Lafayette Road, North Hampton, NH 03862',
+          E'New Hampshire surf shop with a high-end surfboard rental and demo program. Cinnamon Rainbows publishes model-level demo boards from Firewire, Channel Islands, and Pyzel with day pricing and available size notes.',
+          42.9968316,
+          -70.8158301
+        )
+    ) AS s(name, city, email, category, website, phone, address, about, lat, lng)
+  LOOP
+    IF v_display_role IN ('retail-store', 'builder') THEN
+      CASE shop.category
+        WHEN 'surfboards' THEN
+          v_avatar_url := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/73de4049-7ffd-45cd-868b-c2d0076107b3/profile-1752863282257.png';
+          v_hero_image_url := 'https://images.unsplash.com/photo-1502680390469-be75c86b636f?q=80&w=3540&auto=format&fit=crop&ixlib=rb-4.0.3';
+        WHEN 'snowboards' THEN
+          v_avatar_url := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/c5b450a8-7414-463b-b863-d78698fd0f95/profile-1752636842828.png';
+          v_hero_image_url := 'https://images.unsplash.com/photo-1590461283969-47fedf408cfd?q=80&w=2670&auto=format&fit=crop&ixlib=rb-4.1.0';
+        WHEN 'skis' THEN
+          v_avatar_url := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/7ef925ac-4b8f-496c-b4d9-10895164f03c/profile-1769637319540.png';
+          v_hero_image_url := 'https://images.unsplash.com/photo-1509791413599-93ba127a66b7?q=80&w=3540&auto=format&fit=crop&ixlib=rb-4.0.3';
+        WHEN 'mountain-bikes' THEN
+          v_avatar_url := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/ad2ad153-bb35-4e88-bfb0-d0d4f85ba62f/profile-1752637760487.png';
+          v_hero_image_url := 'https://images.unsplash.com/photo-1506316940527-4d1c138978a0?q=80&w=3512&auto=format&fit=crop&ixlib=rb-4.0.3';
+        ELSE
+          v_avatar_url := NULL;
+          v_hero_image_url := NULL;
+      END CASE;
+    ELSE
+      v_avatar_url := NULL;
+      v_hero_image_url := NULL;
+    END IF;
+
+    SELECT id INTO new_user_id
+    FROM auth.users
+    WHERE email = shop.email
+    LIMIT 1;
+
+    IF new_user_id IS NULL THEN
+      new_user_id := gen_random_uuid();
+
+      INSERT INTO auth.users (
+        id,
+        instance_id,
+        aud,
+        role,
+        email,
+        encrypted_password,
+        email_confirmed_at,
+        raw_user_meta_data,
+        raw_app_meta_data,
+        created_at,
+        updated_at,
+        confirmation_token,
+        recovery_token,
+        email_change,
+        email_change_token_current,
+        email_change_token_new,
+        email_change_confirm_status,
+        phone_change,
+        phone_change_token,
+        reauthentication_token
+      ) VALUES (
+        new_user_id,
+        '00000000-0000-0000-0000-000000000000',
+        'authenticated',
+        'authenticated',
+        shop.email,
+        crypt('$uO9RX^1P%bd#8crEAM!', gen_salt('bf')),
+        now(),
+        jsonb_build_object('name', shop.name),
+        jsonb_build_object('provider', 'email', 'providers', ARRAY['email']),
+        now(),
+        now(),
+        '',
+        '',
+        '',
+        '',
+        '',
+        0,
+        '',
+        '',
+        ''
+      );
+
+      INSERT INTO auth.identities (
+        id,
+        user_id,
+        identity_data,
+        provider,
+        provider_id,
+        last_sign_in_at,
+        created_at,
+        updated_at
+      ) VALUES (
+        gen_random_uuid(),
+        new_user_id,
+        jsonb_build_object('sub', new_user_id::text, 'email', shop.email),
+        'email',
+        new_user_id::text,
+        now(),
+        now(),
+        now()
+      );
+    END IF;
+
+    UPDATE public.profiles SET
+      name = shop.name,
+      website = shop.website,
+      phone = shop.phone,
+      address = shop.address,
+      about = shop.about,
+      location_lat = shop.lat,
+      location_lng = shop.lng,
+      avatar_url = COALESCE(v_avatar_url, avatar_url),
+      hero_image_url = COALESCE(v_hero_image_url, hero_image_url)
+    WHERE id = new_user_id;
+
+    IF NOT FOUND THEN
+      INSERT INTO public.profiles (
+        id, name, website, phone, address, about,
+        location_lat, location_lng, avatar_url, hero_image_url
+      ) VALUES (
+        new_user_id,
+        shop.name,
+        shop.website,
+        shop.phone,
+        shop.address,
+        shop.about,
+        shop.lat,
+        shop.lng,
+        v_avatar_url,
+        v_hero_image_url
+      );
+    END IF;
+
+    UPDATE public.user_roles
+      SET display_role = v_display_role
+      WHERE user_id = new_user_id;
+
+    IF NOT FOUND THEN
+      INSERT INTO public.user_roles (user_id, display_role)
+      VALUES (new_user_id, v_display_role);
+    END IF;
+
+    RAISE NOTICE 'User upserted successfully: id=%, email=%, role=%', new_user_id, shop.email, v_display_role;
+  END LOOP;
+END $$;

--- a/supabase/migrations/20260530120100_seed_eastern_time_zone_surfboards_gear.sql
+++ b/supabase/migrations/20260530120100_seed_eastern_time_zone_surfboards_gear.sql
@@ -1,0 +1,307 @@
+-- Seed migration: Eastern Time Zone surfboard gear
+-- Batch: eastern_time_zone_all_categories
+-- Created: 2026-05-30
+-- Depends on: 20260530120000_seed_eastern_time_zone_all_categories_shops.sql (apply shops first)
+-- Apply to remote (human approval required):
+--   supabase db query --linked -f "/Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260530120100_seed_eastern_time_zone_surfboards_gear.sql"
+-- Do NOT use supabase db push or supabase migration up.
+--
+-- Gear batches are category-homogeneous.
+-- Surfboards primary image:   https://images.pexels.com/photos/2370006/pexels-photo-2370006.jpeg
+-- Surfboards secondary image: https://images.pexels.com/photos/8907535/pexels-photo-8907535.jpeg
+
+-- =============================================
+-- EQUIPMENT: Eastern Time Zone surf shops - surfboards
+-- Price basis: official Firewire Fleets / surfboard demo rental pages, retrieved 2026-05-30.
+-- Coordinates sourced from OpenStreetMap/Nominatim for REAL Watersports and US Census Geocoder street-address/range matches for Warm Winds and Cinnamon Rainbows.
+-- =============================================
+DO $$
+DECLARE
+  missing_email text;
+  v_equipment_inserted int := 0;
+  v_primary_images_added int := 0;
+  v_secondary_images_added int := 0;
+BEGIN
+  SELECT seed_email INTO missing_email
+  FROM (
+    VALUES
+      (E'michaelzick+realwatersportswaves@gmail.com'),
+      (E'michaelzick+warmwindssurfshopnarragansett@gmail.com'),
+      (E'michaelzick+cinnamonrainbowsnorthhampton@gmail.com')
+  ) AS planned(seed_email)
+  WHERE NOT EXISTS (SELECT 1 FROM auth.users au WHERE au.email = planned.seed_email)
+  LIMIT 1;
+
+  IF missing_email IS NOT NULL THEN
+    RAISE EXCEPTION 'User not found for email: %', missing_email;
+  END IF;
+
+  WITH seed_equipment (seed_email, name, category, description, price_per_day, price_per_hour, price_per_week, size, weight, material, suitable_skill_level, status, location_lat, location_lng, location_address, subcategory, damage_deposit, visible_on_map) AS (
+    VALUES
+      (
+        E'michaelzick+realwatersportswaves@gmail.com',
+        E'Firewire Seaside',
+        E'surfboards',
+        E'The Firewire Seaside is a fast quad-fish shape for small to medium Outer Banks surf. REAL Watersports lists a broad Seaside size range in its Firewire Fleets quiver, making it a strong travel-board choice for everyday beach-break sessions.',
+        50.00::numeric, NULL::numeric, 200.00::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        35.5659701, -75.4693984,
+        E'25706 North Carolina Hwy 12, Waves, NC 27982',
+        E'fish', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+realwatersportswaves@gmail.com',
+        E'Firewire Groove',
+        E'surfboards',
+        E'The Firewire Groove is a punchy-wave shortboard in REAL Watersports'' Firewire Fleets quiver. It is set up for beach-break speed and control, with thruster baseline handling and quad-fin flexibility for hollower days.',
+        50.00::numeric, NULL::numeric, 200.00::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        35.5659701, -75.4693984,
+        E'25706 North Carolina Hwy 12, Waves, NC 27982',
+        E'performance shortboard', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+realwatersportswaves@gmail.com',
+        E'Firewire TJ Twinzer',
+        E'surfboards',
+        E'The Firewire TJ Twinzer is a performance mid-length demo board in REAL Watersports'' Firewire Fleets lineup. It blends early glide with a twinzer feel that can trim easily or turn hard on Outer Banks walls.',
+        50.00::numeric, NULL::numeric, 200.00::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        35.5659701, -75.4693984,
+        E'25706 North Carolina Hwy 12, Waves, NC 27982',
+        E'mid-length', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+realwatersportswaves@gmail.com',
+        E'Firewire Sunday',
+        E'surfboards',
+        E'The Firewire Sunday is a fast twin-fin mid-length in REAL Watersports'' Firewire Fleets quiver. REAL lists it as a proven small-to-medium surf option with enough volume and flow to suit a wide range of ability levels.',
+        50.00::numeric, NULL::numeric, 200.00::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        35.5659701, -75.4693984,
+        E'25706 North Carolina Hwy 12, Waves, NC 27982',
+        E'mid-length', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+realwatersportswaves@gmail.com',
+        E'Firewire The Gem',
+        E'surfboards',
+        E'The Firewire The Gem is Dan Mann''s all-around longboard shape in REAL Watersports'' Firewire Fleets program. It is built for trimming, gliding, hard turns off the tail, and softer Outer Banks days when extra paddle power helps.',
+        50.00::numeric, NULL::numeric, 200.00::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        35.5659701, -75.4693984,
+        E'25706 North Carolina Hwy 12, Waves, NC 27982',
+        E'longboard', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+warmwindssurfshopnarragansett@gmail.com',
+        E'Firewire Seaside',
+        E'surfboards',
+        E'The Firewire Seaside is part of Warm Winds Surf Shop''s premium Firewire Fleets rental stock. It is a speed-focused small-wave board that works well for New England summer surf and playful points.',
+        60.00::numeric, NULL::numeric, 200.00::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        41.4308365, -71.4587796,
+        E'26 Kingstown Road, Narragansett, RI 02882',
+        E'fish', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+warmwindssurfshopnarragansett@gmail.com',
+        E'Firewire Sweet Potato',
+        E'surfboards',
+        E'The Firewire Sweet Potato is a high-volume groveler in Warm Winds Surf Shop''s premium rental fleet. Its wide outline and easy speed make it a useful choice for softer Narragansett conditions.',
+        60.00::numeric, NULL::numeric, 200.00::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        41.4308365, -71.4587796,
+        E'26 Kingstown Road, Narragansett, RI 02882',
+        E'groveler', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+warmwindssurfshopnarragansett@gmail.com',
+        E'Firewire Dominator 2',
+        E'surfboards',
+        E'The Firewire Dominator 2 is a versatile all-around shortboard in Warm Winds Surf Shop''s Firewire Fleets stock. It gives progressing and experienced surfers a dependable board for mixed New England beach-break conditions.',
+        60.00::numeric, NULL::numeric, 200.00::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        41.4308365, -71.4587796,
+        E'26 Kingstown Road, Narragansett, RI 02882',
+        E'all-around shortboard', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+cinnamonrainbowsnorthhampton@gmail.com',
+        E'Firewire Sweet Potato',
+        E'surfboards',
+        E'The Firewire Sweet Potato is a high-end Cinnamon Rainbows demo board for weak or playful surf. The compact, wide groveler shape helps surfers keep speed when the New Hampshire beach break is soft.',
+        50.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        42.9968316, -70.8158301,
+        E'62 Lafayette Road, North Hampton, NH 03862',
+        E'groveler', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+cinnamonrainbowsnorthhampton@gmail.com',
+        E'Firewire Mashup',
+        E'surfboards',
+        E'The Firewire Mashup is a Cinnamon Rainbows demo board that blends Rob Machado and Dan Mann small-wave design ideas. It carries Seaside-inspired speed with added vertical performance for better sections.',
+        50.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        42.9968316, -70.8158301,
+        E'62 Lafayette Road, North Hampton, NH 03862',
+        E'groveler', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+cinnamonrainbowsnorthhampton@gmail.com',
+        E'Firewire S Boss',
+        E'surfboards',
+        E'The Firewire S Boss is a Cinnamon Rainbows high-end demo board for accessible performance surfing. Its forgiving outline and hidden volume make it a strong option for average-to-advanced surfers in varied Northeast surf.',
+        50.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        42.9968316, -70.8158301,
+        E'62 Lafayette Road, North Hampton, NH 03862',
+        E'performance shortboard', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+cinnamonrainbowsnorthhampton@gmail.com',
+        E'Firewire Seaside',
+        E'surfboards',
+        E'The Firewire Seaside is one of Cinnamon Rainbows'' high-end rental and demo boards. Its quad-fish speed and easy flow make it a useful demo choice for small to medium New Hampshire surf.',
+        50.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        42.9968316, -70.8158301,
+        E'62 Lafayette Road, North Hampton, NH 03862',
+        E'fish', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+cinnamonrainbowsnorthhampton@gmail.com',
+        E'Channel Islands G-Skate',
+        E'surfboards',
+        E'The Channel Islands G-Skate is a Cinnamon Rainbows high-end demo board for surfers who want skateboard-like speed and release. It fits smaller, bowly beach-break days while still giving stronger surfers room to push turns.',
+        50.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        42.9968316, -70.8158301,
+        E'62 Lafayette Road, North Hampton, NH 03862',
+        E'performance shortboard', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+cinnamonrainbowsnorthhampton@gmail.com',
+        E'Pyzel White Tiger',
+        E'surfboards',
+        E'The Pyzel White Tiger is a Cinnamon Rainbows demo board for everyday surf with enough foam to cover weaker sessions. It gives intermediate and advanced riders a lively board that still paddles well.',
+        50.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        42.9968316, -70.8158301,
+        E'62 Lafayette Road, North Hampton, NH 03862',
+        E'all-around shortboard', NULL::numeric, true
+      )
+  ),
+  inserted AS (
+    INSERT INTO public.equipment (
+      id, user_id, name, category, description,
+      price_per_day, price_per_hour, price_per_week,
+      size, weight, material, suitable_skill_level, status,
+      location_lat, location_lng, location_address, subcategory,
+      damage_deposit, visible_on_map
+    )
+    SELECT
+      gen_random_uuid(),
+      su.id,
+      s.name, s.category, s.description,
+      s.price_per_day, s.price_per_hour, s.price_per_week,
+      s.size, s.weight, s.material, s.suitable_skill_level, s.status,
+      s.location_lat, s.location_lng, s.location_address, s.subcategory,
+      s.damage_deposit, s.visible_on_map
+    FROM seed_equipment s
+    JOIN auth.users su ON su.email = s.seed_email
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment e
+      WHERE e.user_id = su.id
+        AND e.name = s.name
+    )
+    RETURNING id
+  ),
+  ins1 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT
+      i.id,
+      'https://images.pexels.com/photos/2370006/pexels-photo-2370006.jpeg',
+      0,
+      true
+    FROM inserted i
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment_images ei
+      WHERE ei.equipment_id = i.id
+        AND ei.display_order = 0
+    )
+    RETURNING equipment_id
+  ),
+  ins2 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT
+      i.id,
+      'https://images.pexels.com/photos/8907535/pexels-photo-8907535.jpeg',
+      1,
+      false
+    FROM inserted i
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment_images ei
+      WHERE ei.equipment_id = i.id
+        AND ei.display_order = 1
+    )
+    RETURNING equipment_id
+  )
+  SELECT
+    (SELECT count(*) FROM inserted),
+    (SELECT count(*) FROM ins1),
+    (SELECT count(*) FROM ins2)
+  INTO
+    v_equipment_inserted,
+    v_primary_images_added,
+    v_secondary_images_added;
+
+  RAISE NOTICE 'Eastern Time Zone surfboards inserted=%, primary_images_added=%, secondary_images_added=%',
+    v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+END $$;

--- a/supabase/migrations/20260530120200_seed_eastern_time_zone_skis_gear.sql
+++ b/supabase/migrations/20260530120200_seed_eastern_time_zone_skis_gear.sql
@@ -1,0 +1,180 @@
+-- Seed migration: Eastern Time Zone ski gear
+-- Batch: eastern_time_zone_all_categories
+-- Created: 2026-05-30
+-- Depends on: 20260530120000_seed_eastern_time_zone_all_categories_shops.sql (apply shops first)
+-- Apply to remote (human approval required):
+--   supabase db query --linked -f "/Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260530120200_seed_eastern_time_zone_skis_gear.sql"
+-- Do NOT use supabase db push or supabase migration up.
+--
+-- Gear batches are category-homogeneous.
+-- Skis primary image:   https://images.pexels.com/photos/848699/pexels-photo-848699.jpeg
+-- Skis secondary image: https://images.pexels.com/photos/36084973/pexels-photo-36084973.jpeg
+
+-- =============================================
+-- EQUIPMENT: Belleayre Mountain (Highmount, NY) - skis
+-- Email: michaelzick+belleayremountainhighmount@gmail.com
+-- Price basis: belleayre.com/tickets/high-performance-demos, Rossignol adult ski-only demo day rate, retrieved 2026-05-30.
+-- Coordinates sourced from OpenStreetMap/Nominatim place match for Belleayre Mountain Ski Center.
+-- =============================================
+DO $$
+DECLARE
+  missing_email text;
+  v_equipment_inserted int := 0;
+  v_primary_images_added int := 0;
+  v_secondary_images_added int := 0;
+BEGIN
+  SELECT seed_email INTO missing_email
+  FROM (
+    VALUES
+      (E'michaelzick+belleayremountainhighmount@gmail.com')
+  ) AS planned(seed_email)
+  WHERE NOT EXISTS (SELECT 1 FROM auth.users au WHERE au.email = planned.seed_email)
+  LIMIT 1;
+
+  IF missing_email IS NOT NULL THEN
+    RAISE EXCEPTION 'User not found for email: %', missing_email;
+  END IF;
+
+  WITH seed_equipment (seed_email, name, category, description, price_per_day, price_per_hour, price_per_week, size, weight, material, suitable_skill_level, status, location_lat, location_lng, location_address, subcategory, damage_deposit, visible_on_map) AS (
+    VALUES
+      (
+        E'michaelzick+belleayremountainhighmount@gmail.com',
+        E'Rossignol Hero Elite MT TI C.A.M',
+        E'skis',
+        E'The Rossignol Hero Elite MT TI C.A.M is Belleayre''s race-inspired high-performance ski demo. It is built for precise on-trail turns and strong edge hold for skiers who want a quicker, more powerful carver.',
+        70.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        42.1299384, -74.5060014,
+        E'181 Galli Curci Road, Highmount, NY 12441',
+        E'frontside carver', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+belleayremountainhighmount@gmail.com',
+        E'Rossignol Forza 70 V-Ti',
+        E'skis',
+        E'The Rossignol Forza 70 V-Ti is Belleayre''s expert-focused carving demo ski. Its wide platform and race-proven construction support high-speed arcs and committed frontside turns.',
+        70.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        42.1299384, -74.5060014,
+        E'181 Galli Curci Road, Highmount, NY 12441',
+        E'frontside carver', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+belleayremountainhighmount@gmail.com',
+        E'Rossignol Forza 60 Ti',
+        E'skis',
+        E'The Rossignol Forza 60 Ti is a Belleayre on-piste demo ski for confident intermediate and advanced riders. It balances edge precision with approachable control for skiers working on stronger carving technique.',
+        70.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        42.1299384, -74.5060014,
+        E'181 Galli Curci Road, Highmount, NY 12441',
+        E'frontside carver', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+belleayremountainhighmount@gmail.com',
+        E'Rossignol Sender Soul 102',
+        E'skis',
+        E'The Rossignol Sender Soul 102 is Belleayre''s freeride demo for mixed snow and soft-snow days. It has enough width for fresh snow while staying versatile for trees, soft groomers, and variable afternoon conditions.',
+        70.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        42.1299384, -74.5060014,
+        E'181 Galli Curci Road, Highmount, NY 12441',
+        E'freeride', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+belleayremountainhighmount@gmail.com',
+        E'Rossignol Arcade 84',
+        E'skis',
+        E'The Rossignol Arcade 84 is Belleayre''s all-mountain demo ski for advanced riders who want one ski for changing resort conditions. It blends frontside carving energy with enough width and rocker for mixed terrain.',
+        70.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        42.1299384, -74.5060014,
+        E'181 Galli Curci Road, Highmount, NY 12441',
+        E'all-mountain', NULL::numeric, true
+      )
+  ),
+  inserted AS (
+    INSERT INTO public.equipment (
+      id, user_id, name, category, description,
+      price_per_day, price_per_hour, price_per_week,
+      size, weight, material, suitable_skill_level, status,
+      location_lat, location_lng, location_address, subcategory,
+      damage_deposit, visible_on_map
+    )
+    SELECT
+      gen_random_uuid(),
+      su.id,
+      s.name, s.category, s.description,
+      s.price_per_day, s.price_per_hour, s.price_per_week,
+      s.size, s.weight, s.material, s.suitable_skill_level, s.status,
+      s.location_lat, s.location_lng, s.location_address, s.subcategory,
+      s.damage_deposit, s.visible_on_map
+    FROM seed_equipment s
+    JOIN auth.users su ON su.email = s.seed_email
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment e
+      WHERE e.user_id = su.id
+        AND e.name = s.name
+    )
+    RETURNING id
+  ),
+  ins1 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT
+      i.id,
+      'https://images.pexels.com/photos/848699/pexels-photo-848699.jpeg',
+      0,
+      true
+    FROM inserted i
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment_images ei
+      WHERE ei.equipment_id = i.id
+        AND ei.display_order = 0
+    )
+    RETURNING equipment_id
+  ),
+  ins2 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT
+      i.id,
+      'https://images.pexels.com/photos/36084973/pexels-photo-36084973.jpeg',
+      1,
+      false
+    FROM inserted i
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment_images ei
+      WHERE ei.equipment_id = i.id
+        AND ei.display_order = 1
+    )
+    RETURNING equipment_id
+  )
+  SELECT
+    (SELECT count(*) FROM inserted),
+    (SELECT count(*) FROM ins1),
+    (SELECT count(*) FROM ins2)
+  INTO
+    v_equipment_inserted,
+    v_primary_images_added,
+    v_secondary_images_added;
+
+  RAISE NOTICE 'Belleayre Mountain skis inserted=%, primary_images_added=%, secondary_images_added=%',
+    v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+END $$;

--- a/supabase/migrations/20260530120300_seed_eastern_time_zone_snowboards_gear.sql
+++ b/supabase/migrations/20260530120300_seed_eastern_time_zone_snowboards_gear.sql
@@ -1,0 +1,138 @@
+-- Seed migration: Eastern Time Zone snowboard gear
+-- Batch: eastern_time_zone_all_categories
+-- Created: 2026-05-30
+-- Depends on: 20260530120000_seed_eastern_time_zone_all_categories_shops.sql (apply shops first)
+-- Apply to remote (human approval required):
+--   supabase db query --linked -f "/Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260530120300_seed_eastern_time_zone_snowboards_gear.sql"
+-- Do NOT use supabase db push or supabase migration up.
+--
+-- Gear batches are category-homogeneous.
+-- Snowboards primary image:   https://images.pexels.com/photos/7406683/pexels-photo-7406683.jpeg
+-- Snowboards secondary image: https://images.pexels.com/photos/7166118/pexels-photo-7166118.jpeg
+
+-- =============================================
+-- EQUIPMENT: Belleayre Mountain (Highmount, NY) - snowboards
+-- Email: michaelzick+belleayremountainhighmount@gmail.com
+-- Price basis: belleayre.com/tickets/high-performance-demos, adult snowboard demo package day rate, retrieved 2026-05-30.
+-- Coordinates sourced from OpenStreetMap/Nominatim place match for Belleayre Mountain Ski Center.
+-- =============================================
+DO $$
+DECLARE
+  missing_email text;
+  v_equipment_inserted int := 0;
+  v_primary_images_added int := 0;
+  v_secondary_images_added int := 0;
+BEGIN
+  SELECT seed_email INTO missing_email
+  FROM (
+    VALUES
+      (E'michaelzick+belleayremountainhighmount@gmail.com')
+  ) AS planned(seed_email)
+  WHERE NOT EXISTS (SELECT 1 FROM auth.users au WHERE au.email = planned.seed_email)
+  LIMIT 1;
+
+  IF missing_email IS NOT NULL THEN
+    RAISE EXCEPTION 'User not found for email: %', missing_email;
+  END IF;
+
+  WITH seed_equipment (seed_email, name, category, description, price_per_day, price_per_hour, price_per_week, size, weight, material, suitable_skill_level, status, location_lat, location_lng, location_address, subcategory, damage_deposit, visible_on_map) AS (
+    VALUES
+      (
+        E'michaelzick+belleayremountainhighmount@gmail.com',
+        E'Burton Custom',
+        E'snowboards',
+        E'The Burton Custom is Belleayre''s men''s all-mountain snowboard demo with Step On bindings. It is a poppy, versatile camber board for riders who want a responsive platform across groomers, side hits, and mixed resort terrain.',
+        80.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        42.1299384, -74.5060014,
+        E'181 Galli Curci Road, Highmount, NY 12441',
+        E'all-mountain', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+belleayremountainhighmount@gmail.com',
+        E'Burton Feelgood',
+        E'snowboards',
+        E'The Burton Feelgood is Belleayre''s women''s all-mountain snowboard demo with Step On bindings. Its camber feel, directional shaping, and powerful edge response make it a strong board for riders chasing lines and natural hits.',
+        80.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        42.1299384, -74.5060014,
+        E'181 Galli Curci Road, Highmount, NY 12441',
+        E'all-mountain', NULL::numeric, true
+      )
+  ),
+  inserted AS (
+    INSERT INTO public.equipment (
+      id, user_id, name, category, description,
+      price_per_day, price_per_hour, price_per_week,
+      size, weight, material, suitable_skill_level, status,
+      location_lat, location_lng, location_address, subcategory,
+      damage_deposit, visible_on_map
+    )
+    SELECT
+      gen_random_uuid(),
+      su.id,
+      s.name, s.category, s.description,
+      s.price_per_day, s.price_per_hour, s.price_per_week,
+      s.size, s.weight, s.material, s.suitable_skill_level, s.status,
+      s.location_lat, s.location_lng, s.location_address, s.subcategory,
+      s.damage_deposit, s.visible_on_map
+    FROM seed_equipment s
+    JOIN auth.users su ON su.email = s.seed_email
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment e
+      WHERE e.user_id = su.id
+        AND e.name = s.name
+    )
+    RETURNING id
+  ),
+  ins1 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT
+      i.id,
+      'https://images.pexels.com/photos/7406683/pexels-photo-7406683.jpeg',
+      0,
+      true
+    FROM inserted i
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment_images ei
+      WHERE ei.equipment_id = i.id
+        AND ei.display_order = 0
+    )
+    RETURNING equipment_id
+  ),
+  ins2 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT
+      i.id,
+      'https://images.pexels.com/photos/7166118/pexels-photo-7166118.jpeg',
+      1,
+      false
+    FROM inserted i
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment_images ei
+      WHERE ei.equipment_id = i.id
+        AND ei.display_order = 1
+    )
+    RETURNING equipment_id
+  )
+  SELECT
+    (SELECT count(*) FROM inserted),
+    (SELECT count(*) FROM ins1),
+    (SELECT count(*) FROM ins2)
+  INTO
+    v_equipment_inserted,
+    v_primary_images_added,
+    v_secondary_images_added;
+
+  RAISE NOTICE 'Belleayre Mountain snowboards inserted=%, primary_images_added=%, secondary_images_added=%',
+    v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+END $$;

--- a/supabase/migrations/20260530120400_seed_eastern_time_zone_mountain_bikes_gear.sql
+++ b/supabase/migrations/20260530120400_seed_eastern_time_zone_mountain_bikes_gear.sql
@@ -1,0 +1,377 @@
+-- Seed migration: Eastern Time Zone mountain-bike gear
+-- Batch: eastern_time_zone_all_categories
+-- Created: 2026-05-30
+-- Depends on: 20260530120000_seed_eastern_time_zone_all_categories_shops.sql (apply shops first)
+-- Apply to remote (human approval required):
+--   supabase db query --linked -f "/Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260530120400_seed_eastern_time_zone_mountain_bikes_gear.sql"
+-- Do NOT use supabase db push or supabase migration up.
+--
+-- Gear batches are category-homogeneous.
+-- Mountain-bikes primary image:   https://images.pexels.com/photos/30447388/pexels-photo-30447388.jpeg
+-- Mountain-bikes secondary image: https://images.pexels.com/photos/25753440/pexels-photo-25753440.jpeg
+
+-- =============================================
+-- EQUIPMENT: Eastern Time Zone bike parks - mountain-bikes
+-- Price basis: official bike-rental pages for Highland Mountain Bike Park, Thunder Mountain Bike Park, and Ride Kanuga, retrieved 2026-05-30.
+-- Coordinates sourced from US Census Geocoder street-address/range matches.
+-- =============================================
+DO $$
+DECLARE
+  missing_email text;
+  v_equipment_inserted int := 0;
+  v_primary_images_added int := 0;
+  v_secondary_images_added int := 0;
+BEGIN
+  SELECT seed_email INTO missing_email
+  FROM (
+    VALUES
+      (E'michaelzick+highlandmountainbikeparknorthfield@gmail.com'),
+      (E'michaelzick+thundermountainbikeparkcharlemont@gmail.com'),
+      (E'michaelzick+ridekanugahendersonville@gmail.com')
+  ) AS planned(seed_email)
+  WHERE NOT EXISTS (SELECT 1 FROM auth.users au WHERE au.email = planned.seed_email)
+  LIMIT 1;
+
+  IF missing_email IS NOT NULL THEN
+    RAISE EXCEPTION 'User not found for email: %', missing_email;
+  END IF;
+
+  WITH seed_equipment (seed_email, name, category, description, price_per_day, price_per_hour, price_per_week, size, weight, material, suitable_skill_level, status, location_lat, location_lng, location_address, subcategory, damage_deposit, visible_on_map) AS (
+    VALUES
+      (
+        E'michaelzick+highlandmountainbikeparknorthfield@gmail.com',
+        E'Santa Cruz V10',
+        E'mountain-bikes',
+        E'The Santa Cruz V10 is Highland Mountain Bike Park''s premium downhill rental. It is a lift-access race bike for steep park laps, rough braking bumps, and riders who want maximum stability at speed.',
+        150.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        43.4071495, -71.5548452,
+        E'75 Ski Hill Drive, Northfield, NH 03276',
+        E'downhill', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+highlandmountainbikeparknorthfield@gmail.com',
+        E'Specialized Status 2 170 DH',
+        E'mountain-bikes',
+        E'The Specialized Status 2 170 DH is Highland''s full-day downhill rental for bike-park terrain. It gives riders a gravity-focused platform with long travel and confident handling for chairlift laps.',
+        130.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        43.4071495, -71.5548452,
+        E'75 Ski Hill Drive, Northfield, NH 03276',
+        E'downhill', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+highlandmountainbikeparknorthfield@gmail.com',
+        E'Santa Cruz Bronson',
+        E'mountain-bikes',
+        E'The Santa Cruz Bronson is one of Highland''s premium enduro all-mountain rentals. It is built for riders who want a playful bike that still has enough travel for technical descents and park features.',
+        150.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        43.4071495, -71.5548452,
+        E'75 Ski Hill Drive, Northfield, NH 03276',
+        E'enduro', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+highlandmountainbikeparknorthfield@gmail.com',
+        E'Santa Cruz Megatower',
+        E'mountain-bikes',
+        E'The Santa Cruz Megatower is a premium Highland enduro rental for high-speed descents and rough trails. It suits riders who want a composed all-mountain bike with enough travel for aggressive park days.',
+        150.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        43.4071495, -71.5548452,
+        E'75 Ski Hill Drive, Northfield, NH 03276',
+        E'enduro', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+highlandmountainbikeparknorthfield@gmail.com',
+        E'Santa Cruz Nomad',
+        E'mountain-bikes',
+        E'The Santa Cruz Nomad is a premium Highland all-mountain rental with a freeride-friendly feel. It is a strong fit for riders mixing jump lines, chunky descents, and technical park laps.',
+        150.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        43.4071495, -71.5548452,
+        E'75 Ski Hill Drive, Northfield, NH 03276',
+        E'enduro', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+highlandmountainbikeparknorthfield@gmail.com',
+        E'Giant Reign',
+        E'mountain-bikes',
+        E'The Giant Reign is a Highland enduro all-mountain rental for riders who want dependable suspension travel without moving into the premium tier. It works well for bike-park laps, rough descents, and mixed terrain.',
+        130.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        43.4071495, -71.5548452,
+        E'75 Ski Hill Drive, Northfield, NH 03276',
+        E'enduro', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+highlandmountainbikeparknorthfield@gmail.com',
+        E'Norco Fluid',
+        E'mountain-bikes',
+        E'The Norco Fluid is part of Highland''s youth rental lineup. It gives younger riders a real trail-bike platform for learning bike-park skills with an appropriately sized full-suspension setup.',
+        130.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        43.4071495, -71.5548452,
+        E'75 Ski Hill Drive, Northfield, NH 03276',
+        E'youth trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+highlandmountainbikeparknorthfield@gmail.com',
+        E'Norco Sight',
+        E'mountain-bikes',
+        E'The Norco Sight is part of Highland''s youth and smaller-rider rental options. It offers trail-bike capability for progressing riders who need a smaller park-ready setup.',
+        130.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        43.4071495, -71.5548452,
+        E'75 Ski Hill Drive, Northfield, NH 03276',
+        E'youth trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thundermountainbikeparkcharlemont@gmail.com',
+        E'Scott Gambler 920',
+        E'mountain-bikes',
+        E'The Scott Gambler 920 is Thunder Mountain Bike Park''s downhill rental option for gravity laps. It is a full-on park bike for riders who want a stable platform on lift-served descents.',
+        145.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        42.6225361, -72.8782811,
+        E'66 Thunder Mountain Road, Charlemont, MA 01339',
+        E'downhill', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thundermountainbikeparkcharlemont@gmail.com',
+        E'Santa Cruz V10 29',
+        E'mountain-bikes',
+        E'The Santa Cruz V10 29 is one of Thunder Mountain''s premium downhill rentals. It is built for fast lift-access terrain and riders who want a race-proven platform with big-wheel speed.',
+        160.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        42.6225361, -72.8782811,
+        E'66 Thunder Mountain Road, Charlemont, MA 01339',
+        E'downhill', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thundermountainbikeparkcharlemont@gmail.com',
+        E'Transition TR11',
+        E'mountain-bikes',
+        E'The Transition TR11 is a Thunder Mountain premium downhill rental for bike-park terrain. It is a purpose-built gravity bike for riders who want a playful but capable setup on rough descents and jump lines.',
+        160.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        42.6225361, -72.8782811,
+        E'66 Thunder Mountain Road, Charlemont, MA 01339',
+        E'downhill', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thundermountainbikeparkcharlemont@gmail.com',
+        E'Yeti SB160',
+        E'mountain-bikes',
+        E'The Yeti SB160 is part of Thunder Mountain''s premium enduro demo fleet. It suits riders who want a pedal-capable enduro bike that still feels composed on steep park trails.',
+        160.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        42.6225361, -72.8782811,
+        E'66 Thunder Mountain Road, Charlemont, MA 01339',
+        E'enduro', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thundermountainbikeparkcharlemont@gmail.com',
+        E'Yeti SB165',
+        E'mountain-bikes',
+        E'The Yeti SB165 is part of Thunder Mountain''s premium enduro demo fleet. It gives aggressive riders a long-travel platform for steep, rough, and jump-heavy bike-park days.',
+        160.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        42.6225361, -72.8782811,
+        E'66 Thunder Mountain Road, Charlemont, MA 01339',
+        E'enduro', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thundermountainbikeparkcharlemont@gmail.com',
+        E'Transition Patrol',
+        E'mountain-bikes',
+        E'The Transition Patrol is a Thunder Mountain premium enduro rental. It is a freeride-leaning all-mountain bike for riders who want stability on chunky descents with enough pop for park features.',
+        160.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        42.6225361, -72.8782811,
+        E'66 Thunder Mountain Road, Charlemont, MA 01339',
+        E'enduro', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thundermountainbikeparkcharlemont@gmail.com',
+        E'Rocky Mountain Instinct',
+        E'mountain-bikes',
+        E'The Rocky Mountain Instinct is Thunder Mountain''s trail rental option for smaller riders. It gives riders a full-suspension platform for smoother park trails, progression laps, and all-mountain control.',
+        110.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        42.6225361, -72.8782811,
+        E'66 Thunder Mountain Road, Charlemont, MA 01339',
+        E'trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+thundermountainbikeparkcharlemont@gmail.com',
+        E'Rocky Mountain Reaper',
+        E'mountain-bikes',
+        E'The Rocky Mountain Reaper is Thunder Mountain''s youth rental bike for junior riders. It gives younger riders real suspension and trail geometry for bike-park progression.',
+        105.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        42.6225361, -72.8782811,
+        E'66 Thunder Mountain Road, Charlemont, MA 01339',
+        E'youth trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+ridekanugahendersonville@gmail.com',
+        E'Specialized Turbo Levo Gen 4 Premium',
+        E'mountain-bikes',
+        E'The Specialized Turbo Levo Gen 4 Premium is Ride Kanuga''s top e-bike rental. It gives riders pedal-assist range and modern trail capability for a full day on Kanuga''s climbing and descending network.',
+        149.00::numeric, NULL::numeric, NULL::numeric,
+        E'Small, Medium, Large, XL',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        35.2676542, -82.5140571,
+        E'1249 Kanuga Lake Road, Hendersonville, NC 28739',
+        E'e-mountain bike', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+ridekanugahendersonville@gmail.com',
+        E'Specialized Turbo Levo',
+        E'mountain-bikes',
+        E'The Specialized Turbo Levo is Ride Kanuga''s standard e-bike rental for full-day trail access. It is a pedal-assist mountain bike for riders who want extra range on the climb before descending Kanuga''s gravity trails.',
+        129.00::numeric, NULL::numeric, NULL::numeric,
+        E'XS',
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        35.2676542, -82.5140571,
+        E'1249 Kanuga Lake Road, Hendersonville, NC 28739',
+        E'e-mountain bike', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+ridekanugahendersonville@gmail.com',
+        E'Specialized Turbo Levo SL Kids',
+        E'mountain-bikes',
+        E'The Specialized Turbo Levo SL Kids is Ride Kanuga''s youth e-bike rental. It gives younger riders pedal-assist support for the climb and a lighter trail platform for full-day park sessions.',
+        99.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text,
+        NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        35.2676542, -82.5140571,
+        E'1249 Kanuga Lake Road, Hendersonville, NC 28739',
+        E'youth e-mountain bike', NULL::numeric, true
+      )
+  ),
+  inserted AS (
+    INSERT INTO public.equipment (
+      id, user_id, name, category, description,
+      price_per_day, price_per_hour, price_per_week,
+      size, weight, material, suitable_skill_level, status,
+      location_lat, location_lng, location_address, subcategory,
+      damage_deposit, visible_on_map
+    )
+    SELECT
+      gen_random_uuid(),
+      su.id,
+      s.name, s.category, s.description,
+      s.price_per_day, s.price_per_hour, s.price_per_week,
+      s.size, s.weight, s.material, s.suitable_skill_level, s.status,
+      s.location_lat, s.location_lng, s.location_address, s.subcategory,
+      s.damage_deposit, s.visible_on_map
+    FROM seed_equipment s
+    JOIN auth.users su ON su.email = s.seed_email
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment e
+      WHERE e.user_id = su.id
+        AND e.name = s.name
+    )
+    RETURNING id
+  ),
+  ins1 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT
+      i.id,
+      'https://images.pexels.com/photos/30447388/pexels-photo-30447388.jpeg',
+      0,
+      true
+    FROM inserted i
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment_images ei
+      WHERE ei.equipment_id = i.id
+        AND ei.display_order = 0
+    )
+    RETURNING equipment_id
+  ),
+  ins2 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT
+      i.id,
+      'https://images.pexels.com/photos/25753440/pexels-photo-25753440.jpeg',
+      1,
+      false
+    FROM inserted i
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment_images ei
+      WHERE ei.equipment_id = i.id
+        AND ei.display_order = 1
+    )
+    RETURNING equipment_id
+  )
+  SELECT
+    (SELECT count(*) FROM inserted),
+    (SELECT count(*) FROM ins1),
+    (SELECT count(*) FROM ins2)
+  INTO
+    v_equipment_inserted,
+    v_primary_images_added,
+    v_secondary_images_added;
+
+  RAISE NOTICE 'Eastern Time Zone mountain bikes inserted=%, primary_images_added=%, secondary_images_added=%',
+    v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+END $$;


### PR DESCRIPTION
## Summary

Turns the Eastern Time Zone seed work into a local-only, ready-to-apply package for `main`.

- **7 accepted shops across EST states**: Belleayre Mountain, Highland Mountain Bike Park, Thunder Mountain Bike Park, Ride Kanuga, REAL Watersports, Warm Winds Surf Shop, and Cinnamon Rainbows Surf Co.
- **Category coverage across all requested gear types**: skis, snowboards, surfboards, and mountain bikes, organized into separate migration files.
- **Duplicate protection**: the seed SQL checks linked DB state first and uses idempotent `WHERE NOT EXISTS` guards so existing shops and equipment are not reinserted.
- **Audit trail for the batch**: added discovery notes, rejected-candidate notes, a remote runbook, a validation script, and a remote validation report under `demostoke_seed_batches/eastern_time_zone_all_categories/`.
- **Agent memory sync**: updated `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` so the pending local batch is documented consistently.

## Testing

- Static SQL safety checks passed: no `DELETE`, `TRUNCATE`, `DROP`, `ALTER TABLE`, `ON CONFLICT`, or `specs` usage in the seed migrations.
- Generated artifacts passed the ASCII check and `git diff --check`.
- Read-only linked DB review was used to exclude existing Eastern Time Zone shops before writing the local seed files.
- Not run (not requested): applying the migrations to the linked Supabase project.