### PR TITLE
Apply pending timezone seed migrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,7 +252,7 @@ Do not substitute other image sources for seed data. If new categories are added
 
 ## Seed Data — Current Seeded Shops
 
-This summary reflects read-only linked DemoStoke data checks after the May 24, 2026 Canada seed apply. The Wax Bench row is an existing live profile retargeted by the Canada batch; its gear count is the current profile count after 17 inserts and 11 updates, not a newly created shop.
+This summary reflects read-only linked DemoStoke data checks after the June 1, 2026 U.S. Eastern, Hawaii, Mountain, and Central seed applies. The Wax Bench row is an existing live profile retargeted by the Canada batch; its gear count is the current profile count after 17 inserts and 11 updates, not a newly created shop.
 
 | # | Shop | Region | Category | Gear | Status |
 |---|---|---|---|---|---|
@@ -286,7 +286,30 @@ This summary reflects read-only linked DemoStoke data checks after the May 24, 2
 | 28 | Mont-Sainte-Anne Sports Alpins | Beaupre, QC | mountain-bikes | 6 | applied |
 | 29 | Vallee Bras-du-Nord Shannahan | Saint-Raymond, QC | mountain-bikes | 3 | applied |
 | 30 | The Wax Bench | Revelstoke, BC | skis + snowboards | 48 | existing profile retargeted; applied |
-| | **Total** | | | **244** | |
+| 31 | Belleayre Mountain | Highmount, NY | skis + snowboards | 7 | applied |
+| 32 | Highland Mountain Bike Park | Northfield, NH | mountain-bikes | 8 | applied |
+| 33 | Thunder Mountain Bike Park | Charlemont, MA | mountain-bikes | 8 | applied |
+| 34 | Ride Kanuga | Hendersonville, NC | mountain-bikes | 3 | applied |
+| 35 | REAL Watersports | Waves, NC | surfboards | 5 | applied |
+| 36 | Warm Winds Surf Shop | Narragansett, RI | surfboards | 3 | applied |
+| 37 | Cinnamon Rainbows Surf Co. | North Hampton, NH | surfboards | 6 | applied |
+| 38 | Hawaiian South Shore | Honolulu, HI | surfboards | 15 | applied |
+| 39 | Clips Hawaii | Honolulu, HI | surfboards | 39 | applied |
+| 40 | Haleiwa Surf Shop | Haleiwa, HI | surfboards | 29 | applied |
+| 41 | Kauai Surfboard Rentals | Hanalei, HI | surfboards | 121 | applied |
+| 42 | Hanalei Surfboard Rentals | Hanalei, HI | surfboards | 31 | applied |
+| 43 | Maui Sunriders Kihei Bike Shop | Kihei, HI | mountain-bikes | 2 | applied |
+| 44 | Maui Sunriders Kapalua Bike Shop | Lahaina, HI | mountain-bikes | 4 | applied |
+| 45 | Bike Maui | Haiku, HI | mountain-bikes | 3 | applied |
+| 46 | Big Island Bike Tours | Waimea, HI | mountain-bikes | 3 | applied |
+| 47 | Dan Bailey's Outdoor Co. | Livingston, MT | mountain-bikes | 2 | applied |
+| 48 | proVelo Bicycles | Fort Collins, CO | mountain-bikes | 6 | applied |
+| 49 | Habitat Dirt + Snow Grand Targhee | Alta, WY | mountain-bikes | 2 | applied |
+| 50 | Village Ski Shop | Angel Fire, NM | skis + snowboards | 20 | applied |
+| 51 | Arizona Snowbowl Agassiz Pro Shop | Flagstaff, AZ | skis + snowboards | 20 | applied |
+| 52 | Deer Valley Resort Ski Rentals | Park City, UT | skis | 6 | applied |
+| 53 | Hi Tempo | White Bear Lake, MN | skis | 22 | applied |
+| | **Total** | | | **609** | |
 
 Do not re-seed any shop already in this table. Do not seed Hawaii Surfboard Rentals under any Hawaii discovery task.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,7 +252,7 @@ Do not substitute other image sources for seed data. If new categories are added
 
 ## Seed Data — Current Seeded Shops
 
-This summary reflects read-only linked DemoStoke data checks after the May 24, 2026 Canada seed apply. The Wax Bench row is an existing live profile retargeted by the Canada batch; its gear count is the current profile count after 17 inserts and 11 updates, not a newly created shop.
+This summary reflects read-only linked DemoStoke data checks after the June 1, 2026 U.S. Eastern, Hawaii, Mountain, and Central seed applies. The Wax Bench row is an existing live profile retargeted by the Canada batch; its gear count is the current profile count after 17 inserts and 11 updates, not a newly created shop.
 
 | # | Shop | Region | Category | Gear | Status |
 |---|---|---|---|---|---|
@@ -286,7 +286,30 @@ This summary reflects read-only linked DemoStoke data checks after the May 24, 2
 | 28 | Mont-Sainte-Anne Sports Alpins | Beaupre, QC | mountain-bikes | 6 | applied |
 | 29 | Vallee Bras-du-Nord Shannahan | Saint-Raymond, QC | mountain-bikes | 3 | applied |
 | 30 | The Wax Bench | Revelstoke, BC | skis + snowboards | 48 | existing profile retargeted; applied |
-| | **Total** | | | **244** | |
+| 31 | Belleayre Mountain | Highmount, NY | skis + snowboards | 7 | applied |
+| 32 | Highland Mountain Bike Park | Northfield, NH | mountain-bikes | 8 | applied |
+| 33 | Thunder Mountain Bike Park | Charlemont, MA | mountain-bikes | 8 | applied |
+| 34 | Ride Kanuga | Hendersonville, NC | mountain-bikes | 3 | applied |
+| 35 | REAL Watersports | Waves, NC | surfboards | 5 | applied |
+| 36 | Warm Winds Surf Shop | Narragansett, RI | surfboards | 3 | applied |
+| 37 | Cinnamon Rainbows Surf Co. | North Hampton, NH | surfboards | 6 | applied |
+| 38 | Hawaiian South Shore | Honolulu, HI | surfboards | 15 | applied |
+| 39 | Clips Hawaii | Honolulu, HI | surfboards | 39 | applied |
+| 40 | Haleiwa Surf Shop | Haleiwa, HI | surfboards | 29 | applied |
+| 41 | Kauai Surfboard Rentals | Hanalei, HI | surfboards | 121 | applied |
+| 42 | Hanalei Surfboard Rentals | Hanalei, HI | surfboards | 31 | applied |
+| 43 | Maui Sunriders Kihei Bike Shop | Kihei, HI | mountain-bikes | 2 | applied |
+| 44 | Maui Sunriders Kapalua Bike Shop | Lahaina, HI | mountain-bikes | 4 | applied |
+| 45 | Bike Maui | Haiku, HI | mountain-bikes | 3 | applied |
+| 46 | Big Island Bike Tours | Waimea, HI | mountain-bikes | 3 | applied |
+| 47 | Dan Bailey's Outdoor Co. | Livingston, MT | mountain-bikes | 2 | applied |
+| 48 | proVelo Bicycles | Fort Collins, CO | mountain-bikes | 6 | applied |
+| 49 | Habitat Dirt + Snow Grand Targhee | Alta, WY | mountain-bikes | 2 | applied |
+| 50 | Village Ski Shop | Angel Fire, NM | skis + snowboards | 20 | applied |
+| 51 | Arizona Snowbowl Agassiz Pro Shop | Flagstaff, AZ | skis + snowboards | 20 | applied |
+| 52 | Deer Valley Resort Ski Rentals | Park City, UT | skis | 6 | applied |
+| 53 | Hi Tempo | White Bear Lake, MN | skis | 22 | applied |
+| | **Total** | | | **609** | |
 
 Do not re-seed any shop already in this table. Do not seed Hawaii Surfboard Rentals under any Hawaii discovery task.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -252,7 +252,7 @@ Do not substitute other image sources for seed data. If new categories are added
 
 ## Seed Data — Current Seeded Shops
 
-This summary reflects read-only linked DemoStoke data checks after the May 24, 2026 Canada seed apply. The Wax Bench row is an existing live profile retargeted by the Canada batch; its gear count is the current profile count after 17 inserts and 11 updates, not a newly created shop.
+This summary reflects read-only linked DemoStoke data checks after the June 1, 2026 U.S. Eastern, Hawaii, Mountain, and Central seed applies. The Wax Bench row is an existing live profile retargeted by the Canada batch; its gear count is the current profile count after 17 inserts and 11 updates, not a newly created shop.
 
 | # | Shop | Region | Category | Gear | Status |
 |---|---|---|---|---|---|
@@ -286,7 +286,30 @@ This summary reflects read-only linked DemoStoke data checks after the May 24, 2
 | 28 | Mont-Sainte-Anne Sports Alpins | Beaupre, QC | mountain-bikes | 6 | applied |
 | 29 | Vallee Bras-du-Nord Shannahan | Saint-Raymond, QC | mountain-bikes | 3 | applied |
 | 30 | The Wax Bench | Revelstoke, BC | skis + snowboards | 48 | existing profile retargeted; applied |
-| | **Total** | | | **244** | |
+| 31 | Belleayre Mountain | Highmount, NY | skis + snowboards | 7 | applied |
+| 32 | Highland Mountain Bike Park | Northfield, NH | mountain-bikes | 8 | applied |
+| 33 | Thunder Mountain Bike Park | Charlemont, MA | mountain-bikes | 8 | applied |
+| 34 | Ride Kanuga | Hendersonville, NC | mountain-bikes | 3 | applied |
+| 35 | REAL Watersports | Waves, NC | surfboards | 5 | applied |
+| 36 | Warm Winds Surf Shop | Narragansett, RI | surfboards | 3 | applied |
+| 37 | Cinnamon Rainbows Surf Co. | North Hampton, NH | surfboards | 6 | applied |
+| 38 | Hawaiian South Shore | Honolulu, HI | surfboards | 15 | applied |
+| 39 | Clips Hawaii | Honolulu, HI | surfboards | 39 | applied |
+| 40 | Haleiwa Surf Shop | Haleiwa, HI | surfboards | 29 | applied |
+| 41 | Kauai Surfboard Rentals | Hanalei, HI | surfboards | 121 | applied |
+| 42 | Hanalei Surfboard Rentals | Hanalei, HI | surfboards | 31 | applied |
+| 43 | Maui Sunriders Kihei Bike Shop | Kihei, HI | mountain-bikes | 2 | applied |
+| 44 | Maui Sunriders Kapalua Bike Shop | Lahaina, HI | mountain-bikes | 4 | applied |
+| 45 | Bike Maui | Haiku, HI | mountain-bikes | 3 | applied |
+| 46 | Big Island Bike Tours | Waimea, HI | mountain-bikes | 3 | applied |
+| 47 | Dan Bailey's Outdoor Co. | Livingston, MT | mountain-bikes | 2 | applied |
+| 48 | proVelo Bicycles | Fort Collins, CO | mountain-bikes | 6 | applied |
+| 49 | Habitat Dirt + Snow Grand Targhee | Alta, WY | mountain-bikes | 2 | applied |
+| 50 | Village Ski Shop | Angel Fire, NM | skis + snowboards | 20 | applied |
+| 51 | Arizona Snowbowl Agassiz Pro Shop | Flagstaff, AZ | skis + snowboards | 20 | applied |
+| 52 | Deer Valley Resort Ski Rentals | Park City, UT | skis | 6 | applied |
+| 53 | Hi Tempo | White Bear Lake, MN | skis | 22 | applied |
+| | **Total** | | | **609** | |
 
 Do not re-seed any shop already in this table. Do not seed Hawaii Surfboard Rentals under any Hawaii discovery task.
 

--- a/supabase/migrations/20260530120000_seed_eastern_time_zone_all_categories_shops.sql
+++ b/supabase/migrations/20260530120000_seed_eastern_time_zone_all_categories_shops.sql
@@ -172,7 +172,7 @@ BEGIN
         'authenticated',
         'authenticated',
         shop.email,
-        crypt('$uO9RX^1P%bd#8crEAM!', gen_salt('bf')),
+        extensions.crypt('$uO9RX^1P%bd#8crEAM!', extensions.gen_salt('bf')),
         now(),
         jsonb_build_object('name', shop.name),
         jsonb_build_object('provider', 'email', 'providers', ARRAY['email']),

--- a/supabase/migrations/20260531120000_seed_us_mountain_mountain_bikes_shops.sql
+++ b/supabase/migrations/20260531120000_seed_us_mountain_mountain_bikes_shops.sql
@@ -1,0 +1,157 @@
+-- Seed migration: U.S. Mountain timezone mountain-bike shops
+-- Batch: us_mountain_mountain_bikes
+-- Created: 2026-05-31
+-- Remote status: files only; not pushed, applied, or deployed.
+-- Do not use supabase db push or supabase migration up for this seed package.
+
+-- =============================================
+-- U.S. MOUNTAIN MOUNTAIN-BIKE SHOPS
+-- Shop/user inserts (auth.users + auth.identities + public.profiles + public.user_roles)
+-- Password: $uO9RX^1P%bd#8crEAM!
+-- NOTE: auth.users insert is guarded by email lookup for idempotent local testing.
+-- NOTE: user_roles upsert uses UPDATE...IF NOT FOUND THEN INSERT.
+-- NOTE: profile upsert uses UPDATE...IF NOT FOUND THEN INSERT.
+-- =============================================
+
+DO $$
+DECLARE
+  s record;
+  new_user_id uuid;
+  v_avatar_url text := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/ad2ad153-bb35-4e88-bfb0-d0d4f85ba62f/profile-1752637760487.png';
+  v_hero_image_url text := 'https://images.unsplash.com/photo-1506316940527-4d1c138978a0?q=80&w=3512&auto=format&fit=crop&ixlib=rb-4.0.3';
+  v_display_role text := 'retail-store';
+BEGIN
+  CREATE TEMP TABLE _seed_us_mountain_mtb_shops (
+    seed_email text,
+    shop_name text,
+    website text,
+    phone text,
+    address text,
+    about text,
+    lat numeric,
+    lng numeric
+  ) ON COMMIT DROP;
+
+  INSERT INTO _seed_us_mountain_mtb_shops VALUES
+    (
+      'michaelzick+danbaileyslivingston@gmail.com',
+      'Dan Bailey''s Outdoor Co.',
+      'https://danbaileys.com/',
+      '(406) 222-1673',
+      '209 W Park Street, Livingston, MT 59047',
+      'Livingston outdoor shop with a public 2026 mountain-bike rental page listing Specialized hardtail and electric mountain-bike models with daily prices.',
+      45.6616265,
+      -110.5623716
+    ),
+    (
+      'michaelzick+provelobicyclesfortcollins@gmail.com',
+      'proVelo Bicycles',
+      'https://www.provelobikes.com/',
+      '(970) 204-9935',
+      '1003 W Horsetooth Rd, Fort Collins, CO 80526',
+      'Fort Collins bike shop with a public rental and demo program listing Santa Cruz, Ibis, Giant, Liv, and Specialized mountain-bike models with 24-hour carbon and aluminum pricing tiers.',
+      40.5377487,
+      -105.0949238
+    ),
+    (
+      'michaelzick+habitatgrandtarghee@gmail.com',
+      'Habitat Dirt + Snow Grand Targhee',
+      'https://ridethetetons.com/',
+      '(307) 353-2300',
+      '3300 E Ski Hill Rd, Alta, WY 83414',
+      'Habitat Dirt + Snow mountainside location at Grand Targhee with public bike rental pages listing adult downhill and cross-country mountain-bike models and full-day pricing.',
+      43.7849766,
+      -110.9469857
+    );
+
+  FOR s IN SELECT * FROM _seed_us_mountain_mtb_shops LOOP
+    SELECT id INTO new_user_id
+    FROM auth.users
+    WHERE email = s.seed_email
+    LIMIT 1;
+
+    IF new_user_id IS NULL THEN
+      new_user_id := gen_random_uuid();
+
+      INSERT INTO auth.users (
+        id, instance_id, aud, role, email, encrypted_password,
+        email_confirmed_at, raw_user_meta_data, raw_app_meta_data,
+        created_at, updated_at, confirmation_token, recovery_token,
+        email_change, email_change_token_current, email_change_token_new,
+        email_change_confirm_status, phone_change, phone_change_token,
+        reauthentication_token
+      ) VALUES (
+        new_user_id,
+        '00000000-0000-0000-0000-000000000000',
+        'authenticated',
+        'authenticated',
+        s.seed_email,
+        extensions.crypt('$uO9RX^1P%bd#8crEAM!', extensions.gen_salt('bf')),
+        now(),
+        jsonb_build_object('name', s.shop_name),
+        jsonb_build_object('provider', 'email', 'providers', ARRAY['email']),
+        now(), now(), '', '', '', '', '', 0, '', '', ''
+      );
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM auth.identities
+      WHERE user_id = new_user_id
+        AND provider = 'email'
+    ) THEN
+      INSERT INTO auth.identities (
+        id, user_id, identity_data, provider, provider_id,
+        last_sign_in_at, created_at, updated_at
+      ) VALUES (
+        gen_random_uuid(),
+        new_user_id,
+        jsonb_build_object('sub', new_user_id::text, 'email', s.seed_email),
+        'email',
+        new_user_id::text,
+        now(), now(), now()
+      );
+    END IF;
+
+    UPDATE public.profiles SET
+      name = s.shop_name,
+      website = s.website,
+      phone = s.phone,
+      address = s.address,
+      about = s.about,
+      location_lat = s.lat,
+      location_lng = s.lng,
+      avatar_url = COALESCE(v_avatar_url, avatar_url),
+      hero_image_url = COALESCE(v_hero_image_url, hero_image_url)
+    WHERE id = new_user_id;
+
+    IF NOT FOUND THEN
+      INSERT INTO public.profiles (
+        id, name, website, phone, address, about,
+        location_lat, location_lng, avatar_url, hero_image_url
+      ) VALUES (
+        new_user_id,
+        s.shop_name,
+        s.website,
+        s.phone,
+        s.address,
+        s.about,
+        s.lat,
+        s.lng,
+        v_avatar_url,
+        v_hero_image_url
+      );
+    END IF;
+
+    UPDATE public.user_roles
+      SET display_role = v_display_role
+      WHERE user_id = new_user_id;
+
+    IF NOT FOUND THEN
+      INSERT INTO public.user_roles (user_id, display_role)
+      VALUES (new_user_id, v_display_role);
+    END IF;
+
+    RAISE NOTICE 'User upserted successfully: id=%, email=%, role=%', new_user_id, s.seed_email, v_display_role;
+  END LOOP;
+END $$;

--- a/supabase/migrations/20260531120100_seed_us_mountain_mountain_bikes_gear.sql
+++ b/supabase/migrations/20260531120100_seed_us_mountain_mountain_bikes_gear.sql
@@ -1,0 +1,95 @@
+-- Seed migration: U.S. Mountain timezone mountain-bike gear
+-- Batch: us_mountain_mountain_bikes
+-- Created: 2026-05-31
+-- Depends on: 20260531120000_seed_us_mountain_mountain_bikes_shops.sql
+-- Remote status: files only; not pushed, applied, or deployed.
+-- Image URLs (mountain-bikes): https://images.pexels.com/photos/30447388/pexels-photo-30447388.jpeg and https://images.pexels.com/photos/25753440/pexels-photo-25753440.jpeg
+
+DO $$
+DECLARE
+  v_equipment_inserted int := 0;
+  v_primary_images_added int := 0;
+  v_secondary_images_added int := 0;
+BEGIN
+  CREATE TEMP TABLE _seed_us_mountain_mtb_gear (
+    seed_email text,
+    name text,
+    description text,
+    price_per_day numeric,
+    size text,
+    suitable_skill_level text,
+    location_lat numeric,
+    location_lng numeric,
+    location_address text,
+    subcategory text
+  ) ON COMMIT DROP;
+
+  INSERT INTO _seed_us_mountain_mtb_gear VALUES
+    ('michaelzick+danbaileyslivingston@gmail.com', 'Specialized Rockhopper Comp MTB', $$The Specialized Rockhopper Comp MTB is a hardtail mountain bike suited to Livingston singletrack and gravel rides. Dan Bailey's public bike rental page lists it as a mountain bike rental with a daily price and helmet included.$$, 40, NULL, 'Beginner, Intermediate', 45.6616265, -110.5623716, '209 W Park Street, Livingston, MT 59047', 'hardtail'),
+    ('michaelzick+danbaileyslivingston@gmail.com', 'Specialized Turbo Levo', $$The Specialized Turbo Levo is a full-suspension electric mountain bike for riders who want powered help on longer or steeper Montana trail days. Dan Bailey's public page lists it as an e-bike rental with a daily rate.$$, 100, NULL, 'Beginner, Intermediate, Advanced', 45.6616265, -110.5623716, '209 W Park Street, Livingston, MT 59047', 'electric-mountain-bike'),
+    ('michaelzick+provelobicyclesfortcollins@gmail.com', 'Santa Cruz Carbon Tallboy', $$The Santa Cruz Carbon Tallboy is a short-travel carbon trail bike for efficient Fort Collins singletrack. proVelo lists the Carbon Tallboy in its rental and demo program under the carbon 24-hour pricing tier.$$, 150, 'Medium', 'Beginner, Intermediate, Advanced', 40.5377487, -105.0949238, '1003 W Horsetooth Rd, Fort Collins, CO 80526', 'carbon-trail'),
+    ('michaelzick+provelobicyclesfortcollins@gmail.com', 'Santa Cruz Carbon Hightower', $$The Santa Cruz Carbon Hightower is a versatile carbon all-mountain bike for rougher Front Range trail riding. proVelo lists Carbon Hightower sizes in its rental and demo program under the carbon bike rate.$$, 150, 'Large, XL', 'Intermediate, Advanced, Expert', 40.5377487, -105.0949238, '1003 W Horsetooth Rd, Fort Collins, CO 80526', 'carbon-all-mountain'),
+    ('michaelzick+provelobicyclesfortcollins@gmail.com', 'Ibis Carbon Ripley', $$The Ibis Carbon Ripley is a light and efficient trail bike for riders who want responsive climbing and quick handling. proVelo lists Carbon Ripley sizes in its public rental and demo selection.$$, 150, 'Small, Medium, Large', 'Beginner, Intermediate, Advanced', 40.5377487, -105.0949238, '1003 W Horsetooth Rd, Fort Collins, CO 80526', 'carbon-trail'),
+    ('michaelzick+provelobicyclesfortcollins@gmail.com', 'Ibis Carbon Ripmo', $$The Ibis Carbon Ripmo is a carbon all-mountain bike for bigger trail days and technical descents. proVelo lists Carbon Ripmo sizes in its public rental and demo selection.$$, 150, 'Medium, Large', 'Intermediate, Advanced, Expert', 40.5377487, -105.0949238, '1003 W Horsetooth Rd, Fort Collins, CO 80526', 'carbon-enduro'),
+    ('michaelzick+provelobicyclesfortcollins@gmail.com', 'Giant Trance X 29', $$The Giant Trance X 29 is an aluminum full-suspension trail bike with a broad fit range. proVelo lists Aluminum Trance X 29 under its rental selection and aluminum 24-hour pricing tier.$$, 100, 'Medium, Large, XL', 'Beginner, Intermediate, Advanced', 40.5377487, -105.0949238, '1003 W Horsetooth Rd, Fort Collins, CO 80526', 'aluminum-trail'),
+    ('michaelzick+provelobicyclesfortcollins@gmail.com', 'Liv Intrigue 27.5', $$The Liv Intrigue 27.5 is an aluminum full-suspension trail bike with smaller size options. proVelo lists Aluminum Intrigue 27.5 sizes in its public rental and demo program.$$, 100, 'XS, Small, Medium', 'Beginner, Intermediate, Advanced', 40.5377487, -105.0949238, '1003 W Horsetooth Rd, Fort Collins, CO 80526', 'aluminum-trail'),
+    ('michaelzick+habitatgrandtarghee@gmail.com', 'Specialized Status 170', $$The Specialized Status 170 is a downhill-focused mountain bike for lift-served laps and rough resort terrain. Habitat's Grand Targhee location lists it with three-hour and full-day public pricing.$$, 119, 'XS, Small, Medium, Large, XL', 'Intermediate, Advanced, Expert', 43.7849766, -110.9469857, '3300 E Ski Hill Rd, Alta, WY 83414', 'downhill'),
+    ('michaelzick+habitatgrandtarghee@gmail.com', 'Kona Process 134 DL', $$The Kona Process 134 DL is a cross-country and trail-oriented full-suspension mountain bike for Grand Targhee's pedal-access and mixed trail network. Habitat lists it with three-hour and full-day public pricing.$$, 99, 'XS, Small, Medium, Large, XL', 'Beginner, Intermediate, Advanced', 43.7849766, -110.9469857, '3300 E Ski Hill Rd, Alta, WY 83414', 'trail');
+
+  IF EXISTS (
+    SELECT 1
+    FROM _seed_us_mountain_mtb_gear g
+    WHERE NOT EXISTS (
+      SELECT 1 FROM auth.users au WHERE au.email = g.seed_email
+    )
+  ) THEN
+    RAISE EXCEPTION 'Required shop user missing for U.S. Mountain mountain-bike gear batch';
+  END IF;
+
+  WITH source_rows AS (
+    SELECT au.id AS user_id, g.*
+    FROM _seed_us_mountain_mtb_gear g
+    JOIN auth.users au ON au.email = g.seed_email
+  ),
+  inserted AS (
+    INSERT INTO public.equipment (
+      id, user_id, name, category, description,
+      price_per_day, price_per_hour, price_per_week,
+      size, weight, material, suitable_skill_level, status,
+      location_lat, location_lng, location_address, subcategory,
+      damage_deposit, visible_on_map
+    )
+    SELECT
+      gen_random_uuid(), s.user_id, s.name, 'mountain-bikes', s.description,
+      s.price_per_day, NULL, NULL,
+      s.size, NULL, NULL, s.suitable_skill_level, 'available',
+      s.location_lat, s.location_lng, s.location_address, s.subcategory,
+      NULL, true
+    FROM source_rows s
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment e
+      WHERE e.user_id = s.user_id
+        AND e.category = 'mountain-bikes'
+        AND lower(btrim(e.name)) = lower(btrim(s.name))
+    )
+    RETURNING id
+  ),
+  ins1 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT id, 'https://images.pexels.com/photos/30447388/pexels-photo-30447388.jpeg', 0, true
+    FROM inserted
+    RETURNING equipment_id
+  ),
+  ins2 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT id, 'https://images.pexels.com/photos/25753440/pexels-photo-25753440.jpeg', 1, false
+    FROM inserted
+    RETURNING equipment_id
+  )
+  SELECT (SELECT count(*) FROM inserted), (SELECT count(*) FROM ins1), (SELECT count(*) FROM ins2)
+  INTO v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+
+  RAISE NOTICE 'U.S. Mountain mountain-bike gear inserted=%, primary_images_added=%, secondary_images_added=%',
+    v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+END $$;

--- a/supabase/migrations/20260531120100_seed_us_mountain_mountain_bikes_gear.sql
+++ b/supabase/migrations/20260531120100_seed_us_mountain_mountain_bikes_gear.sql
@@ -5,7 +5,7 @@
 -- Remote status: files only; not pushed, applied, or deployed.
 -- Image URLs (mountain-bikes): https://images.pexels.com/photos/30447388/pexels-photo-30447388.jpeg and https://images.pexels.com/photos/25753440/pexels-photo-25753440.jpeg
 
-DO $$
+DO $seed_migration$
 DECLARE
   v_equipment_inserted int := 0;
   v_primary_images_added int := 0;
@@ -92,4 +92,4 @@ BEGIN
 
   RAISE NOTICE 'U.S. Mountain mountain-bike gear inserted=%, primary_images_added=%, secondary_images_added=%',
     v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
-END $$;
+END $seed_migration$;

--- a/supabase/migrations/20260531120200_seed_us_mountain_winter_sports_shops.sql
+++ b/supabase/migrations/20260531120200_seed_us_mountain_winter_sports_shops.sql
@@ -1,0 +1,154 @@
+-- Seed migration: U.S. Mountain timezone winter-sports shops
+-- Batch: us_mountain_winter_sports
+-- Created: 2026-05-31
+-- Remote status: files only; not pushed, applied, or deployed.
+-- Do not use supabase db push or supabase migration up for this seed package.
+
+-- =============================================
+-- U.S. MOUNTAIN WINTER-SPORTS SHOPS
+-- Shop/user inserts (auth.users + auth.identities + public.profiles + public.user_roles)
+-- Password: $uO9RX^1P%bd#8crEAM!
+-- =============================================
+
+DO $$
+DECLARE
+  s record;
+  new_user_id uuid;
+  v_avatar_url text := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/7ef925ac-4b8f-496c-b4d9-10895164f03c/profile-1769637319540.png';
+  v_hero_image_url text := 'https://images.unsplash.com/photo-1509791413599-93ba127a66b7?q=80&w=3540&auto=format&fit=crop&ixlib=rb-4.0.3';
+  v_display_role text := 'retail-store';
+BEGIN
+  CREATE TEMP TABLE _seed_us_mountain_winter_shops (
+    seed_email text,
+    shop_name text,
+    website text,
+    phone text,
+    address text,
+    about text,
+    lat numeric,
+    lng numeric
+  ) ON COMMIT DROP;
+
+  INSERT INTO _seed_us_mountain_winter_shops VALUES
+    (
+      'michaelzick+villageskishopangelfire@gmail.com',
+      'Village Ski Shop',
+      'https://www.villageskishop.com/',
+      '(575) 377-2475',
+      '26 Aspen St, Angel Fire, NM 87710',
+      'Angel Fire ski and snowboard rental shop with public 2025/2026 rates, advanced ski model lists, and snowboard model lists for Never Summer, Salomon, Rossignol, and Burton boards.',
+      36.3876434,
+      -105.2753910
+    ),
+    (
+      'michaelzick+arizonasnowbowlagassiz@gmail.com',
+      'Arizona Snowbowl Agassiz Pro Shop',
+      'https://www.snowbowl.ski/agassiz-pro-shop/',
+      '(928) 447-9928',
+      '9300 N Snowbowl Rd, Flagstaff, AZ 86002',
+      'Arizona Snowbowl Agassiz Lodge pro shop with a public 25/26 demo gear program, published daily demo pricing, and a model-level ski and snowboard demo menu.',
+      35.3303900,
+      -111.7106600
+    ),
+    (
+      'michaelzick+deervalleyrentalsparkcity@gmail.com',
+      'Deer Valley Resort Ski Rentals',
+      'https://www.deervalley.com/plan-your-trip/ski-rentals/demo',
+      '(435) 645-6648',
+      '2250 Deer Valley Drive S, Park City, UT 84060',
+      'Deer Valley Snow Park rental shop with a public Rossignol demo ski rental page listing product pricing, model details, and rental locations.',
+      40.6374025,
+      -111.4782514
+    );
+
+  FOR s IN SELECT * FROM _seed_us_mountain_winter_shops LOOP
+    SELECT id INTO new_user_id
+    FROM auth.users
+    WHERE email = s.seed_email
+    LIMIT 1;
+
+    IF new_user_id IS NULL THEN
+      new_user_id := gen_random_uuid();
+
+      INSERT INTO auth.users (
+        id, instance_id, aud, role, email, encrypted_password,
+        email_confirmed_at, raw_user_meta_data, raw_app_meta_data,
+        created_at, updated_at, confirmation_token, recovery_token,
+        email_change, email_change_token_current, email_change_token_new,
+        email_change_confirm_status, phone_change, phone_change_token,
+        reauthentication_token
+      ) VALUES (
+        new_user_id,
+        '00000000-0000-0000-0000-000000000000',
+        'authenticated',
+        'authenticated',
+        s.seed_email,
+        extensions.crypt('$uO9RX^1P%bd#8crEAM!', extensions.gen_salt('bf')),
+        now(),
+        jsonb_build_object('name', s.shop_name),
+        jsonb_build_object('provider', 'email', 'providers', ARRAY['email']),
+        now(), now(), '', '', '', '', '', 0, '', '', ''
+      );
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM auth.identities
+      WHERE user_id = new_user_id
+        AND provider = 'email'
+    ) THEN
+      INSERT INTO auth.identities (
+        id, user_id, identity_data, provider, provider_id,
+        last_sign_in_at, created_at, updated_at
+      ) VALUES (
+        gen_random_uuid(),
+        new_user_id,
+        jsonb_build_object('sub', new_user_id::text, 'email', s.seed_email),
+        'email',
+        new_user_id::text,
+        now(), now(), now()
+      );
+    END IF;
+
+    UPDATE public.profiles SET
+      name = s.shop_name,
+      website = s.website,
+      phone = s.phone,
+      address = s.address,
+      about = s.about,
+      location_lat = s.lat,
+      location_lng = s.lng,
+      avatar_url = COALESCE(v_avatar_url, avatar_url),
+      hero_image_url = COALESCE(v_hero_image_url, hero_image_url)
+    WHERE id = new_user_id;
+
+    IF NOT FOUND THEN
+      INSERT INTO public.profiles (
+        id, name, website, phone, address, about,
+        location_lat, location_lng, avatar_url, hero_image_url
+      ) VALUES (
+        new_user_id,
+        s.shop_name,
+        s.website,
+        s.phone,
+        s.address,
+        s.about,
+        s.lat,
+        s.lng,
+        v_avatar_url,
+        v_hero_image_url
+      );
+    END IF;
+
+    UPDATE public.user_roles
+      SET display_role = v_display_role
+      WHERE user_id = new_user_id;
+
+    IF NOT FOUND THEN
+      INSERT INTO public.user_roles (user_id, display_role)
+      VALUES (new_user_id, v_display_role);
+    END IF;
+
+    RAISE NOTICE 'User upserted successfully: id=%, email=%, role=%', new_user_id, s.seed_email, v_display_role;
+  END LOOP;
+END $$;

--- a/supabase/migrations/20260531120300_seed_us_mountain_skis_gear.sql
+++ b/supabase/migrations/20260531120300_seed_us_mountain_skis_gear.sql
@@ -5,7 +5,7 @@
 -- Remote status: files only; not pushed, applied, or deployed.
 -- Image URLs (skis): https://images.pexels.com/photos/848699/pexels-photo-848699.jpeg and https://images.pexels.com/photos/36084973/pexels-photo-36084973.jpeg
 
-DO $$
+DO $seed_migration$
 DECLARE
   v_equipment_inserted int := 0;
   v_primary_images_added int := 0;
@@ -107,4 +107,4 @@ BEGIN
 
   RAISE NOTICE 'U.S. Mountain ski gear inserted=%, primary_images_added=%, secondary_images_added=%',
     v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
-END $$;
+END $seed_migration$;

--- a/supabase/migrations/20260531120300_seed_us_mountain_skis_gear.sql
+++ b/supabase/migrations/20260531120300_seed_us_mountain_skis_gear.sql
@@ -1,0 +1,110 @@
+-- Seed migration: U.S. Mountain timezone ski gear
+-- Batch: us_mountain_winter_sports
+-- Created: 2026-05-31
+-- Depends on: 20260531120200_seed_us_mountain_winter_sports_shops.sql
+-- Remote status: files only; not pushed, applied, or deployed.
+-- Image URLs (skis): https://images.pexels.com/photos/848699/pexels-photo-848699.jpeg and https://images.pexels.com/photos/36084973/pexels-photo-36084973.jpeg
+
+DO $$
+DECLARE
+  v_equipment_inserted int := 0;
+  v_primary_images_added int := 0;
+  v_secondary_images_added int := 0;
+BEGIN
+  CREATE TEMP TABLE _seed_us_mountain_skis_gear (
+    seed_email text,
+    name text,
+    description text,
+    price_per_day numeric,
+    suitable_skill_level text,
+    location_lat numeric,
+    location_lng numeric,
+    location_address text,
+    subcategory text
+  ) ON COMMIT DROP;
+
+  INSERT INTO _seed_us_mountain_skis_gear VALUES
+    ('michaelzick+villageskishopangelfire@gmail.com', 'Armada ARV 94', $$The Armada ARV 94 is a versatile all-mountain freestyle ski from Village Ski Shop's advanced ski list. It suits skiers who want a playful platform for groomers, soft snow, and side hits at Angel Fire.$$, 69, 'Intermediate, Advanced', 36.3876434, -105.2753910, '26 Aspen St, Angel Fire, NM 87710', 'all-mountain-freestyle'),
+    ('michaelzick+villageskishopangelfire@gmail.com', 'Armada Declivity 88', $$The Armada Declivity 88 is listed in Village Ski Shop's advanced men's ski inventory and fits skiers who want firm-snow edge hold with all-mountain versatility.$$, 69, 'Intermediate, Advanced', 36.3876434, -105.2753910, '26 Aspen St, Angel Fire, NM 87710', 'all-mountain'),
+    ('michaelzick+villageskishopangelfire@gmail.com', 'Atomic Bent 100', $$The Atomic Bent 100 appears on Village Ski Shop's advanced ski list for skiers who want a wider all-mountain platform with soft-snow capability and playful handling.$$, 69, 'Intermediate, Advanced, Expert', 36.3876434, -105.2753910, '26 Aspen St, Angel Fire, NM 87710', 'freeride'),
+    ('michaelzick+villageskishopangelfire@gmail.com', 'Atomic Maverick 83', $$The Atomic Maverick 83 is a narrower all-mountain ski listed by Village Ski Shop for advanced rentals. It is a good fit for carving-focused resort days.$$, 69, 'Beginner, Intermediate, Advanced', 36.3876434, -105.2753910, '26 Aspen St, Angel Fire, NM 87710', 'frontside-all-mountain'),
+    ('michaelzick+villageskishopangelfire@gmail.com', 'Blizzard Anomaly 88', $$The Blizzard Anomaly 88 is listed in Village Ski Shop's advanced fleet and works well for stronger skiers looking for stability and edge grip across mixed resort conditions.$$, 69, 'Intermediate, Advanced, Expert', 36.3876434, -105.2753910, '26 Aspen St, Angel Fire, NM 87710', 'all-mountain'),
+    ('michaelzick+villageskishopangelfire@gmail.com', 'Rossignol M-Cross 78', $$The Rossignol M-Cross 78 is an advanced rental option from Village Ski Shop for skiers who want a quick, frontside-oriented all-mountain ski.$$, 69, 'Beginner, Intermediate, Advanced', 36.3876434, -105.2753910, '26 Aspen St, Angel Fire, NM 87710', 'frontside'),
+    ('michaelzick+villageskishopangelfire@gmail.com', 'Salomon QST 98', $$The Salomon QST 98 is listed in Village Ski Shop's advanced ski lineup and gives skiers a freeride-oriented platform for softer snow, bumps, and variable terrain.$$, 69, 'Intermediate, Advanced, Expert', 36.3876434, -105.2753910, '26 Aspen St, Angel Fire, NM 87710', 'freeride'),
+    ('michaelzick+villageskishopangelfire@gmail.com', 'Blizzard Black Pearl 88', $$The Blizzard Black Pearl 88 is listed on Village Ski Shop's women's advanced ski list and offers approachable all-mountain performance for a broad range of conditions.$$, 69, 'Beginner, Intermediate, Advanced', 36.3876434, -105.2753910, '26 Aspen St, Angel Fire, NM 87710', 'all-mountain'),
+    ('michaelzick+villageskishopangelfire@gmail.com', 'Rossignol Rallybird 90', $$The Rossignol Rallybird 90 appears on Village Ski Shop's women's advanced ski list as a playful, all-mountain option for progressing and confident skiers.$$, 69, 'Intermediate, Advanced', 36.3876434, -105.2753910, '26 Aspen St, Angel Fire, NM 87710', 'all-mountain-freeride'),
+    ('michaelzick+villageskishopangelfire@gmail.com', 'Armada Reliance 88', $$The Armada Reliance 88 is listed in Village Ski Shop's women's advanced inventory and fits skiers looking for composed all-mountain turns on groomers and variable snow.$$, 69, 'Intermediate, Advanced', 36.3876434, -105.2753910, '26 Aspen St, Angel Fire, NM 87710', 'all-mountain'),
+    ('michaelzick+arizonasnowbowlagassiz@gmail.com', 'Atomic Bent 110', $$The Atomic Bent 110 is part of Arizona Snowbowl Agassiz Pro Shop's 2025/2026 demo ski menu. It is a wider, playful freeride ski for soft snow and advanced all-mountain use.$$, 30, 'Intermediate, Advanced, Expert', 35.3303900, -111.7106600, '9300 N Snowbowl Rd, Flagstaff, AZ 86002', 'powder-freeride'),
+    ('michaelzick+arizonasnowbowlagassiz@gmail.com', 'Dynastar M-Pro 94', $$The Dynastar M-Pro 94 is listed in the Agassiz Pro Shop demo menu as a playful freeride ski with enough width for mixed snow and enough hold for groomers.$$, 30, 'Intermediate, Advanced', 35.3303900, -111.7106600, '9300 N Snowbowl Rd, Flagstaff, AZ 86002', 'freeride'),
+    ('michaelzick+arizonasnowbowlagassiz@gmail.com', 'Elan Playmaker 91', $$The Elan Playmaker 91 is listed in Arizona Snowbowl's demo menu as a nimble freeride twin for skiers who want pop, easy turn initiation, and all-mountain playfulness.$$, 30, 'Intermediate, Advanced', 35.3303900, -111.7106600, '9300 N Snowbowl Rd, Flagstaff, AZ 86002', 'freeride-twin'),
+    ('michaelzick+arizonasnowbowlagassiz@gmail.com', 'Nordica Unleashed 98', $$The Nordica Unleashed 98 appears on the Agassiz Pro Shop demo menu as a maneuverable freeride ski for powder-oriented profiles and varied resort terrain.$$, 30, 'Intermediate, Advanced, Expert', 35.3303900, -111.7106600, '9300 N Snowbowl Rd, Flagstaff, AZ 86002', 'freeride'),
+    ('michaelzick+arizonasnowbowlagassiz@gmail.com', 'Head Kore 94', $$The Head Kore 94 is listed by Arizona Snowbowl as a redesigned all-mountain ski for skiers who want control on groomers plus smooth handling in deeper snow.$$, 30, 'Intermediate, Advanced, Expert', 35.3303900, -111.7106600, '9300 N Snowbowl Rd, Flagstaff, AZ 86002', 'all-mountain'),
+    ('michaelzick+arizonasnowbowlagassiz@gmail.com', 'Head Supershape E-Rally', $$The Head Supershape E-Rally is an Agassiz demo ski for frontside skiers who want race-inspired edge grip, easy initiation, and strong power delivery.$$, 30, 'Intermediate, Advanced, Expert', 35.3303900, -111.7106600, '9300 N Snowbowl Rd, Flagstaff, AZ 86002', 'frontside-carver'),
+    ('michaelzick+arizonasnowbowlagassiz@gmail.com', 'Atomic Maverick 88 Ti', $$The Atomic Maverick 88 Ti is listed as a fan-favorite Agassiz demo ski for skiers who want a stiff, stable all-mountain option for groomers, moguls, and powder days.$$, 30, 'Intermediate, Advanced, Expert', 35.3303900, -111.7106600, '9300 N Snowbowl Rd, Flagstaff, AZ 86002', 'all-mountain'),
+    ('michaelzick+arizonasnowbowlagassiz@gmail.com', 'Faction Prodigy 2', $$The Faction Prodigy 2 is listed in Arizona Snowbowl's demo menu as an all-mountain directional twin with park pedigree and a poppy, versatile feel.$$, 30, 'Intermediate, Advanced', 35.3303900, -111.7106600, '9300 N Snowbowl Rd, Flagstaff, AZ 86002', 'all-mountain-twin'),
+    ('michaelzick+arizonasnowbowlagassiz@gmail.com', 'Salomon QST 94', $$The Salomon QST 94 is listed in the Agassiz demo menu as an all-mountain freeride ski bridging groomer control and soft-snow versatility.$$, 30, 'Intermediate, Advanced', 35.3303900, -111.7106600, '9300 N Snowbowl Rd, Flagstaff, AZ 86002', 'all-mountain-freeride'),
+    ('michaelzick+arizonasnowbowlagassiz@gmail.com', 'Atomic Maven 86 C', $$The Atomic Maven 86 C is part of Arizona Snowbowl's demo menu and offers a lighter, responsive all-mountain feel for skiers seeking controlled turns and tip rocker.$$, 30, 'Beginner, Intermediate, Advanced', 35.3303900, -111.7106600, '9300 N Snowbowl Rd, Flagstaff, AZ 86002', 'all-mountain'),
+    ('michaelzick+deervalleyrentalsparkcity@gmail.com', 'Rossignol Arcade 94', $$The Rossignol Arcade 94 is listed on Deer Valley's demo ski rental page as part of the Rossignol demo fleet. It is the widest Arcade option in this rental set for advanced resort versatility.$$, 84, 'Intermediate, Advanced, Expert', 40.6374025, -111.4782514, '2250 Deer Valley Drive S, Park City, UT 84060', 'all-mountain'),
+    ('michaelzick+deervalleyrentalsparkcity@gmail.com', 'Rossignol Arcade 88', $$The Rossignol Arcade 88 is a Deer Valley demo ski for skiers seeking a stable all-mountain platform with frontside precision and enough width for mixed conditions.$$, 84, 'Intermediate, Advanced', 40.6374025, -111.4782514, '2250 Deer Valley Drive S, Park City, UT 84060', 'all-mountain'),
+    ('michaelzick+deervalleyrentalsparkcity@gmail.com', 'Rossignol Arcade 84', $$The Rossignol Arcade 84 is listed in Deer Valley's demo ski product details as a narrower all-mountain option for quick resort turns and groomed snow.$$, 84, 'Beginner, Intermediate, Advanced', 40.6374025, -111.4782514, '2250 Deer Valley Drive S, Park City, UT 84060', 'frontside-all-mountain'),
+    ('michaelzick+deervalleyrentalsparkcity@gmail.com', 'Rossignol Sender Soul 102', $$The Rossignol Sender Soul 102 is part of Deer Valley's public demo ski fleet and fits skiers looking for a freeride-oriented ride with more soft-snow support.$$, 84, 'Intermediate, Advanced, Expert', 40.6374025, -111.4782514, '2250 Deer Valley Drive S, Park City, UT 84060', 'freeride'),
+    ('michaelzick+deervalleyrentalsparkcity@gmail.com', 'Rossignol Forza 70', $$The Rossignol Forza 70 is listed in Deer Valley's demo ski product details and suits advanced frontside skiers who want strong carving energy.$$, 84, 'Intermediate, Advanced, Expert', 40.6374025, -111.4782514, '2250 Deer Valley Drive S, Park City, UT 84060', 'frontside-carver'),
+    ('michaelzick+deervalleyrentalsparkcity@gmail.com', 'Rossignol Forza 60', $$The Rossignol Forza 60 is a Deer Valley Rossignol demo ski for skiers who want a precise, frontside-focused carving option with approachable performance.$$, 84, 'Beginner, Intermediate, Advanced', 40.6374025, -111.4782514, '2250 Deer Valley Drive S, Park City, UT 84060', 'frontside-carver');
+
+  IF EXISTS (
+    SELECT 1
+    FROM _seed_us_mountain_skis_gear g
+    WHERE NOT EXISTS (
+      SELECT 1 FROM auth.users au WHERE au.email = g.seed_email
+    )
+  ) THEN
+    RAISE EXCEPTION 'Required shop user missing for U.S. Mountain ski gear batch';
+  END IF;
+
+  WITH source_rows AS (
+    SELECT au.id AS user_id, g.*
+    FROM _seed_us_mountain_skis_gear g
+    JOIN auth.users au ON au.email = g.seed_email
+  ),
+  inserted AS (
+    INSERT INTO public.equipment (
+      id, user_id, name, category, description,
+      price_per_day, price_per_hour, price_per_week,
+      size, weight, material, suitable_skill_level, status,
+      location_lat, location_lng, location_address, subcategory,
+      damage_deposit, visible_on_map
+    )
+    SELECT
+      gen_random_uuid(), s.user_id, s.name, 'skis', s.description,
+      s.price_per_day, NULL, NULL,
+      NULL, NULL, NULL, s.suitable_skill_level, 'available',
+      s.location_lat, s.location_lng, s.location_address, s.subcategory,
+      NULL, true
+    FROM source_rows s
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment e
+      WHERE e.user_id = s.user_id
+        AND e.category = 'skis'
+        AND lower(btrim(e.name)) = lower(btrim(s.name))
+    )
+    RETURNING id
+  ),
+  ins1 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT id, 'https://images.pexels.com/photos/848699/pexels-photo-848699.jpeg', 0, true
+    FROM inserted
+    RETURNING equipment_id
+  ),
+  ins2 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT id, 'https://images.pexels.com/photos/36084973/pexels-photo-36084973.jpeg', 1, false
+    FROM inserted
+    RETURNING equipment_id
+  )
+  SELECT (SELECT count(*) FROM inserted), (SELECT count(*) FROM ins1), (SELECT count(*) FROM ins2)
+  INTO v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+
+  RAISE NOTICE 'U.S. Mountain ski gear inserted=%, primary_images_added=%, secondary_images_added=%',
+    v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+END $$;

--- a/supabase/migrations/20260531120400_seed_us_mountain_snowboards_gear.sql
+++ b/supabase/migrations/20260531120400_seed_us_mountain_snowboards_gear.sql
@@ -1,0 +1,104 @@
+-- Seed migration: U.S. Mountain timezone snowboard gear
+-- Batch: us_mountain_winter_sports
+-- Created: 2026-05-31
+-- Depends on: 20260531120200_seed_us_mountain_winter_sports_shops.sql
+-- Remote status: files only; not pushed, applied, or deployed.
+-- Image URLs (snowboards): https://images.pexels.com/photos/7406683/pexels-photo-7406683.jpeg and https://images.pexels.com/photos/7166118/pexels-photo-7166118.jpeg
+
+DO $$
+DECLARE
+  v_equipment_inserted int := 0;
+  v_primary_images_added int := 0;
+  v_secondary_images_added int := 0;
+BEGIN
+  CREATE TEMP TABLE _seed_us_mountain_snowboards_gear (
+    seed_email text,
+    name text,
+    description text,
+    price_per_day numeric,
+    suitable_skill_level text,
+    location_lat numeric,
+    location_lng numeric,
+    location_address text,
+    subcategory text
+  ) ON COMMIT DROP;
+
+  INSERT INTO _seed_us_mountain_snowboards_gear VALUES
+    ('michaelzick+villageskishopangelfire@gmail.com', 'Burton Custom', $$The Burton Custom is listed on Village Ski Shop's snowboard inventory page and is a classic all-mountain board for riders who want dependable edge hold and pop across resort terrain.$$, 69, 'Intermediate, Advanced', 36.3876434, -105.2753910, '26 Aspen St, Angel Fire, NM 87710', 'all-mountain'),
+    ('michaelzick+villageskishopangelfire@gmail.com', 'Burton Process Flying V', $$The Burton Process Flying V is a playful all-mountain freestyle board from Village Ski Shop's public snowboard list, suited to riders who want easy turn initiation and park-friendly flex.$$, 69, 'Beginner, Intermediate, Advanced', 36.3876434, -105.2753910, '26 Aspen St, Angel Fire, NM 87710', 'all-mountain-freestyle'),
+    ('michaelzick+villageskishopangelfire@gmail.com', 'Never Summer Proto Synthesis', $$The Never Summer Proto Synthesis is listed by Village Ski Shop as an advanced snowboard option for riders who want an energetic all-mountain twin for carving, freestyle, and mixed terrain.$$, 69, 'Intermediate, Advanced, Expert', 36.3876434, -105.2753910, '26 Aspen St, Angel Fire, NM 87710', 'all-mountain-twin'),
+    ('michaelzick+villageskishopangelfire@gmail.com', 'Never Summer Harpoon', $$The Never Summer Harpoon appears on Village Ski Shop's snowboard list and fits riders looking for a directional, surfy ride with strong float and carving capability.$$, 69, 'Intermediate, Advanced', 36.3876434, -105.2753910, '26 Aspen St, Angel Fire, NM 87710', 'powder-freeride'),
+    ('michaelzick+villageskishopangelfire@gmail.com', 'Never Summer Snowtrooper', $$The Never Summer Snowtrooper is listed in Village Ski Shop's men's snowboard inventory and offers an all-mountain profile for riders progressing from groomers into varied terrain.$$, 69, 'Beginner, Intermediate, Advanced', 36.3876434, -105.2753910, '26 Aspen St, Angel Fire, NM 87710', 'all-mountain'),
+    ('michaelzick+villageskishopangelfire@gmail.com', 'Never Summer Westbound', $$The Never Summer Westbound is a directional all-mountain board listed by Village Ski Shop for riders who want a confident, freeride-leaning setup for New Mexico resort laps.$$, 69, 'Intermediate, Advanced, Expert', 36.3876434, -105.2753910, '26 Aspen St, Angel Fire, NM 87710', 'freeride'),
+    ('michaelzick+villageskishopangelfire@gmail.com', 'Rossignol Sushi', $$The Rossignol Sushi is listed on Village Ski Shop's snowboard inventory page and gives riders a short, surfy powder board for soft snow and directional carving.$$, 69, 'Intermediate, Advanced', 36.3876434, -105.2753910, '26 Aspen St, Angel Fire, NM 87710', 'powder'),
+    ('michaelzick+villageskishopangelfire@gmail.com', 'Salomon Assassin', $$The Salomon Assassin is a Village Ski Shop snowboard option for riders who want an all-mountain freestyle board with enough backbone for faster groomer and side-hit laps.$$, 69, 'Intermediate, Advanced', 36.3876434, -105.2753910, '26 Aspen St, Angel Fire, NM 87710', 'all-mountain-freestyle'),
+    ('michaelzick+villageskishopangelfire@gmail.com', 'Burton Hideaway', $$The Burton Hideaway appears in Village Ski Shop's women's snowboard list and provides an approachable all-mountain ride for beginner and intermediate riders.$$, 69, 'Beginner, Intermediate', 36.3876434, -105.2753910, '26 Aspen St, Angel Fire, NM 87710', 'all-mountain'),
+    ('michaelzick+villageskishopangelfire@gmail.com', 'Never Summer Infinity', $$The Never Summer Infinity is listed in Village Ski Shop's women's snowboard inventory and offers a forgiving but capable all-terrain ride.$$, 69, 'Beginner, Intermediate, Advanced', 36.3876434, -105.2753910, '26 Aspen St, Angel Fire, NM 87710', 'all-mountain'),
+    ('michaelzick+arizonasnowbowlagassiz@gmail.com', 'Lib Tech TRice Pro', $$The Lib Tech TRice Pro is part of Arizona Snowbowl Agassiz Pro Shop's 2025/2026 demo snowboard menu and is listed as a lightweight all-mountain freestyle twin.$$, 30, 'Intermediate, Advanced, Expert', 35.3303900, -111.7106600, '9300 N Snowbowl Rd, Flagstaff, AZ 86002', 'all-mountain-freestyle'),
+    ('michaelzick+arizonasnowbowlagassiz@gmail.com', 'Lib Tech Orca', $$The Lib Tech Orca is listed on Arizona Snowbowl's demo snowboard menu as a directional all-mountain powder board for intermediate to advanced riders.$$, 30, 'Intermediate, Advanced, Expert', 35.3303900, -111.7106600, '9300 N Snowbowl Rd, Flagstaff, AZ 86002', 'powder-freeride'),
+    ('michaelzick+arizonasnowbowlagassiz@gmail.com', 'Gnu Gremlin', $$The Gnu Gremlin appears in the Agassiz Pro Shop demo snowboard menu as an all-mountain directional board for riders seeking float, pop, and edge hold.$$, 30, 'Intermediate, Advanced', 35.3303900, -111.7106600, '9300 N Snowbowl Rd, Flagstaff, AZ 86002', 'all-mountain'),
+    ('michaelzick+arizonasnowbowlagassiz@gmail.com', 'Nitro T1', $$The Nitro T1 is listed by Arizona Snowbowl as a freestyle snowboard with a twin shape and forgiving, responsive camber profile.$$, 30, 'Beginner, Intermediate, Advanced', 35.3303900, -111.7106600, '9300 N Snowbowl Rd, Flagstaff, AZ 86002', 'freestyle'),
+    ('michaelzick+arizonasnowbowlagassiz@gmail.com', 'Capita Slush Slasherz', $$The Capita Slush Slasherz is in Arizona Snowbowl's demo menu as a directional powder and spring-slush board with a surfy freeride feel.$$, 30, 'Intermediate, Advanced', 35.3303900, -111.7106600, '9300 N Snowbowl Rd, Flagstaff, AZ 86002', 'powder'),
+    ('michaelzick+arizonasnowbowlagassiz@gmail.com', 'Capita Indoor Survival', $$The Capita Indoor Survival appears on the Agassiz demo menu as a true twin board for controlled groomer and freestyle riding.$$, 30, 'Intermediate, Advanced', 35.3303900, -111.7106600, '9300 N Snowbowl Rd, Flagstaff, AZ 86002', 'freestyle'),
+    ('michaelzick+arizonasnowbowlagassiz@gmail.com', 'United Shapes Horizon', $$The United Shapes Horizon is listed in Arizona Snowbowl's demo menu as a directional all-mountain and freestyle board with traditional camber and early-rise nose.$$, 30, 'Intermediate, Advanced', 35.3303900, -111.7106600, '9300 N Snowbowl Rd, Flagstaff, AZ 86002', 'all-mountain-freestyle'),
+    ('michaelzick+arizonasnowbowlagassiz@gmail.com', 'Rossignol Sushi', $$The Rossignol Sushi is listed in Arizona Snowbowl's Agassiz demo menu as a surfy powder board with a smooth, versatile ride.$$, 30, 'Intermediate, Advanced', 35.3303900, -111.7106600, '9300 N Snowbowl Rd, Flagstaff, AZ 86002', 'powder'),
+    ('michaelzick+arizonasnowbowlagassiz@gmail.com', 'Salomon Dance Haul', $$The Salomon Dance Haul appears in the Agassiz Pro Shop demo list as a tapered directional board with a wide platform for float and pop.$$, 30, 'Intermediate, Advanced', 35.3303900, -111.7106600, '9300 N Snowbowl Rd, Flagstaff, AZ 86002', 'all-mountain-freeride'),
+    ('michaelzick+arizonasnowbowlagassiz@gmail.com', 'Never Summer V Twin', $$The Never Summer V Twin is listed by Arizona Snowbowl as an energetic twin-shaped board with a hybrid triple camber profile for capable all-mountain riding.$$, 30, 'Intermediate, Advanced', 35.3303900, -111.7106600, '9300 N Snowbowl Rd, Flagstaff, AZ 86002', 'all-mountain-twin');
+
+  IF EXISTS (
+    SELECT 1
+    FROM _seed_us_mountain_snowboards_gear g
+    WHERE NOT EXISTS (
+      SELECT 1 FROM auth.users au WHERE au.email = g.seed_email
+    )
+  ) THEN
+    RAISE EXCEPTION 'Required shop user missing for U.S. Mountain snowboard gear batch';
+  END IF;
+
+  WITH source_rows AS (
+    SELECT au.id AS user_id, g.*
+    FROM _seed_us_mountain_snowboards_gear g
+    JOIN auth.users au ON au.email = g.seed_email
+  ),
+  inserted AS (
+    INSERT INTO public.equipment (
+      id, user_id, name, category, description,
+      price_per_day, price_per_hour, price_per_week,
+      size, weight, material, suitable_skill_level, status,
+      location_lat, location_lng, location_address, subcategory,
+      damage_deposit, visible_on_map
+    )
+    SELECT
+      gen_random_uuid(), s.user_id, s.name, 'snowboards', s.description,
+      s.price_per_day, NULL, NULL,
+      NULL, NULL, NULL, s.suitable_skill_level, 'available',
+      s.location_lat, s.location_lng, s.location_address, s.subcategory,
+      NULL, true
+    FROM source_rows s
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment e
+      WHERE e.user_id = s.user_id
+        AND e.category = 'snowboards'
+        AND lower(btrim(e.name)) = lower(btrim(s.name))
+    )
+    RETURNING id
+  ),
+  ins1 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT id, 'https://images.pexels.com/photos/7406683/pexels-photo-7406683.jpeg', 0, true
+    FROM inserted
+    RETURNING equipment_id
+  ),
+  ins2 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT id, 'https://images.pexels.com/photos/7166118/pexels-photo-7166118.jpeg', 1, false
+    FROM inserted
+    RETURNING equipment_id
+  )
+  SELECT (SELECT count(*) FROM inserted), (SELECT count(*) FROM ins1), (SELECT count(*) FROM ins2)
+  INTO v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+
+  RAISE NOTICE 'U.S. Mountain snowboard gear inserted=%, primary_images_added=%, secondary_images_added=%',
+    v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+END $$;

--- a/supabase/migrations/20260531120400_seed_us_mountain_snowboards_gear.sql
+++ b/supabase/migrations/20260531120400_seed_us_mountain_snowboards_gear.sql
@@ -5,7 +5,7 @@
 -- Remote status: files only; not pushed, applied, or deployed.
 -- Image URLs (snowboards): https://images.pexels.com/photos/7406683/pexels-photo-7406683.jpeg and https://images.pexels.com/photos/7166118/pexels-photo-7166118.jpeg
 
-DO $$
+DO $seed_migration$
 DECLARE
   v_equipment_inserted int := 0;
   v_primary_images_added int := 0;
@@ -101,4 +101,4 @@ BEGIN
 
   RAISE NOTICE 'U.S. Mountain snowboard gear inserted=%, primary_images_added=%, secondary_images_added=%',
     v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
-END $$;
+END $seed_migration$;

--- a/supabase/migrations/20260531120500_seed_us_central_winter_sports_shops.sql
+++ b/supabase/migrations/20260531120500_seed_us_central_winter_sports_shops.sql
@@ -1,0 +1,109 @@
+-- Seed migration: U.S. Central timezone winter-sports shops
+-- Batch: us_central_winter_sports
+-- Created: 2026-05-31
+-- Remote status: files only; not pushed, applied, or deployed.
+-- Do not use supabase db push or supabase migration up for this seed package.
+
+-- =============================================
+-- U.S. CENTRAL WINTER-SPORTS SHOPS
+-- Shop/user inserts (auth.users + auth.identities + public.profiles + public.user_roles)
+-- Password: $uO9RX^1P%bd#8crEAM!
+-- =============================================
+
+DO $$
+DECLARE
+  new_user_id uuid;
+  v_avatar_url text := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/7ef925ac-4b8f-496c-b4d9-10895164f03c/profile-1769637319540.png';
+  v_hero_image_url text := 'https://images.unsplash.com/photo-1509791413599-93ba127a66b7?q=80&w=3540&auto=format&fit=crop&ixlib=rb-4.0.3';
+  v_display_role text := 'retail-store';
+  v_email text := 'michaelzick+hitempowhitebearlake@gmail.com';
+BEGIN
+  SELECT id INTO new_user_id
+  FROM auth.users
+  WHERE email = v_email
+  LIMIT 1;
+
+  IF new_user_id IS NULL THEN
+    new_user_id := gen_random_uuid();
+
+    INSERT INTO auth.users (
+      id, instance_id, aud, role, email, encrypted_password,
+      email_confirmed_at, raw_user_meta_data, raw_app_meta_data,
+      created_at, updated_at, confirmation_token, recovery_token,
+      email_change, email_change_token_current, email_change_token_new,
+      email_change_confirm_status, phone_change, phone_change_token,
+      reauthentication_token
+    ) VALUES (
+      new_user_id,
+      '00000000-0000-0000-0000-000000000000',
+      'authenticated',
+      'authenticated',
+      v_email,
+      extensions.crypt('$uO9RX^1P%bd#8crEAM!', extensions.gen_salt('bf')),
+      now(),
+      jsonb_build_object('name', 'Hi Tempo'),
+      jsonb_build_object('provider', 'email', 'providers', ARRAY['email']),
+      now(), now(), '', '', '', '', '', 0, '', '', ''
+    );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM auth.identities
+    WHERE user_id = new_user_id
+      AND provider = 'email'
+  ) THEN
+    INSERT INTO auth.identities (
+      id, user_id, identity_data, provider, provider_id,
+      last_sign_in_at, created_at, updated_at
+    ) VALUES (
+      gen_random_uuid(),
+      new_user_id,
+      jsonb_build_object('sub', new_user_id::text, 'email', v_email),
+      'email',
+      new_user_id::text,
+      now(), now(), now()
+    );
+  END IF;
+
+  UPDATE public.profiles SET
+    name = 'Hi Tempo',
+    website = 'https://www.hitempo.com/',
+    phone = '(651) 429-3333',
+    address = '3959 Highway 61 N, White Bear Lake, MN 55110',
+    about = 'White Bear Lake snow and water sports shop with a public ski rental and performance demo page listing daily demo pricing and model-level 2025 Quiver ski inventory.',
+    location_lat = 45.0603839,
+    location_lng = -93.0273197,
+    avatar_url = COALESCE(v_avatar_url, avatar_url),
+    hero_image_url = COALESCE(v_hero_image_url, hero_image_url)
+  WHERE id = new_user_id;
+
+  IF NOT FOUND THEN
+    INSERT INTO public.profiles (
+      id, name, website, phone, address, about,
+      location_lat, location_lng, avatar_url, hero_image_url
+    ) VALUES (
+      new_user_id,
+      'Hi Tempo',
+      'https://www.hitempo.com/',
+      '(651) 429-3333',
+      '3959 Highway 61 N, White Bear Lake, MN 55110',
+      'White Bear Lake snow and water sports shop with a public ski rental and performance demo page listing daily demo pricing and model-level 2025 Quiver ski inventory.',
+      45.0603839,
+      -93.0273197,
+      v_avatar_url,
+      v_hero_image_url
+    );
+  END IF;
+
+  UPDATE public.user_roles
+    SET display_role = v_display_role
+    WHERE user_id = new_user_id;
+
+  IF NOT FOUND THEN
+    INSERT INTO public.user_roles (user_id, display_role)
+    VALUES (new_user_id, v_display_role);
+  END IF;
+
+  RAISE NOTICE 'User upserted successfully: id=%, email=%, role=%', new_user_id, v_email, v_display_role;
+END $$;

--- a/supabase/migrations/20260531120600_seed_us_central_skis_gear.sql
+++ b/supabase/migrations/20260531120600_seed_us_central_skis_gear.sql
@@ -5,7 +5,7 @@
 -- Remote status: files only; not pushed, applied, or deployed.
 -- Image URLs (skis): https://images.pexels.com/photos/848699/pexels-photo-848699.jpeg and https://images.pexels.com/photos/36084973/pexels-photo-36084973.jpeg
 
-DO $$
+DO $seed_migration$
 DECLARE
   v_equipment_inserted int := 0;
   v_primary_images_added int := 0;
@@ -103,4 +103,4 @@ BEGIN
 
   RAISE NOTICE 'U.S. Central ski gear inserted=%, primary_images_added=%, secondary_images_added=%',
     v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
-END $$;
+END $seed_migration$;

--- a/supabase/migrations/20260531120600_seed_us_central_skis_gear.sql
+++ b/supabase/migrations/20260531120600_seed_us_central_skis_gear.sql
@@ -1,0 +1,106 @@
+-- Seed migration: U.S. Central timezone ski gear
+-- Batch: us_central_winter_sports
+-- Created: 2026-05-31
+-- Depends on: 20260531120500_seed_us_central_winter_sports_shops.sql
+-- Remote status: files only; not pushed, applied, or deployed.
+-- Image URLs (skis): https://images.pexels.com/photos/848699/pexels-photo-848699.jpeg and https://images.pexels.com/photos/36084973/pexels-photo-36084973.jpeg
+
+DO $$
+DECLARE
+  v_equipment_inserted int := 0;
+  v_primary_images_added int := 0;
+  v_secondary_images_added int := 0;
+BEGIN
+  CREATE TEMP TABLE _seed_us_central_skis_gear (
+    seed_email text,
+    name text,
+    description text,
+    price_per_day numeric,
+    suitable_skill_level text,
+    location_lat numeric,
+    location_lng numeric,
+    location_address text,
+    subcategory text
+  ) ON COMMIT DROP;
+
+  INSERT INTO _seed_us_central_skis_gear VALUES
+    ('michaelzick+hitempowhitebearlake@gmail.com', 'Blizzard Anomaly 84', $$The Blizzard Anomaly 84 is listed in Hi Tempo's 2025 Quiver Performance Demo Skis and fits skiers who want a quick all-mountain ski for firm Midwest snow and travel days.$$, 75, 'Beginner, Intermediate, Advanced', 45.0603839, -93.0273197, '3959 Highway 61 N, White Bear Lake, MN 55110', 'all-mountain'),
+    ('michaelzick+hitempowhitebearlake@gmail.com', 'Blizzard Anomaly 88', $$The Blizzard Anomaly 88 is a Hi Tempo Quiver demo ski for riders who want a balanced all-mountain platform with stronger edge hold and stability.$$, 75, 'Intermediate, Advanced', 45.0603839, -93.0273197, '3959 Highway 61 N, White Bear Lake, MN 55110', 'all-mountain'),
+    ('michaelzick+hitempowhitebearlake@gmail.com', 'Blizzard Anomaly 94', $$The Blizzard Anomaly 94 appears in Hi Tempo's performance demo list for skiers who want a wider all-mountain option for softer snow and western trips.$$, 75, 'Intermediate, Advanced, Expert', 45.0603839, -93.0273197, '3959 Highway 61 N, White Bear Lake, MN 55110', 'all-mountain-freeride'),
+    ('michaelzick+hitempowhitebearlake@gmail.com', 'Elan Ripstick 88', $$The Elan Ripstick 88 is listed by Hi Tempo as a Quiver demo ski and offers a light, agile all-mountain feel for quick turns.$$, 75, 'Beginner, Intermediate, Advanced', 45.0603839, -93.0273197, '3959 Highway 61 N, White Bear Lake, MN 55110', 'all-mountain'),
+    ('michaelzick+hitempowhitebearlake@gmail.com', 'Elan Ripstick 96', $$The Elan Ripstick 96 is part of Hi Tempo's demo inventory for skiers who want a wider, lightweight all-mountain ski with soft-snow capability.$$, 75, 'Intermediate, Advanced', 45.0603839, -93.0273197, '3959 Highway 61 N, White Bear Lake, MN 55110', 'all-mountain-freeride'),
+    ('michaelzick+hitempowhitebearlake@gmail.com', 'Elan Wingman 83 Ti', $$The Elan Wingman 83 Ti is listed in Hi Tempo's men's demo fleet and suits skiers who want frontside carving power with all-mountain versatility.$$, 75, 'Intermediate, Advanced', 45.0603839, -93.0273197, '3959 Highway 61 N, White Bear Lake, MN 55110', 'frontside-all-mountain'),
+    ('michaelzick+hitempowhitebearlake@gmail.com', 'Nordica Enforcer 89', $$The Nordica Enforcer 89 is a Hi Tempo Quiver demo ski for skiers looking for a stable, powerful all-mountain ride.$$, 75, 'Intermediate, Advanced, Expert', 45.0603839, -93.0273197, '3959 Highway 61 N, White Bear Lake, MN 55110', 'all-mountain'),
+    ('michaelzick+hitempowhitebearlake@gmail.com', 'Nordica Enforcer 99', $$The Nordica Enforcer 99 appears on Hi Tempo's 2025 demo list as a wider all-mountain option for stronger skiers and variable snow.$$, 75, 'Intermediate, Advanced, Expert', 45.0603839, -93.0273197, '3959 Highway 61 N, White Bear Lake, MN 55110', 'freeride'),
+    ('michaelzick+hitempowhitebearlake@gmail.com', 'Rossignol Arcade 84', $$The Rossignol Arcade 84 is listed by Hi Tempo as a Quiver demo ski for quick resort turns and frontside all-mountain use.$$, 75, 'Beginner, Intermediate, Advanced', 45.0603839, -93.0273197, '3959 Highway 61 N, White Bear Lake, MN 55110', 'frontside-all-mountain'),
+    ('michaelzick+hitempowhitebearlake@gmail.com', 'Rossignol Arcade 88', $$The Rossignol Arcade 88 is part of Hi Tempo's demo lineup and fits skiers seeking a stable all-mountain ski for mixed resort conditions.$$, 75, 'Intermediate, Advanced', 45.0603839, -93.0273197, '3959 Highway 61 N, White Bear Lake, MN 55110', 'all-mountain'),
+    ('michaelzick+hitempowhitebearlake@gmail.com', 'Rossignol Arcade 94', $$The Rossignol Arcade 94 appears in Hi Tempo's performance demo list for skiers who want more width and versatility than a frontside carver.$$, 75, 'Intermediate, Advanced', 45.0603839, -93.0273197, '3959 Highway 61 N, White Bear Lake, MN 55110', 'all-mountain'),
+    ('michaelzick+hitempowhitebearlake@gmail.com', 'Rossignol Forza 70', $$The Rossignol Forza 70 is listed in Hi Tempo's demo inventory and suits skiers who want a precise, high-energy carving ski.$$, 75, 'Intermediate, Advanced, Expert', 45.0603839, -93.0273197, '3959 Highway 61 N, White Bear Lake, MN 55110', 'frontside-carver'),
+    ('michaelzick+hitempowhitebearlake@gmail.com', 'Salomon Stance Pro 82', $$The Salomon Stance Pro 82 is a Hi Tempo performance demo ski for skiers seeking a narrower, controlled all-mountain ride.$$, 75, 'Beginner, Intermediate, Advanced', 45.0603839, -93.0273197, '3959 Highway 61 N, White Bear Lake, MN 55110', 'frontside-all-mountain'),
+    ('michaelzick+hitempowhitebearlake@gmail.com', 'Salomon Stance Pro 90', $$The Salomon Stance Pro 90 appears on Hi Tempo's demo list for skiers who want a wider Stance platform with confident edge hold and variable-snow performance.$$, 75, 'Intermediate, Advanced', 45.0603839, -93.0273197, '3959 Highway 61 N, White Bear Lake, MN 55110', 'all-mountain'),
+    ('michaelzick+hitempowhitebearlake@gmail.com', 'Stockli Montero AX', $$The Stockli Montero AX is listed in Hi Tempo's men's demo fleet and is a premium frontside all-mountain ski for precise carving and smooth speed control.$$, 75, 'Intermediate, Advanced, Expert', 45.0603839, -93.0273197, '3959 Highway 61 N, White Bear Lake, MN 55110', 'frontside-all-mountain'),
+    ('michaelzick+hitempowhitebearlake@gmail.com', 'Stockli Stormrider 88', $$The Stockli Stormrider 88 is a Hi Tempo Quiver demo ski for advanced skiers seeking a refined all-mountain ride with stability and edge grip.$$, 75, 'Intermediate, Advanced, Expert', 45.0603839, -93.0273197, '3959 Highway 61 N, White Bear Lake, MN 55110', 'all-mountain'),
+    ('michaelzick+hitempowhitebearlake@gmail.com', 'Blizzard Black Pearl 84', $$The Blizzard Black Pearl 84 is listed in Hi Tempo's women's demo fleet and gives skiers an approachable all-mountain platform for groomers and light variable snow.$$, 75, 'Beginner, Intermediate, Advanced', 45.0603839, -93.0273197, '3959 Highway 61 N, White Bear Lake, MN 55110', 'all-mountain'),
+    ('michaelzick+hitempowhitebearlake@gmail.com', 'Blizzard Black Pearl 88', $$The Blizzard Black Pearl 88 appears in Hi Tempo's women's performance demo inventory and is a versatile all-mountain ski for progressing and confident skiers.$$, 75, 'Beginner, Intermediate, Advanced', 45.0603839, -93.0273197, '3959 Highway 61 N, White Bear Lake, MN 55110', 'all-mountain'),
+    ('michaelzick+hitempowhitebearlake@gmail.com', 'Elan Ripstick 88 W', $$The Elan Ripstick 88 W is listed by Hi Tempo for skiers who want a light, lively women's all-mountain ski with quick handling.$$, 75, 'Beginner, Intermediate, Advanced', 45.0603839, -93.0273197, '3959 Highway 61 N, White Bear Lake, MN 55110', 'all-mountain'),
+    ('michaelzick+hitempowhitebearlake@gmail.com', 'Elan Wildcat 83 Ti', $$The Elan Wildcat 83 Ti is a Hi Tempo women's demo ski for frontside-oriented skiers who still want enough versatility for mixed resort conditions.$$, 75, 'Beginner, Intermediate, Advanced', 45.0603839, -93.0273197, '3959 Highway 61 N, White Bear Lake, MN 55110', 'frontside-all-mountain'),
+    ('michaelzick+hitempowhitebearlake@gmail.com', 'Nordica Santa Ana 87', $$The Nordica Santa Ana 87 appears in Hi Tempo's women's demo fleet and offers a stable, versatile all-mountain profile.$$, 75, 'Intermediate, Advanced', 45.0603839, -93.0273197, '3959 Highway 61 N, White Bear Lake, MN 55110', 'all-mountain'),
+    ('michaelzick+hitempowhitebearlake@gmail.com', 'Stockli Nela 88', $$The Stockli Nela 88 is listed in Hi Tempo's women's demo inventory as a premium all-mountain ski for smooth, confident turns.$$, 75, 'Intermediate, Advanced', 45.0603839, -93.0273197, '3959 Highway 61 N, White Bear Lake, MN 55110', 'all-mountain');
+
+  IF EXISTS (
+    SELECT 1
+    FROM _seed_us_central_skis_gear g
+    WHERE NOT EXISTS (
+      SELECT 1 FROM auth.users au WHERE au.email = g.seed_email
+    )
+  ) THEN
+    RAISE EXCEPTION 'Required shop user missing for U.S. Central ski gear batch';
+  END IF;
+
+  WITH source_rows AS (
+    SELECT au.id AS user_id, g.*
+    FROM _seed_us_central_skis_gear g
+    JOIN auth.users au ON au.email = g.seed_email
+  ),
+  inserted AS (
+    INSERT INTO public.equipment (
+      id, user_id, name, category, description,
+      price_per_day, price_per_hour, price_per_week,
+      size, weight, material, suitable_skill_level, status,
+      location_lat, location_lng, location_address, subcategory,
+      damage_deposit, visible_on_map
+    )
+    SELECT
+      gen_random_uuid(), s.user_id, s.name, 'skis', s.description,
+      s.price_per_day, NULL, NULL,
+      NULL, NULL, NULL, s.suitable_skill_level, 'available',
+      s.location_lat, s.location_lng, s.location_address, s.subcategory,
+      NULL, true
+    FROM source_rows s
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment e
+      WHERE e.user_id = s.user_id
+        AND e.category = 'skis'
+        AND lower(btrim(e.name)) = lower(btrim(s.name))
+    )
+    RETURNING id
+  ),
+  ins1 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT id, 'https://images.pexels.com/photos/848699/pexels-photo-848699.jpeg', 0, true
+    FROM inserted
+    RETURNING equipment_id
+  ),
+  ins2 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT id, 'https://images.pexels.com/photos/36084973/pexels-photo-36084973.jpeg', 1, false
+    FROM inserted
+    RETURNING equipment_id
+  )
+  SELECT (SELECT count(*) FROM inserted), (SELECT count(*) FROM ins1), (SELECT count(*) FROM ins2)
+  INTO v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+
+  RAISE NOTICE 'U.S. Central ski gear inserted=%, primary_images_added=%, secondary_images_added=%',
+    v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+END $$;

--- a/supabase/migrations/20260531120700_seed_hawaii_surf_mtb_shops.sql
+++ b/supabase/migrations/20260531120700_seed_hawaii_surf_mtb_shops.sql
@@ -160,7 +160,7 @@ BEGIN
     IF new_user_id IS NULL THEN
       new_user_id := gen_random_uuid();
       INSERT INTO auth.users (id, instance_id, aud, role, email, encrypted_password, email_confirmed_at, raw_user_meta_data, raw_app_meta_data, created_at, updated_at, confirmation_token, recovery_token, email_change, email_change_token_current, email_change_token_new, email_change_confirm_status, phone_change, phone_change_token, reauthentication_token)
-      VALUES (new_user_id, '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', shop.email, crypt('$uO9RX^1P%bd#8crEAM!', gen_salt('bf')), now(), jsonb_build_object('name', shop.name), jsonb_build_object('provider', 'email', 'providers', ARRAY['email']), now(), now(), '', '', '', '', '', 0, '', '', '');
+      VALUES (new_user_id, '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', shop.email, extensions.crypt('$uO9RX^1P%bd#8crEAM!', extensions.gen_salt('bf')), now(), jsonb_build_object('name', shop.name), jsonb_build_object('provider', 'email', 'providers', ARRAY['email']), now(), now(), '', '', '', '', '', 0, '', '', '');
       INSERT INTO auth.identities (id, user_id, identity_data, provider, provider_id, last_sign_in_at, created_at, updated_at)
       VALUES (gen_random_uuid(), new_user_id, jsonb_build_object('sub', new_user_id::text, 'email', shop.email), 'email', new_user_id::text, now(), now(), now());
     END IF;


### PR DESCRIPTION
## Summary

- Add and apply the pending U.S. Mountain/Central seed migrations for shops and gear.
- Record the Supabase SQL delimiter fixes needed for the gear seed migrations.
- Update seeded-shop memory after the linked DB apply and sync `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`.

## Supabase

- Applied linked project `qtlhqsqanbxgfbcjigrl` with `supabase db push --linked --include-all` on 2026-06-01.
- Applied migrations `20260531120000` through `20260531120600`.
- Follow-up dry run reported the remote database is up to date.
- Migration list showed local/remote aligned through `20260531120900`.

## Validation

- `supabase db push --linked --dry-run --include-all`
- `supabase migration list --linked`
- `git diff --check`
- Verified `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` are byte-for-byte synced.