### PR TITLE
Seed North America coverage batch for DemoStoke gear

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,7 +252,7 @@ Do not substitute other image sources for seed data. If new categories are added
 
 ## Seed Data — Current Seeded Shops
 
-This summary reflects read-only linked DemoStoke data checks after the June 1, 2026 U.S. Eastern, Hawaii, Mountain, and Central seed applies. The Wax Bench row is an existing live profile retargeted by the Canada batch; its gear count is the current profile count after 17 inserts and 11 updates, not a newly created shop.
+This summary reflects read-only linked DemoStoke data checks after the June 1, 2026 U.S. Eastern, Hawaii, Mountain, Central, and North America coverage fill seed applies. The Wax Bench row is an existing live profile retargeted by the Canada batch; its gear count is the current profile count after 17 inserts and 11 updates, not a newly created shop.
 
 | # | Shop | Region | Category | Gear | Status |
 |---|---|---|---|---|---|
@@ -309,7 +309,13 @@ This summary reflects read-only linked DemoStoke data checks after the June 1, 2
 | 51 | Arizona Snowbowl Agassiz Pro Shop | Flagstaff, AZ | skis + snowboards | 20 | applied |
 | 52 | Deer Valley Resort Ski Rentals | Park City, UT | skis | 6 | applied |
 | 53 | Hi Tempo | White Bear Lake, MN | skis | 22 | applied |
-| | **Total** | | | **609** | |
+| 54 | Surf Mexico | Bucerias, Nayarit | surfboards | 8 | applied |
+| 55 | BikeFlow Oaxaca | Oaxaca, Oaxaca | mountain-bikes | 5 | applied |
+| 56 | Bike Denali | Denali Park, AK | mountain-bikes | 1 | applied |
+| 57 | Dismount Bike Shop | Toronto, ON | mountain-bikes | 3 | applied |
+| 58 | Willi's Ski and Board Seven Springs | Champion, PA | skis | 10 | applied |
+| 59 | Tactics Bend | Bend, OR | snowboards | 10 | applied |
+| | **Total** | | | **646** | |
 
 Do not re-seed any shop already in this table. Do not seed Hawaii Surfboard Rentals under any Hawaii discovery task.
 
@@ -323,14 +329,6 @@ These files exist locally but have **not** been pushed/applied to the linked Dem
   - audit folder: `demostoke_seed_batches/eastern_time_zone_all_categories/`
   - shops: Belleayre Mountain; Highland Mountain Bike Park; Thunder Mountain Bike Park; Ride Kanuga; REAL Watersports; Warm Winds Surf Shop; Cinnamon Rainbows Surf Co.
   - planned gear counts: surfboards 14, skis 5, snowboards 2, mountain-bikes 19
-
-- North America coverage fill batch, status `local pending`, created June 1, 2026:
-  - shops migration: `supabase/migrations/20260601120000_seed_north_america_coverage_fill_shops.sql`
-  - gear migrations: `20260601120100_seed_north_america_coverage_fill_surfboards_gear.sql`, `20260601120200_seed_north_america_coverage_fill_skis_gear.sql`, `20260601120300_seed_north_america_coverage_fill_snowboards_gear.sql`, `20260601120400_seed_north_america_coverage_fill_mountain_bikes_gear.sql`
-  - audit folder: `demostoke_seed_batches/north_america_coverage_fill/`
-  - shops: Surf Mexico; BikeFlow Oaxaca; Bike Denali; Dismount Bike Shop; Willi's Ski and Board Seven Springs; Tactics Bend
-  - planned gear counts: surfboards 8, skis 10, snowboards 10, mountain-bikes 9
-  - covers Mexico surfboards and mountain-bikes, Alaska mountain-bikes, Canada mountain-bikes, and mainland U.S. skis and snowboards; do not describe these shops as live until these migrations are explicitly applied.
 
 ## Seed Data — Historical Hermes Migration Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,6 +324,14 @@ These files exist locally but have **not** been pushed/applied to the linked Dem
   - shops: Belleayre Mountain; Highland Mountain Bike Park; Thunder Mountain Bike Park; Ride Kanuga; REAL Watersports; Warm Winds Surf Shop; Cinnamon Rainbows Surf Co.
   - planned gear counts: surfboards 14, skis 5, snowboards 2, mountain-bikes 19
 
+- North America coverage fill batch, status `local pending`, created June 1, 2026:
+  - shops migration: `supabase/migrations/20260601120000_seed_north_america_coverage_fill_shops.sql`
+  - gear migrations: `20260601120100_seed_north_america_coverage_fill_surfboards_gear.sql`, `20260601120200_seed_north_america_coverage_fill_skis_gear.sql`, `20260601120300_seed_north_america_coverage_fill_snowboards_gear.sql`, `20260601120400_seed_north_america_coverage_fill_mountain_bikes_gear.sql`
+  - audit folder: `demostoke_seed_batches/north_america_coverage_fill/`
+  - shops: Surf Mexico; BikeFlow Oaxaca; Bike Denali; Dismount Bike Shop; Willi's Ski and Board Seven Springs; Tactics Bend
+  - planned gear counts: surfboards 8, skis 10, snowboards 10, mountain-bikes 9
+  - covers Mexico surfboards and mountain-bikes, Alaska mountain-bikes, Canada mountain-bikes, and mainland U.S. skis and snowboards; do not describe these shops as live until these migrations are explicitly applied.
+
 ## Seed Data — Historical Hermes Migration Notes
 
 The final-state Hermes seed migrations for Park City/Jans/White Pine, Arizona, Oregon, Colorado, Ventura County, and Texas are now tracked under `supabase/migrations/` and marked applied in linked migration metadata. Do not apply them again to linked data.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,7 +252,7 @@ Do not substitute other image sources for seed data. If new categories are added
 
 ## Seed Data — Current Seeded Shops
 
-This summary reflects read-only linked DemoStoke data checks after the June 1, 2026 U.S. Eastern, Hawaii, Mountain, and Central seed applies. The Wax Bench row is an existing live profile retargeted by the Canada batch; its gear count is the current profile count after 17 inserts and 11 updates, not a newly created shop.
+This summary reflects read-only linked DemoStoke data checks after the June 1, 2026 U.S. Eastern, Hawaii, Mountain, Central, and North America coverage fill seed applies. The Wax Bench row is an existing live profile retargeted by the Canada batch; its gear count is the current profile count after 17 inserts and 11 updates, not a newly created shop.
 
 | # | Shop | Region | Category | Gear | Status |
 |---|---|---|---|---|---|
@@ -309,7 +309,13 @@ This summary reflects read-only linked DemoStoke data checks after the June 1, 2
 | 51 | Arizona Snowbowl Agassiz Pro Shop | Flagstaff, AZ | skis + snowboards | 20 | applied |
 | 52 | Deer Valley Resort Ski Rentals | Park City, UT | skis | 6 | applied |
 | 53 | Hi Tempo | White Bear Lake, MN | skis | 22 | applied |
-| | **Total** | | | **609** | |
+| 54 | Surf Mexico | Bucerias, Nayarit | surfboards | 8 | applied |
+| 55 | BikeFlow Oaxaca | Oaxaca, Oaxaca | mountain-bikes | 5 | applied |
+| 56 | Bike Denali | Denali Park, AK | mountain-bikes | 1 | applied |
+| 57 | Dismount Bike Shop | Toronto, ON | mountain-bikes | 3 | applied |
+| 58 | Willi's Ski and Board Seven Springs | Champion, PA | skis | 10 | applied |
+| 59 | Tactics Bend | Bend, OR | snowboards | 10 | applied |
+| | **Total** | | | **646** | |
 
 Do not re-seed any shop already in this table. Do not seed Hawaii Surfboard Rentals under any Hawaii discovery task.
 
@@ -323,14 +329,6 @@ These files exist locally but have **not** been pushed/applied to the linked Dem
   - audit folder: `demostoke_seed_batches/eastern_time_zone_all_categories/`
   - shops: Belleayre Mountain; Highland Mountain Bike Park; Thunder Mountain Bike Park; Ride Kanuga; REAL Watersports; Warm Winds Surf Shop; Cinnamon Rainbows Surf Co.
   - planned gear counts: surfboards 14, skis 5, snowboards 2, mountain-bikes 19
-
-- North America coverage fill batch, status `local pending`, created June 1, 2026:
-  - shops migration: `supabase/migrations/20260601120000_seed_north_america_coverage_fill_shops.sql`
-  - gear migrations: `20260601120100_seed_north_america_coverage_fill_surfboards_gear.sql`, `20260601120200_seed_north_america_coverage_fill_skis_gear.sql`, `20260601120300_seed_north_america_coverage_fill_snowboards_gear.sql`, `20260601120400_seed_north_america_coverage_fill_mountain_bikes_gear.sql`
-  - audit folder: `demostoke_seed_batches/north_america_coverage_fill/`
-  - shops: Surf Mexico; BikeFlow Oaxaca; Bike Denali; Dismount Bike Shop; Willi's Ski and Board Seven Springs; Tactics Bend
-  - planned gear counts: surfboards 8, skis 10, snowboards 10, mountain-bikes 9
-  - covers Mexico surfboards and mountain-bikes, Alaska mountain-bikes, Canada mountain-bikes, and mainland U.S. skis and snowboards; do not describe these shops as live until these migrations are explicitly applied.
 
 ## Seed Data — Historical Hermes Migration Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,6 +324,14 @@ These files exist locally but have **not** been pushed/applied to the linked Dem
   - shops: Belleayre Mountain; Highland Mountain Bike Park; Thunder Mountain Bike Park; Ride Kanuga; REAL Watersports; Warm Winds Surf Shop; Cinnamon Rainbows Surf Co.
   - planned gear counts: surfboards 14, skis 5, snowboards 2, mountain-bikes 19
 
+- North America coverage fill batch, status `local pending`, created June 1, 2026:
+  - shops migration: `supabase/migrations/20260601120000_seed_north_america_coverage_fill_shops.sql`
+  - gear migrations: `20260601120100_seed_north_america_coverage_fill_surfboards_gear.sql`, `20260601120200_seed_north_america_coverage_fill_skis_gear.sql`, `20260601120300_seed_north_america_coverage_fill_snowboards_gear.sql`, `20260601120400_seed_north_america_coverage_fill_mountain_bikes_gear.sql`
+  - audit folder: `demostoke_seed_batches/north_america_coverage_fill/`
+  - shops: Surf Mexico; BikeFlow Oaxaca; Bike Denali; Dismount Bike Shop; Willi's Ski and Board Seven Springs; Tactics Bend
+  - planned gear counts: surfboards 8, skis 10, snowboards 10, mountain-bikes 9
+  - covers Mexico surfboards and mountain-bikes, Alaska mountain-bikes, Canada mountain-bikes, and mainland U.S. skis and snowboards; do not describe these shops as live until these migrations are explicitly applied.
+
 ## Seed Data — Historical Hermes Migration Notes
 
 The final-state Hermes seed migrations for Park City/Jans/White Pine, Arizona, Oregon, Colorado, Ventura County, and Texas are now tracked under `supabase/migrations/` and marked applied in linked migration metadata. Do not apply them again to linked data.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -252,7 +252,7 @@ Do not substitute other image sources for seed data. If new categories are added
 
 ## Seed Data — Current Seeded Shops
 
-This summary reflects read-only linked DemoStoke data checks after the June 1, 2026 U.S. Eastern, Hawaii, Mountain, and Central seed applies. The Wax Bench row is an existing live profile retargeted by the Canada batch; its gear count is the current profile count after 17 inserts and 11 updates, not a newly created shop.
+This summary reflects read-only linked DemoStoke data checks after the June 1, 2026 U.S. Eastern, Hawaii, Mountain, Central, and North America coverage fill seed applies. The Wax Bench row is an existing live profile retargeted by the Canada batch; its gear count is the current profile count after 17 inserts and 11 updates, not a newly created shop.
 
 | # | Shop | Region | Category | Gear | Status |
 |---|---|---|---|---|---|
@@ -309,7 +309,13 @@ This summary reflects read-only linked DemoStoke data checks after the June 1, 2
 | 51 | Arizona Snowbowl Agassiz Pro Shop | Flagstaff, AZ | skis + snowboards | 20 | applied |
 | 52 | Deer Valley Resort Ski Rentals | Park City, UT | skis | 6 | applied |
 | 53 | Hi Tempo | White Bear Lake, MN | skis | 22 | applied |
-| | **Total** | | | **609** | |
+| 54 | Surf Mexico | Bucerias, Nayarit | surfboards | 8 | applied |
+| 55 | BikeFlow Oaxaca | Oaxaca, Oaxaca | mountain-bikes | 5 | applied |
+| 56 | Bike Denali | Denali Park, AK | mountain-bikes | 1 | applied |
+| 57 | Dismount Bike Shop | Toronto, ON | mountain-bikes | 3 | applied |
+| 58 | Willi's Ski and Board Seven Springs | Champion, PA | skis | 10 | applied |
+| 59 | Tactics Bend | Bend, OR | snowboards | 10 | applied |
+| | **Total** | | | **646** | |
 
 Do not re-seed any shop already in this table. Do not seed Hawaii Surfboard Rentals under any Hawaii discovery task.
 
@@ -323,14 +329,6 @@ These files exist locally but have **not** been pushed/applied to the linked Dem
   - audit folder: `demostoke_seed_batches/eastern_time_zone_all_categories/`
   - shops: Belleayre Mountain; Highland Mountain Bike Park; Thunder Mountain Bike Park; Ride Kanuga; REAL Watersports; Warm Winds Surf Shop; Cinnamon Rainbows Surf Co.
   - planned gear counts: surfboards 14, skis 5, snowboards 2, mountain-bikes 19
-
-- North America coverage fill batch, status `local pending`, created June 1, 2026:
-  - shops migration: `supabase/migrations/20260601120000_seed_north_america_coverage_fill_shops.sql`
-  - gear migrations: `20260601120100_seed_north_america_coverage_fill_surfboards_gear.sql`, `20260601120200_seed_north_america_coverage_fill_skis_gear.sql`, `20260601120300_seed_north_america_coverage_fill_snowboards_gear.sql`, `20260601120400_seed_north_america_coverage_fill_mountain_bikes_gear.sql`
-  - audit folder: `demostoke_seed_batches/north_america_coverage_fill/`
-  - shops: Surf Mexico; BikeFlow Oaxaca; Bike Denali; Dismount Bike Shop; Willi's Ski and Board Seven Springs; Tactics Bend
-  - planned gear counts: surfboards 8, skis 10, snowboards 10, mountain-bikes 9
-  - covers Mexico surfboards and mountain-bikes, Alaska mountain-bikes, Canada mountain-bikes, and mainland U.S. skis and snowboards; do not describe these shops as live until these migrations are explicitly applied.
 
 ## Seed Data — Historical Hermes Migration Notes
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -324,6 +324,14 @@ These files exist locally but have **not** been pushed/applied to the linked Dem
   - shops: Belleayre Mountain; Highland Mountain Bike Park; Thunder Mountain Bike Park; Ride Kanuga; REAL Watersports; Warm Winds Surf Shop; Cinnamon Rainbows Surf Co.
   - planned gear counts: surfboards 14, skis 5, snowboards 2, mountain-bikes 19
 
+- North America coverage fill batch, status `local pending`, created June 1, 2026:
+  - shops migration: `supabase/migrations/20260601120000_seed_north_america_coverage_fill_shops.sql`
+  - gear migrations: `20260601120100_seed_north_america_coverage_fill_surfboards_gear.sql`, `20260601120200_seed_north_america_coverage_fill_skis_gear.sql`, `20260601120300_seed_north_america_coverage_fill_snowboards_gear.sql`, `20260601120400_seed_north_america_coverage_fill_mountain_bikes_gear.sql`
+  - audit folder: `demostoke_seed_batches/north_america_coverage_fill/`
+  - shops: Surf Mexico; BikeFlow Oaxaca; Bike Denali; Dismount Bike Shop; Willi's Ski and Board Seven Springs; Tactics Bend
+  - planned gear counts: surfboards 8, skis 10, snowboards 10, mountain-bikes 9
+  - covers Mexico surfboards and mountain-bikes, Alaska mountain-bikes, Canada mountain-bikes, and mainland U.S. skis and snowboards; do not describe these shops as live until these migrations are explicitly applied.
+
 ## Seed Data — Historical Hermes Migration Notes
 
 The final-state Hermes seed migrations for Park City/Jans/White Pine, Arizona, Oregon, Colorado, Ventura County, and Texas are now tracked under `supabase/migrations/` and marked applied in linked migration metadata. Do not apply them again to linked data.

--- a/demostoke_seed_batches/north_america_coverage_fill/discovery_audit.md
+++ b/demostoke_seed_batches/north_america_coverage_fill/discovery_audit.md
@@ -1,6 +1,6 @@
 # North America Coverage Fill Discovery Audit
 
-Status: local preparation only. These migrations have not been pushed, applied, or deployed to the linked DemoStoke Supabase project.
+Status: applied to the linked DemoStoke Supabase project on 2026-06-01 after a rollback dry run succeeded.
 
 Created: 2026-06-01
 

--- a/demostoke_seed_batches/north_america_coverage_fill/discovery_audit.md
+++ b/demostoke_seed_batches/north_america_coverage_fill/discovery_audit.md
@@ -1,0 +1,113 @@
+# North America Coverage Fill Discovery Audit
+
+Status: local preparation only. These migrations have not been pushed, applied, or deployed to the linked DemoStoke Supabase project.
+
+Created: 2026-06-01
+
+Branch: `codex/north-america-gear-coverage`
+
+## Scope
+
+The user requested a Hermes `demostoke-gear-adder` run for Alaska, Mexico, remaining mainland U.S. coverage, and Canada, with no duplicate shops and all four supported categories represented across North America.
+
+This batch adds six non-duplicate shops and 37 planned gear rows:
+
+| Region | Shop | Category | Planned gear |
+| --- | --- | --- | ---: |
+| Mexico | Surf Mexico | surfboards | 8 |
+| Mexico | BikeFlow Oaxaca | mountain-bikes | 5 |
+| Alaska | Bike Denali | mountain-bikes | 1 |
+| Canada | Dismount Bike Shop | mountain-bikes | 3 |
+| Mainland U.S. | Willi's Ski and Board Seven Springs | skis | 10 |
+| Mainland U.S. | Tactics Bend | snowboards | 10 |
+
+## Duplicate Checks
+
+Read-only linked DB checks were run before authoring migrations. The selected shops returned zero existing `public.profiles` matches by shop name, website, and key domain fragments.
+
+Representative linked DB query:
+
+```sql
+SELECT p.name, p.website, p.address, u.email, COUNT(DISTINCT e.id) AS gear_count
+FROM public.profiles p
+LEFT JOIN auth.users u ON u.id = p.id
+LEFT JOIN public.equipment e ON e.user_id = p.id
+WHERE lower(p.name) IN (
+  'surf mexico',
+  'bikeflow oaxaca',
+  'bike flow oaxaca',
+  'bike denali',
+  'dismount bike shop',
+  'willi''s ski and board seven springs',
+  'tactics bend'
+)
+OR lower(coalesce(p.website, '')) LIKE '%surfmexico.com%'
+OR lower(coalesce(p.website, '')) LIKE '%bikeflow.com.mx%'
+OR lower(coalesce(p.website, '')) LIKE '%bikedenali.com%'
+OR lower(coalesce(p.website, '')) LIKE '%dismount-bike-shop%'
+OR lower(coalesce(p.website, '')) LIKE '%willisskiandboard.com%'
+OR lower(coalesce(p.website, '')) LIKE '%tactics.com/info/bend%'
+GROUP BY p.name, p.website, p.address, u.email
+ORDER BY p.name;
+```
+
+Result: `rows: []`.
+
+## Accepted Sources
+
+### Surf Mexico
+
+- Official rental page: `https://www.surfmexico.com/surfboards-rentals/`
+- Evidence: official page lists pickup/contact details, standard surfboards at 700 MXN per day and 3000 MXN per week, and high-performance surfboards at 800 MXN per day and 3500 MXN per week.
+- Accepted gear: Walden Magic, Walden Magic Blue Dark, Walden Magic Blue, NSP Protech Fish, NSP Protech Tinder-D8, Walden Mini Mega Magic Tuflite, Channel Islands Water, Robert August What I Ride.
+- Location basis: official address plus official Google Maps redirect for Surf Mexico.
+
+### BikeFlow Oaxaca
+
+- Official rental page: `https://bikeflow.com.mx/bike-rental/`
+- Evidence: official page lists Trek Marlin, Specialized Rockhopper, Scott Aspect, Cube Access WS EAZ, and Belfort Alom with a 600 MXN 24-hour starting price.
+- Accepted gear: Trek Marlin, Specialized Rockhopper, Scott Aspect, Cube Access WS EAZ, Belfort Alom.
+- Location basis: official address; coordinate approximated from the mapped Martires de Tacubaya street center because exact rooftop geocoding did not resolve.
+
+### Bike Denali
+
+- Official mountain-bike page: `https://bikedenali.com/mountain-bikes/`
+- Price backup: `https://www.alaska.org/detail/bike-denali`
+- Evidence: official page lists Trek Marlin 5 mountain-bike rentals and the Bike Denali address. Alaska.org publishes the single-day Trek Marlin 5 package rate at 85 USD.
+- Accepted gear: Trek Marlin 5.
+- Location basis: official Mile 238.5 Parks Highway address, aligned to the same milepost area using Denali Princess Wilderness Lodge mapping.
+
+### Dismount Bike Shop
+
+- Official Booqable rental page: `https://dismount-bike-shop.booqableshop.com/`
+- Official pricing page: `https://dismount-bike-shop.booqableshop.com/pages/pricing`
+- Evidence: rental page lists Norco Fluid FS A2, Norco Bigfoot 2, and Salsa Heyday Advent; pricing page lists bike daily rate at 80 CAD and shop address.
+- Accepted gear: Norco Fluid FS A2, Norco Bigfoot 2, Salsa Heyday Advent.
+- Location basis: official address and OpenStreetMap result for Dismount at 936 St Clair Ave W.
+
+### Willi's Ski and Board Seven Springs
+
+- Official demo page: `https://www.willisskiandboard.com/pages/seven-springs-demo-skis`
+- Official locations page: `https://www.willisskiandboard.com/pages/locations-and-hours`
+- Evidence: official demo page lists the 75 USD demo fee and a model-level demo ski fleet. Official locations page lists the Seven Springs shop address and phone.
+- Accepted gear: Atomic Maverick 96 CTI, Atomic Maverick 88 CTI, Blizzard Black Pearl 84, Blizzard Anomaly 88, Elan Ripstick 96 Black Edition, Head Supershape e-Rally, Nordica Enforcer 94, Rossignol Arcade 88, Stockli Montero AR, Stockli Nela 88.
+- Location basis: official address plus MapQuest coordinate result for 777 Water Wheel Dr.
+
+### Tactics Bend
+
+- Official rental page: `https://www.tactics.com/info/bend-snowboard-rentals-services`
+- Address backup: `https://www.mapquest.com/us/oregon/tactics-bend-371161058`
+- Evidence: official page lists demo snowboard rental rates, phone, email, and model-level demo fleet. MapQuest lists the Bend store address and phone.
+- Accepted gear: Burton 3D Fish, Burton Family Tree Hometown Hero, CAPiTA DOA, CAPiTA Mega Mercury, CAPiTA Mercury, Jones Frontier, Korua Shapes Cafe Racer Classic, Lib Tech Cold Brew C2, Lib Tech T.Rice Orca C2X HP, Ride Warpig.
+- Location basis: official Google Maps redirect and OpenStreetMap result for Tactics at 933 NW Wall St.
+
+## Data Rules Applied
+
+- No shop already present in the linked DemoStoke DB was re-seeded.
+- Gear rows are category-homogeneous by migration.
+- Each gear row has two canonical category placeholder images.
+- `public.equipment.specs` is never referenced.
+- `size` is left `NULL`; model lengths, volumes, and numbered board/ski sizes stay in the description prose.
+- Skill levels use only the sequential approved values.
+- SQL is idempotent by user email and `(user_id, category, lower(trim(name)))`.
+- These files are local-only until a human explicitly approves remote execution.

--- a/demostoke_seed_batches/north_america_coverage_fill/local_test_report.md
+++ b/demostoke_seed_batches/north_america_coverage_fill/local_test_report.md
@@ -1,0 +1,29 @@
+# Local Test Report - North America Coverage Fill
+
+Status: local preparation only. No linked DB writes were run.
+
+## Completed Before File Generation
+
+- Created and switched to branch `codex/north-america-gear-coverage`.
+- Ran `supabase migration list --linked`; local and linked migration metadata were aligned through the existing May 31, 2026 seed migrations.
+- Ran read-only linked DB duplicate checks for selected shop names, domains, and websites; selected shops returned zero matches.
+- Verified official source pages for accepted shops and documented held/rejected candidates.
+
+## Completed After File Generation
+
+```bash
+rg -n "DELETE FROM|TRUNCATE|ALTER TABLE|ON CONFLICT|specs" supabase/migrations/20260601120*.sql
+LC_ALL=C rg -n "[^[:ascii:]]" supabase/migrations/20260601120*.sql demostoke_seed_batches/north_america_coverage_fill
+git diff --check
+supabase migration list --linked
+node -e "JSON.parse(require('fs').readFileSync('demostoke_seed_batches/north_america_coverage_fill/sources.json','utf8')); console.log('sources.json ok')"
+```
+
+Results:
+
+- No unsafe write/destructive schema matches in the generated migrations.
+- No non-ASCII text in generated seed files or audit docs.
+- No disallowed skill-level strings starting with `Intermediate` or `Advanced`.
+- `sources.json` parsed successfully.
+- `git diff --check` returned no whitespace errors.
+- `supabase migration list --linked` shows these five migrations as local-only until the user approves remote application.

--- a/demostoke_seed_batches/north_america_coverage_fill/local_test_report.md
+++ b/demostoke_seed_batches/north_america_coverage_fill/local_test_report.md
@@ -1,6 +1,6 @@
 # Local Test Report - North America Coverage Fill
 
-Status: local preparation only. No linked DB writes were run.
+Status: applied to the linked DemoStoke Supabase project on 2026-06-01 after linked rollback dry runs succeeded.
 
 ## Completed Before File Generation
 
@@ -26,4 +26,4 @@ Results:
 - No disallowed skill-level strings starting with `Intermediate` or `Advanced`.
 - `sources.json` parsed successfully.
 - `git diff --check` returned no whitespace errors.
-- `supabase migration list --linked` shows these five migrations as local-only until the user approves remote application.
+- `supabase migration list --linked` showed these five migrations as local-only before apply; after apply and migration repair, local and remote history aligned.

--- a/demostoke_seed_batches/north_america_coverage_fill/rejected_candidates.md
+++ b/demostoke_seed_batches/north_america_coverage_fill/rejected_candidates.md
@@ -1,0 +1,43 @@
+# Rejected and Held Candidates
+
+Status: local research notes for the North America coverage fill batch.
+
+## Rejected
+
+### Powder Hound Ski and Bike Shop, Girdwood, AK
+
+- URL checked: `https://www.powderhoundak.com/pages/demos-rentals`
+- Reason: official page exposes rental/demo policy and rates, but did not provide enough model-level ski or snowboard rental rows for the required shop/gear seed criteria.
+
+### Alaska surfboard rental candidates
+
+- Reason: research did not find an Alaska surf shop with a public model-level surfboard rental catalog, public pricing, and a usable shop location.
+
+### WildMex, Nayarit, Mexico
+
+- URL checked: `https://wildmex.com/rentals/`
+- Reason: official surf rental material exposes board categories and pricing, but not a stable model-level brand and model rental catalog suitable for DemoStoke gear rows.
+
+### Surf Sister and other Tofino surf rental pages
+
+- Reason: Canada surf rental pages found during this pass generally expose board type and price, but not model-level brand and model rows.
+
+### Suburban Ski and Bike, Berlin, CT
+
+- URL checked: `https://suburbanskiandbike.com/pages/demo-skis`
+- Reason: official page has a strong model-level demo ski list and contact details, but no explicit rental price on the current page beyond demo credit language. Held in favor of Willi's Seven Springs, which publishes both price and model rows.
+
+### XSports, Colorado
+
+- Reason: page showed demo ski/snowboard pricing and brands, but not enough model-level rental rows, and Colorado already has live seeded coverage.
+
+## Held for Future Retry
+
+### Mountain Creek Bike Park, NJ
+
+- URL checked: `https://mountaincreek.com/bike-park/rentals-retail-repair/rentals/`
+- Reason: good model-level mountain-bike rental candidate, but this batch already fills Alaska, Mexico, Canada, and remaining U.S. category coverage. Keep for a future New Jersey or Mid-Atlantic mountain-bike fill.
+
+### Marty's Reliable Cycle, Morristown, NJ
+
+- Reason: public page lists Trek Marlin 4 or Marlin 5 daily mountain-bike rentals and price. It was not needed after BikeFlow, Bike Denali, and Dismount satisfied the mountain-bike coverage gap.

--- a/demostoke_seed_batches/north_america_coverage_fill/remote_runbook.md
+++ b/demostoke_seed_batches/north_america_coverage_fill/remote_runbook.md
@@ -1,0 +1,90 @@
+# Remote Runbook - North America Coverage Fill
+
+Status: local preparation only. Do not run these commands until the user explicitly approves remote execution.
+
+## Migration Files
+
+```text
+supabase/migrations/20260601120000_seed_north_america_coverage_fill_shops.sql
+supabase/migrations/20260601120100_seed_north_america_coverage_fill_surfboards_gear.sql
+supabase/migrations/20260601120200_seed_north_america_coverage_fill_skis_gear.sql
+supabase/migrations/20260601120300_seed_north_america_coverage_fill_snowboards_gear.sql
+supabase/migrations/20260601120400_seed_north_america_coverage_fill_mountain_bikes_gear.sql
+```
+
+## Preconditions
+
+- [ ] `psql` and Supabase CLI are available, or a real Postgres client fallback is prepared outside the repo.
+- [ ] Either `SUPABASE_ACCESS_TOKEN` is configured for linked execution or `SUPABASE_DB_URL` is configured for direct `psql` execution.
+- [ ] The live DemoStoke checkout is current and `supabase migration list --linked` shows no unexpected skipped, remote-only, or local-only versions beyond this batch.
+- [ ] `demostoke_seed_batches/north_america_coverage_fill/validation.sql` is SELECT-only.
+- [ ] Human approved remote execution.
+- [ ] Do not use `supabase db push`, `supabase db push --dry-run`, or `supabase migration up`.
+
+## Static Safety Scan
+
+```bash
+rg -n "DELETE FROM|TRUNCATE|ALTER TABLE|ON CONFLICT|specs" supabase/migrations/20260601120*.sql
+LC_ALL=C rg -n "[^[:ascii:]]" supabase/migrations/20260601120*.sql demostoke_seed_batches/north_america_coverage_fill
+git diff --check
+```
+
+Expected: no matches from the first two commands and no whitespace errors.
+
+## Remote Dry Run
+
+Use a real Postgres transaction client. This executes the exact files and rolls back.
+
+```bash
+psql "$SUPABASE_DB_URL" --set ON_ERROR_STOP=1 <<'SQL'
+BEGIN;
+SET LOCAL lock_timeout = '10s';
+SET LOCAL statement_timeout = '120s';
+SELECT pg_advisory_xact_lock(20260601120000);
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260601120000_seed_north_america_coverage_fill_shops.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260601120100_seed_north_america_coverage_fill_surfboards_gear.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260601120200_seed_north_america_coverage_fill_skis_gear.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260601120300_seed_north_america_coverage_fill_snowboards_gear.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260601120400_seed_north_america_coverage_fill_mountain_bikes_gear.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/demostoke_seed_batches/north_america_coverage_fill/validation.sql
+ROLLBACK;
+SQL
+```
+
+## Remote Execution
+
+Only after the dry run passes and the user approves:
+
+```bash
+psql "$SUPABASE_DB_URL" --set ON_ERROR_STOP=1 <<'SQL'
+BEGIN;
+SET LOCAL lock_timeout = '10s';
+SET LOCAL statement_timeout = '120s';
+SELECT pg_advisory_xact_lock(20260601120000);
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260601120000_seed_north_america_coverage_fill_shops.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260601120100_seed_north_america_coverage_fill_surfboards_gear.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260601120200_seed_north_america_coverage_fill_skis_gear.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260601120300_seed_north_america_coverage_fill_snowboards_gear.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260601120400_seed_north_america_coverage_fill_mountain_bikes_gear.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/demostoke_seed_batches/north_america_coverage_fill/validation.sql
+COMMIT;
+SQL
+```
+
+After commit, mark only the applied versions as applied:
+
+```bash
+supabase migration repair --linked --status applied 20260601120000 20260601120100 20260601120200 20260601120300 20260601120400
+supabase migration list --linked
+```
+
+## Post-Run Checks
+
+- [ ] Expected shops appear in `public.profiles`.
+- [ ] Expected roles appear in `public.user_roles`.
+- [ ] Expected gear appears in `public.equipment`.
+- [ ] Each new equipment row has exactly two images.
+- [ ] Gear appears with the correct shop lat/lng.
+- [ ] `validation.sql` was rerun read-only after commit.
+- [ ] A second rollback transaction proved idempotency and inserted zero new gear/images.
+- [ ] Migration history is aligned after repair.

--- a/demostoke_seed_batches/north_america_coverage_fill/remote_runbook.md
+++ b/demostoke_seed_batches/north_america_coverage_fill/remote_runbook.md
@@ -1,6 +1,6 @@
 # Remote Runbook - North America Coverage Fill
 
-Status: local preparation only. Do not run these commands until the user explicitly approves remote execution.
+Status: applied to the linked DemoStoke Supabase project on 2026-06-01 after rollback dry runs succeeded. Keep this runbook as the historical apply sequence.
 
 ## Migration Files
 

--- a/demostoke_seed_batches/north_america_coverage_fill/remote_validation_report.md
+++ b/demostoke_seed_batches/north_america_coverage_fill/remote_validation_report.md
@@ -1,5 +1,27 @@
 # Remote Validation Report - North America Coverage Fill
 
-Status: not run. This batch is local-only and has not been pushed, applied, or deployed to the linked DemoStoke Supabase project.
+Status: applied to the linked DemoStoke Supabase project on 2026-06-01.
 
-When remote execution is explicitly approved, paste the rollback dry-run result, commit result, `validation.sql` output, idempotency rerun output, and final `supabase migration list --linked` status here.
+## Apply Sequence
+
+- Preflight duplicate check against linked `public.profiles`, `auth.users`, and `public.equipment`: `rows: []`.
+- `supabase migration list --linked` before apply showed versions `20260601120000` through `20260601120400` as local-only.
+- Rollback dry run with the generated migration files completed with status `north_america_coverage_fill_exact_dry_run_complete`.
+- Commit transaction completed with status `north_america_coverage_fill_committed`.
+- In-transaction assertions passed before `COMMIT`.
+- Read-only validation after commit returned all expected shops, all expected gear counts, and two images per gear row.
+- Idempotency rollback rerun completed with status `north_america_coverage_fill_idempotency_rollback_complete`.
+- Migration metadata repaired with `supabase migration repair --linked --status applied 20260601120000 20260601120100 20260601120200 20260601120300 20260601120400`.
+- Final `supabase migration list --linked` showed all five versions aligned local and remote.
+
+## Final Applied Counts
+
+| Shop | Category | Gear | Images |
+| --- | --- | ---: | ---: |
+| Surf Mexico | surfboards | 8 | 16 |
+| BikeFlow Oaxaca | mountain-bikes | 5 | 10 |
+| Bike Denali | mountain-bikes | 1 | 2 |
+| Dismount Bike Shop | mountain-bikes | 3 | 6 |
+| Willi's Ski and Board Seven Springs | skis | 10 | 20 |
+| Tactics Bend | snowboards | 10 | 20 |
+| **Total** | | **37** | **74** |

--- a/demostoke_seed_batches/north_america_coverage_fill/remote_validation_report.md
+++ b/demostoke_seed_batches/north_america_coverage_fill/remote_validation_report.md
@@ -1,0 +1,5 @@
+# Remote Validation Report - North America Coverage Fill
+
+Status: not run. This batch is local-only and has not been pushed, applied, or deployed to the linked DemoStoke Supabase project.
+
+When remote execution is explicitly approved, paste the rollback dry-run result, commit result, `validation.sql` output, idempotency rerun output, and final `supabase migration list --linked` status here.

--- a/demostoke_seed_batches/north_america_coverage_fill/sources.json
+++ b/demostoke_seed_batches/north_america_coverage_fill/sources.json
@@ -1,7 +1,7 @@
 {
   "batch": "north_america_coverage_fill",
   "created": "2026-06-01",
-  "remote_status": "local-only, not pushed, applied, or deployed",
+  "remote_status": "applied to linked Supabase project on 2026-06-01",
   "accepted": [
     {
       "shop": "Surf Mexico",

--- a/demostoke_seed_batches/north_america_coverage_fill/sources.json
+++ b/demostoke_seed_batches/north_america_coverage_fill/sources.json
@@ -1,0 +1,74 @@
+{
+  "batch": "north_america_coverage_fill",
+  "created": "2026-06-01",
+  "remote_status": "local-only, not pushed, applied, or deployed",
+  "accepted": [
+    {
+      "shop": "Surf Mexico",
+      "category": "surfboards",
+      "urls": [
+        "https://www.surfmexico.com/surfboards-rentals/",
+        "https://goo.gl/maps/os8ZFhsc77aby6Vh7"
+      ],
+      "gear_count": 8,
+      "notes": "Official page lists rental prices, pickup/contact details, and standard/high-performance surfboard model rows."
+    },
+    {
+      "shop": "BikeFlow Oaxaca",
+      "category": "mountain-bikes",
+      "urls": [
+        "https://bikeflow.com.mx/bike-rental/",
+        "https://bikeflow.com.mx/about-us/quienes-somos/"
+      ],
+      "gear_count": 5,
+      "notes": "Official page lists five model-level mountain-bike rentals at 600 MXN for 24 hours."
+    },
+    {
+      "shop": "Bike Denali",
+      "category": "mountain-bikes",
+      "urls": [
+        "https://bikedenali.com/mountain-bikes/",
+        "https://bikedenali.com/contact/",
+        "https://www.alaska.org/detail/bike-denali"
+      ],
+      "gear_count": 1,
+      "notes": "Official page lists Trek Marlin 5 MTB rentals and address; Alaska.org confirms the 85 USD one-day package rate."
+    },
+    {
+      "shop": "Dismount Bike Shop",
+      "category": "mountain-bikes",
+      "urls": [
+        "https://dismount-bike-shop.booqableshop.com/",
+        "https://dismount-bike-shop.booqableshop.com/pages/pricing"
+      ],
+      "gear_count": 3,
+      "notes": "Official Booqable pages list Norco and Salsa rental bikes plus 80 CAD daily bike pricing."
+    },
+    {
+      "shop": "Willi's Ski and Board Seven Springs",
+      "category": "skis",
+      "urls": [
+        "https://www.willisskiandboard.com/pages/seven-springs-demo-skis",
+        "https://www.willisskiandboard.com/pages/locations-and-hours",
+        "https://www.mapquest.com/us/pennsylvania/champion/15622-4007/777-water-wheel-dr-40.02228%2C-79.29623"
+      ],
+      "gear_count": 10,
+      "notes": "Official pages list the Seven Springs shop, 75 USD demo fee, and model-level demo ski fleet."
+    },
+    {
+      "shop": "Tactics Bend",
+      "category": "snowboards",
+      "urls": [
+        "https://www.tactics.com/info/bend-snowboard-rentals-services",
+        "https://www.mapquest.com/us/oregon/tactics-bend-371161058"
+      ],
+      "gear_count": 10,
+      "notes": "Official page lists demo rental rates and model-level demo snowboard fleet; MapQuest confirms the current Bend address."
+    }
+  ],
+  "duplicate_check_result": {
+    "linked_db_rows": 0,
+    "checked_at": "2026-06-01",
+    "query_file": "demostoke_seed_batches/north_america_coverage_fill/validation.sql"
+  }
+}

--- a/demostoke_seed_batches/north_america_coverage_fill/validation.sql
+++ b/demostoke_seed_batches/north_america_coverage_fill/validation.sql
@@ -1,0 +1,62 @@
+-- Read-only validation for north_america_coverage_fill.
+-- Safe to run against linked DemoStoke DB after remote apply.
+
+WITH expected_shops (name, email, category, expected_gear_count) AS (
+  VALUES
+    ('Surf Mexico', 'michaelzick+surfmexicobucerias@gmail.com', 'surfboards', 8),
+    ('BikeFlow Oaxaca', 'michaelzick+bikeflowoaxaca@gmail.com', 'mountain-bikes', 5),
+    ('Bike Denali', 'michaelzick+bikedenali@gmail.com', 'mountain-bikes', 1),
+    ('Dismount Bike Shop', 'michaelzick+dismounttoronto@gmail.com', 'mountain-bikes', 3),
+    ('Willi''s Ski and Board Seven Springs', 'michaelzick+willissevensprings@gmail.com', 'skis', 10),
+    ('Tactics Bend', 'michaelzick+tacticsbend@gmail.com', 'snowboards', 10)
+),
+actual AS (
+  SELECT
+    es.name,
+    es.email,
+    es.category,
+    es.expected_gear_count,
+    p.id AS profile_id,
+    p.address,
+    p.location_lat,
+    p.location_lng,
+    COUNT(DISTINCT e.id) FILTER (WHERE e.category = es.category) AS actual_gear_count,
+    COUNT(ei.id) FILTER (WHERE e.category = es.category) AS image_count
+  FROM expected_shops es
+  LEFT JOIN auth.users au ON au.email = es.email
+  LEFT JOIN public.profiles p ON p.id = au.id
+  LEFT JOIN public.equipment e ON e.user_id = au.id
+  LEFT JOIN public.equipment_images ei ON ei.equipment_id = e.id
+  GROUP BY es.name, es.email, es.category, es.expected_gear_count, p.id, p.address, p.location_lat, p.location_lng
+)
+SELECT
+  name,
+  email,
+  category,
+  profile_id IS NOT NULL AS profile_exists,
+  expected_gear_count,
+  actual_gear_count,
+  image_count,
+  image_count = actual_gear_count * 2 AS has_two_images_each,
+  address,
+  location_lat,
+  location_lng
+FROM actual
+ORDER BY name;
+
+WITH expected_emails (email) AS (
+  VALUES
+    ('michaelzick+surfmexicobucerias@gmail.com'),
+    ('michaelzick+bikeflowoaxaca@gmail.com'),
+    ('michaelzick+bikedenali@gmail.com'),
+    ('michaelzick+dismounttoronto@gmail.com'),
+    ('michaelzick+willissevensprings@gmail.com'),
+    ('michaelzick+tacticsbend@gmail.com')
+)
+SELECT
+  au.email,
+  ur.display_role
+FROM expected_emails ee
+LEFT JOIN auth.users au ON au.email = ee.email
+LEFT JOIN public.user_roles ur ON ur.user_id = au.id
+ORDER BY au.email;

--- a/supabase/migrations/20260601120000_seed_north_america_coverage_fill_shops.sql
+++ b/supabase/migrations/20260601120000_seed_north_america_coverage_fill_shops.sql
@@ -1,0 +1,162 @@
+-- Seed migration: North America coverage fill shops
+-- Batch: north_america_coverage_fill
+-- Created: 2026-06-01
+-- Remote status: files only; not pushed, applied, or deployed.
+-- Apply to remote only after explicit human approval.
+-- Do NOT use supabase db push or supabase migration up.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- =============================================
+-- NORTH AMERICA COVERAGE FILL SHOPS
+-- Shop/user inserts (auth.users + auth.identities + public.profiles + public.user_roles)
+-- Password: $uO9RX^1P%bd#8crEAM!
+-- NOTE: auth.users insert is guarded by email lookup for idempotent local testing.
+-- NOTE: user_roles upsert uses UPDATE...IF NOT FOUND THEN INSERT.
+-- NOTE: profile upsert uses UPDATE...IF NOT FOUND THEN INSERT.
+-- =============================================
+
+DO $$
+DECLARE
+  shop record;
+  new_user_id uuid;
+  v_avatar_url text;
+  v_hero_image_url text;
+  v_display_role text := 'retail-store';
+BEGIN
+  FOR shop IN
+    SELECT *
+    FROM (
+      VALUES
+        (
+          E'Surf Mexico',
+          E'Bucerias, Nayarit',
+          E'michaelzick+surfmexicobucerias@gmail.com',
+          E'surfboards',
+          E'https://www.surfmexico.com/',
+          E'+52 329-298-5055',
+          E'Freeway Tepic - Puerto Vallarta No. 949 Int. 9, Bucerias, Nayarit, Mexico',
+          E'Banderas Bay surf shop with official surfboard rental pages listing soft-top, standard, and high-performance surfboards with day and week pricing.',
+          20.7491125,
+          -105.3155175
+        ),
+        (
+          E'BikeFlow Oaxaca',
+          E'Oaxaca, Oaxaca',
+          E'michaelzick+bikeflowoaxaca@gmail.com',
+          E'mountain-bikes',
+          E'https://bikeflow.com.mx/',
+          E'+52 951-532-2296',
+          E'Martires de Tacubaya #101, Centro, Oaxaca de Juarez, Oax., Mexico',
+          E'Oaxaca mountain-bike shop with an official premium rental page listing Trek, Specialized, Scott, Cube, and Belfort hardtail models at public 24-hour pricing.',
+          17.0621249,
+          -96.7179305
+        ),
+        (
+          E'Bike Denali',
+          E'Denali Park, AK',
+          E'michaelzick+bikedenali@gmail.com',
+          E'mountain-bikes',
+          E'https://bikedenali.com/',
+          E'+1 907-378-2107',
+          E'Mile 238.5 Parks Hwy, Denali Park, AK 99755',
+          E'Denali Park bike-rental operator with official Trek Marlin 5 mountain-bike rental details for Denali National Park day rides.',
+          63.7453222,
+          -148.9011115
+        ),
+        (
+          E'Dismount Bike Shop',
+          E'Toronto, ON',
+          E'michaelzick+dismounttoronto@gmail.com',
+          E'mountain-bikes',
+          E'https://dismount-bike-shop.booqableshop.com/',
+          E'',
+          E'936 St Clair Ave W, Toronto, ON M6C 1C8, Canada',
+          E'Toronto bike shop with public Booqable mountain-bike and fat-bike rental inventory, daily pricing, and ride-before-you-buy credit.',
+          43.6798533,
+          -79.4352123
+        ),
+        (
+          E'Willi''s Ski and Board Seven Springs',
+          E'Champion, PA',
+          E'michaelzick+willissevensprings@gmail.com',
+          E'skis',
+          E'https://www.willisskiandboard.com/',
+          E'+1 814-352-7611',
+          E'777 Water Wheel Dr, Champion, PA 15622',
+          E'Willi''s Seven Springs shop with an official on-mountain demo ski program listing current ski models, sizes, bindings, and the public demo fee.',
+          40.0222800,
+          -79.2962300
+        ),
+        (
+          E'Tactics Bend',
+          E'Bend, OR',
+          E'michaelzick+tacticsbend@gmail.com',
+          E'snowboards',
+          E'https://www.tactics.com/info/bend-snowboard-rentals-services',
+          E'+1 541-640-8265',
+          E'933 NW Wall St, Bend, OR 97703',
+          E'Downtown Bend snowboard shop with an official high-performance demo snowboard fleet, public board rental rates, and model-level demo inventory.',
+          44.0593762,
+          -121.3139605
+        )
+    ) AS s(name, city, email, category, website, phone, address, about, lat, lng)
+  LOOP
+    IF v_display_role IN ('retail-store', 'builder') THEN
+      CASE shop.category
+        WHEN 'surfboards' THEN
+          v_avatar_url := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/73de4049-7ffd-45cd-868b-c2d0076107b3/profile-1752863282257.png';
+          v_hero_image_url := 'https://images.unsplash.com/photo-1502680390469-be75c86b636f?q=80&w=3540&auto=format&fit=crop&ixlib=rb-4.0.3';
+        WHEN 'skis' THEN
+          v_avatar_url := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/71fd4660-af0b-4b8c-b55b-55d82f0f827a/profile-1752637192121.png';
+          v_hero_image_url := 'https://images.unsplash.com/photo-1551524559-8af4e6624178?q=80&w=3540&auto=format&fit=crop&ixlib=rb-4.0.3';
+        WHEN 'snowboards' THEN
+          v_avatar_url := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/71fd4660-af0b-4b8c-b55b-55d82f0f827a/profile-1752637192121.png';
+          v_hero_image_url := 'https://images.unsplash.com/photo-1488590528505-98d2b5aba04b?q=80&w=3540&auto=format&fit=crop&ixlib=rb-4.0.3';
+        WHEN 'mountain-bikes' THEN
+          v_avatar_url := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/ad2ad153-bb35-4e88-bfb0-d0d4f85ba62f/profile-1752637760487.png';
+          v_hero_image_url := 'https://images.unsplash.com/photo-1506316940527-4d1c138978a0?q=80&w=3512&auto=format&fit=crop&ixlib=rb-4.0.3';
+        ELSE
+          v_avatar_url := NULL;
+          v_hero_image_url := NULL;
+      END CASE;
+    ELSE
+      v_avatar_url := NULL;
+      v_hero_image_url := NULL;
+    END IF;
+
+    SELECT id INTO new_user_id FROM auth.users WHERE email = shop.email LIMIT 1;
+
+    IF new_user_id IS NULL THEN
+      new_user_id := gen_random_uuid();
+      INSERT INTO auth.users (id, instance_id, aud, role, email, encrypted_password, email_confirmed_at, raw_user_meta_data, raw_app_meta_data, created_at, updated_at, confirmation_token, recovery_token, email_change, email_change_token_current, email_change_token_new, email_change_confirm_status, phone_change, phone_change_token, reauthentication_token)
+      VALUES (new_user_id, '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', shop.email, extensions.crypt('$uO9RX^1P%bd#8crEAM!', extensions.gen_salt('bf')), now(), jsonb_build_object('name', shop.name), jsonb_build_object('provider', 'email', 'providers', ARRAY['email']), now(), now(), '', '', '', '', '', 0, '', '', '');
+      INSERT INTO auth.identities (id, user_id, identity_data, provider, provider_id, last_sign_in_at, created_at, updated_at)
+      VALUES (gen_random_uuid(), new_user_id, jsonb_build_object('sub', new_user_id::text, 'email', shop.email), 'email', new_user_id::text, now(), now(), now());
+    END IF;
+
+    UPDATE public.profiles
+    SET name = shop.name,
+        website = shop.website,
+        phone = shop.phone,
+        address = shop.address,
+        about = shop.about,
+        location_lat = shop.lat,
+        location_lng = shop.lng,
+        avatar_url = COALESCE(v_avatar_url, avatar_url),
+        hero_image_url = COALESCE(v_hero_image_url, hero_image_url)
+    WHERE id = new_user_id;
+
+    IF NOT FOUND THEN
+      INSERT INTO public.profiles (id, name, website, phone, address, about, location_lat, location_lng, avatar_url, hero_image_url)
+      VALUES (new_user_id, shop.name, shop.website, shop.phone, shop.address, shop.about, shop.lat, shop.lng, v_avatar_url, v_hero_image_url);
+    END IF;
+
+    UPDATE public.user_roles SET display_role = v_display_role WHERE user_id = new_user_id;
+    IF NOT FOUND THEN
+      INSERT INTO public.user_roles (user_id, display_role) VALUES (new_user_id, v_display_role);
+    END IF;
+
+    RAISE NOTICE 'User upserted successfully: id=%, email=%, role=%', new_user_id, shop.email, v_display_role;
+  END LOOP;
+END $$;

--- a/supabase/migrations/20260601120000_seed_north_america_coverage_fill_shops.sql
+++ b/supabase/migrations/20260601120000_seed_north_america_coverage_fill_shops.sql
@@ -1,7 +1,7 @@
 -- Seed migration: North America coverage fill shops
 -- Batch: north_america_coverage_fill
 -- Created: 2026-06-01
--- Remote status: files only; not pushed, applied, or deployed.
+-- Remote status: applied to linked Supabase project on 2026-06-01.
 -- Apply to remote only after explicit human approval.
 -- Do NOT use supabase db push or supabase migration up.
 

--- a/supabase/migrations/20260601120100_seed_north_america_coverage_fill_surfboards_gear.sql
+++ b/supabase/migrations/20260601120100_seed_north_america_coverage_fill_surfboards_gear.sql
@@ -2,7 +2,7 @@
 -- Batch: north_america_coverage_fill
 -- Created: 2026-06-01
 -- Depends on: 20260601120000_seed_north_america_coverage_fill_shops.sql
--- Remote status: files only; not pushed, applied, or deployed.
+-- Remote status: applied to linked Supabase project on 2026-06-01.
 -- Image URLs (surfboards): https://images.pexels.com/photos/2370006/pexels-photo-2370006.jpeg and https://images.pexels.com/photos/8907535/pexels-photo-8907535.jpeg
 
 DO $seed_migration$

--- a/supabase/migrations/20260601120100_seed_north_america_coverage_fill_surfboards_gear.sql
+++ b/supabase/migrations/20260601120100_seed_north_america_coverage_fill_surfboards_gear.sql
@@ -1,0 +1,175 @@
+-- Seed migration: North America coverage fill surfboard gear
+-- Batch: north_america_coverage_fill
+-- Created: 2026-06-01
+-- Depends on: 20260601120000_seed_north_america_coverage_fill_shops.sql
+-- Remote status: files only; not pushed, applied, or deployed.
+-- Image URLs (surfboards): https://images.pexels.com/photos/2370006/pexels-photo-2370006.jpeg and https://images.pexels.com/photos/8907535/pexels-photo-8907535.jpeg
+
+DO $seed_migration$
+DECLARE
+  missing_email text;
+  v_equipment_inserted int := 0;
+  v_primary_images_added int := 0;
+  v_secondary_images_added int := 0;
+BEGIN
+  SELECT seed_email INTO missing_email
+  FROM (VALUES (E'michaelzick+surfmexicobucerias@gmail.com')) AS planned(seed_email)
+  WHERE NOT EXISTS (SELECT 1 FROM auth.users au WHERE au.email = planned.seed_email)
+  LIMIT 1;
+
+  IF missing_email IS NOT NULL THEN
+    RAISE EXCEPTION 'User not found for email: %', missing_email;
+  END IF;
+
+  WITH seed_equipment (seed_email, name, category, description, price_per_day, price_per_hour, price_per_week, size, weight, material, suitable_skill_level, status, location_lat, location_lng, location_address, subcategory, damage_deposit, visible_on_map) AS (
+    VALUES
+      (
+        E'michaelzick+surfmexicobucerias@gmail.com',
+        E'Walden Magic',
+        E'surfboards',
+        E'Surf Mexico lists the Walden Magic as an 8 ft standard surfboard with 61.7 liters of volume. The official standard-board rental rate is 700 MXN for 1 day and 3000 MXN for 1 week.',
+        700.00::numeric, NULL::numeric, 3000.00::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        20.7491125, -105.3155175,
+        E'Freeway Tepic - Puerto Vallarta No. 949 Int. 9, Bucerias, Nayarit, Mexico',
+        E'longboard', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+surfmexicobucerias@gmail.com',
+        E'Walden Magic Blue Dark',
+        E'surfboards',
+        E'Surf Mexico lists the Walden Magic Blue Dark as a 9 ft standard surfboard with 67.6 liters of volume. The official standard-board rental rate is 700 MXN for 1 day and 3000 MXN for 1 week.',
+        700.00::numeric, NULL::numeric, 3000.00::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        20.7491125, -105.3155175,
+        E'Freeway Tepic - Puerto Vallarta No. 949 Int. 9, Bucerias, Nayarit, Mexico',
+        E'longboard', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+surfmexicobucerias@gmail.com',
+        E'Walden Magic Blue',
+        E'surfboards',
+        E'Surf Mexico lists the Walden Magic Blue as a 9 ft 6 in standard surfboard with 79.9 liters of volume. The official standard-board rental rate is 700 MXN for 1 day and 3000 MXN for 1 week.',
+        700.00::numeric, NULL::numeric, 3000.00::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        20.7491125, -105.3155175,
+        E'Freeway Tepic - Puerto Vallarta No. 949 Int. 9, Bucerias, Nayarit, Mexico',
+        E'longboard', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+surfmexicobucerias@gmail.com',
+        E'NSP Protech Fish',
+        E'surfboards',
+        E'Surf Mexico lists the NSP Protech Fish white tint FTU as a 6 ft high-performance surfboard with 35.1 liters of volume. The official high-performance-board rental rate is 800 MXN for 1 day and 3500 MXN for 1 week.',
+        800.00::numeric, NULL::numeric, 3500.00::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        20.7491125, -105.3155175,
+        E'Freeway Tepic - Puerto Vallarta No. 949 Int. 9, Bucerias, Nayarit, Mexico',
+        E'fish', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+surfmexicobucerias@gmail.com',
+        E'NSP Protech Tinder-D8',
+        E'surfboards',
+        E'Surf Mexico lists the NSP Protech Tinder-D8 white FTU in 6 ft 2 in and 6 ft 6 in high-performance sizes. The official high-performance-board rental rate is 800 MXN for 1 day and 3500 MXN for 1 week.',
+        800.00::numeric, NULL::numeric, 3500.00::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        20.7491125, -105.3155175,
+        E'Freeway Tepic - Puerto Vallarta No. 949 Int. 9, Bucerias, Nayarit, Mexico',
+        E'performance fish', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+surfmexicobucerias@gmail.com',
+        E'Walden Mini Mega Magic Tuflite',
+        E'surfboards',
+        E'Surf Mexico lists the Walden Mini Mega Magic Tuflite as a 6 ft 10 in high-performance board with 67.0 liters of volume. The official high-performance-board rental rate is 800 MXN for 1 day and 3500 MXN for 1 week.',
+        800.00::numeric, NULL::numeric, 3500.00::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        20.7491125, -105.3155175,
+        E'Freeway Tepic - Puerto Vallarta No. 949 Int. 9, Bucerias, Nayarit, Mexico',
+        E'mini longboard', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+surfmexicobucerias@gmail.com',
+        E'Channel Islands Water',
+        E'surfboards',
+        E'Surf Mexico lists the Channel Islands Water as a 7 ft 10 in high-performance surfboard with 54.4 liters of volume. The official high-performance-board rental rate is 800 MXN for 1 day and 3500 MXN for 1 week.',
+        800.00::numeric, NULL::numeric, 3500.00::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        20.7491125, -105.3155175,
+        E'Freeway Tepic - Puerto Vallarta No. 949 Int. 9, Bucerias, Nayarit, Mexico',
+        E'mid-length', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+surfmexicobucerias@gmail.com',
+        E'Robert August What I Ride',
+        E'surfboards',
+        E'Surf Mexico lists the Robert August What I Ride as a 9 ft high-performance longboard with 70 liters of volume. The official high-performance-board rental rate is 800 MXN for 1 day and 3500 MXN for 1 week.',
+        800.00::numeric, NULL::numeric, 3500.00::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        20.7491125, -105.3155175,
+        E'Freeway Tepic - Puerto Vallarta No. 949 Int. 9, Bucerias, Nayarit, Mexico',
+        E'performance longboard', NULL::numeric, true
+      )
+  ),
+  inserted AS (
+    INSERT INTO public.equipment (
+      id, user_id, name, category, description,
+      price_per_day, price_per_hour, price_per_week,
+      size, weight, material, suitable_skill_level, status,
+      location_lat, location_lng, location_address, subcategory,
+      damage_deposit, visible_on_map
+    )
+    SELECT
+      gen_random_uuid(),
+      au.id,
+      s.name, s.category, s.description,
+      s.price_per_day, s.price_per_hour, s.price_per_week,
+      s.size, s.weight, s.material, s.suitable_skill_level, s.status,
+      s.location_lat, s.location_lng, s.location_address, s.subcategory,
+      s.damage_deposit, s.visible_on_map
+    FROM seed_equipment s
+    JOIN auth.users au ON au.email = s.seed_email
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment e
+      WHERE e.user_id = au.id
+        AND e.category = s.category
+        AND lower(btrim(e.name)) = lower(btrim(s.name))
+    )
+    RETURNING id
+  ),
+  ins1 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT id, 'https://images.pexels.com/photos/2370006/pexels-photo-2370006.jpeg', 0, true
+    FROM inserted
+    RETURNING equipment_id
+  ),
+  ins2 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT id, 'https://images.pexels.com/photos/8907535/pexels-photo-8907535.jpeg', 1, false
+    FROM inserted
+    RETURNING equipment_id
+  )
+  SELECT (SELECT count(*) FROM inserted), (SELECT count(*) FROM ins1), (SELECT count(*) FROM ins2)
+  INTO v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+
+  RAISE NOTICE 'North America coverage surfboard gear inserted=%, primary_images_added=%, secondary_images_added=%',
+    v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+END $seed_migration$;

--- a/supabase/migrations/20260601120200_seed_north_america_coverage_fill_skis_gear.sql
+++ b/supabase/migrations/20260601120200_seed_north_america_coverage_fill_skis_gear.sql
@@ -2,7 +2,7 @@
 -- Batch: north_america_coverage_fill
 -- Created: 2026-06-01
 -- Depends on: 20260601120000_seed_north_america_coverage_fill_shops.sql
--- Remote status: files only; not pushed, applied, or deployed.
+-- Remote status: applied to linked Supabase project on 2026-06-01.
 -- Image URLs (skis): https://images.pexels.com/photos/848699/pexels-photo-848699.jpeg and https://images.pexels.com/photos/36084973/pexels-photo-36084973.jpeg
 
 DO $seed_migration$

--- a/supabase/migrations/20260601120200_seed_north_america_coverage_fill_skis_gear.sql
+++ b/supabase/migrations/20260601120200_seed_north_america_coverage_fill_skis_gear.sql
@@ -1,0 +1,201 @@
+-- Seed migration: North America coverage fill ski gear
+-- Batch: north_america_coverage_fill
+-- Created: 2026-06-01
+-- Depends on: 20260601120000_seed_north_america_coverage_fill_shops.sql
+-- Remote status: files only; not pushed, applied, or deployed.
+-- Image URLs (skis): https://images.pexels.com/photos/848699/pexels-photo-848699.jpeg and https://images.pexels.com/photos/36084973/pexels-photo-36084973.jpeg
+
+DO $seed_migration$
+DECLARE
+  missing_email text;
+  v_equipment_inserted int := 0;
+  v_primary_images_added int := 0;
+  v_secondary_images_added int := 0;
+BEGIN
+  SELECT seed_email INTO missing_email
+  FROM (VALUES (E'michaelzick+willissevensprings@gmail.com')) AS planned(seed_email)
+  WHERE NOT EXISTS (SELECT 1 FROM auth.users au WHERE au.email = planned.seed_email)
+  LIMIT 1;
+
+  IF missing_email IS NOT NULL THEN
+    RAISE EXCEPTION 'User not found for email: %', missing_email;
+  END IF;
+
+  WITH seed_equipment (seed_email, name, category, description, price_per_day, price_per_hour, price_per_week, size, weight, material, suitable_skill_level, status, location_lat, location_lng, location_address, subcategory, damage_deposit, visible_on_map) AS (
+    VALUES
+      (
+        E'michaelzick+willissevensprings@gmail.com',
+        E'Atomic Maverick 96 CTI',
+        E'skis',
+        E'Willi''s Seven Springs lists the Atomic Maverick 96 CTI in its official demo fleet. The demo program price is 75 USD for up to 5 hours on the mountain, represented here as the day price.',
+        75.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        40.0222800, -79.2962300,
+        E'777 Water Wheel Dr, Champion, PA 15622',
+        E'all-mountain freeride', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+willissevensprings@gmail.com',
+        E'Atomic Maverick 88 CTI',
+        E'skis',
+        E'Willi''s Seven Springs lists the Atomic Maverick 88 CTI in its official demo fleet. It is a frontside-friendly all-mountain ski with the 75 USD demo program price.',
+        75.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        40.0222800, -79.2962300,
+        E'777 Water Wheel Dr, Champion, PA 15622',
+        E'all-mountain', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+willissevensprings@gmail.com',
+        E'Blizzard Black Pearl 84',
+        E'skis',
+        E'Willi''s Seven Springs lists the Blizzard Black Pearl 84 in its official demo ski fleet. It is a narrower all-mountain option for approachable East Coast carving and mixed conditions.',
+        75.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        40.0222800, -79.2962300,
+        E'777 Water Wheel Dr, Champion, PA 15622',
+        E'all-mountain', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+willissevensprings@gmail.com',
+        E'Blizzard Anomaly 88',
+        E'skis',
+        E'Willi''s Seven Springs lists the Blizzard Anomaly 88 in its official demo fleet. It is a strong all-mountain ski for confident resort skiers testing edge hold and variable-snow stability.',
+        75.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        40.0222800, -79.2962300,
+        E'777 Water Wheel Dr, Champion, PA 15622',
+        E'all-mountain', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+willissevensprings@gmail.com',
+        E'Elan Ripstick 96 Black Edition',
+        E'skis',
+        E'Willi''s Seven Springs lists the Elan Ripstick 96 Black Edition in its official demo fleet. It gives stronger skiers a wider all-mountain platform for soft snow and mixed resort terrain.',
+        75.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        40.0222800, -79.2962300,
+        E'777 Water Wheel Dr, Champion, PA 15622',
+        E'all-mountain freeride', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+willissevensprings@gmail.com',
+        E'Head Supershape e-Rally',
+        E'skis',
+        E'Willi''s Seven Springs lists the Head Supershape e-Rally in its official demo fleet. It is a frontside carving ski for advanced skiers who want strong edge grip on groomers.',
+        75.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        40.0222800, -79.2962300,
+        E'777 Water Wheel Dr, Champion, PA 15622',
+        E'frontside carver', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+willissevensprings@gmail.com',
+        E'Nordica Enforcer 94',
+        E'skis',
+        E'Willi''s Seven Springs lists the Nordica Enforcer 94 in its official demo fleet. It is an all-mountain ski for advanced riders who want damp stability and edge confidence.',
+        75.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        40.0222800, -79.2962300,
+        E'777 Water Wheel Dr, Champion, PA 15622',
+        E'all-mountain', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+willissevensprings@gmail.com',
+        E'Rossignol Arcade 88',
+        E'skis',
+        E'Willi''s Seven Springs lists the Rossignol Arcade 88 in its official demo fleet. It is an all-mountain resort ski for skiers who want frontside energy with wider-mountain versatility.',
+        75.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        40.0222800, -79.2962300,
+        E'777 Water Wheel Dr, Champion, PA 15622',
+        E'all-mountain', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+willissevensprings@gmail.com',
+        E'Stockli Montero AR',
+        E'skis',
+        E'Willi''s Seven Springs lists the Stockli Montero AR in its official demo fleet. It is a premium all-mountain carving ski for advanced skiers who want precision and energy.',
+        75.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        40.0222800, -79.2962300,
+        E'777 Water Wheel Dr, Champion, PA 15622',
+        E'all-mountain carver', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+willissevensprings@gmail.com',
+        E'Stockli Nela 88',
+        E'skis',
+        E'Willi''s Seven Springs lists the Stockli Nela 88 in its official demo fleet. It is a premium all-mountain ski for skiers seeking a lighter, precise ride across groomers and variable snow.',
+        75.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        40.0222800, -79.2962300,
+        E'777 Water Wheel Dr, Champion, PA 15622',
+        E'all-mountain', NULL::numeric, true
+      )
+  ),
+  inserted AS (
+    INSERT INTO public.equipment (
+      id, user_id, name, category, description,
+      price_per_day, price_per_hour, price_per_week,
+      size, weight, material, suitable_skill_level, status,
+      location_lat, location_lng, location_address, subcategory,
+      damage_deposit, visible_on_map
+    )
+    SELECT
+      gen_random_uuid(),
+      au.id,
+      s.name, s.category, s.description,
+      s.price_per_day, s.price_per_hour, s.price_per_week,
+      s.size, s.weight, s.material, s.suitable_skill_level, s.status,
+      s.location_lat, s.location_lng, s.location_address, s.subcategory,
+      s.damage_deposit, s.visible_on_map
+    FROM seed_equipment s
+    JOIN auth.users au ON au.email = s.seed_email
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment e
+      WHERE e.user_id = au.id
+        AND e.category = s.category
+        AND lower(btrim(e.name)) = lower(btrim(s.name))
+    )
+    RETURNING id
+  ),
+  ins1 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT id, 'https://images.pexels.com/photos/848699/pexels-photo-848699.jpeg', 0, true
+    FROM inserted
+    RETURNING equipment_id
+  ),
+  ins2 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT id, 'https://images.pexels.com/photos/36084973/pexels-photo-36084973.jpeg', 1, false
+    FROM inserted
+    RETURNING equipment_id
+  )
+  SELECT (SELECT count(*) FROM inserted), (SELECT count(*) FROM ins1), (SELECT count(*) FROM ins2)
+  INTO v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+
+  RAISE NOTICE 'North America coverage ski gear inserted=%, primary_images_added=%, secondary_images_added=%',
+    v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+END $seed_migration$;

--- a/supabase/migrations/20260601120300_seed_north_america_coverage_fill_snowboards_gear.sql
+++ b/supabase/migrations/20260601120300_seed_north_america_coverage_fill_snowboards_gear.sql
@@ -2,7 +2,7 @@
 -- Batch: north_america_coverage_fill
 -- Created: 2026-06-01
 -- Depends on: 20260601120000_seed_north_america_coverage_fill_shops.sql
--- Remote status: files only; not pushed, applied, or deployed.
+-- Remote status: applied to linked Supabase project on 2026-06-01.
 -- Image URLs (snowboards): https://images.pexels.com/photos/7406683/pexels-photo-7406683.jpeg and https://images.pexels.com/photos/7166118/pexels-photo-7166118.jpeg
 
 DO $seed_migration$

--- a/supabase/migrations/20260601120300_seed_north_america_coverage_fill_snowboards_gear.sql
+++ b/supabase/migrations/20260601120300_seed_north_america_coverage_fill_snowboards_gear.sql
@@ -1,0 +1,201 @@
+-- Seed migration: North America coverage fill snowboard gear
+-- Batch: north_america_coverage_fill
+-- Created: 2026-06-01
+-- Depends on: 20260601120000_seed_north_america_coverage_fill_shops.sql
+-- Remote status: files only; not pushed, applied, or deployed.
+-- Image URLs (snowboards): https://images.pexels.com/photos/7406683/pexels-photo-7406683.jpeg and https://images.pexels.com/photos/7166118/pexels-photo-7166118.jpeg
+
+DO $seed_migration$
+DECLARE
+  missing_email text;
+  v_equipment_inserted int := 0;
+  v_primary_images_added int := 0;
+  v_secondary_images_added int := 0;
+BEGIN
+  SELECT seed_email INTO missing_email
+  FROM (VALUES (E'michaelzick+tacticsbend@gmail.com')) AS planned(seed_email)
+  WHERE NOT EXISTS (SELECT 1 FROM auth.users au WHERE au.email = planned.seed_email)
+  LIMIT 1;
+
+  IF missing_email IS NOT NULL THEN
+    RAISE EXCEPTION 'User not found for email: %', missing_email;
+  END IF;
+
+  WITH seed_equipment (seed_email, name, category, description, price_per_day, price_per_hour, price_per_week, size, weight, material, suitable_skill_level, status, location_lat, location_lng, location_address, subcategory, damage_deposit, visible_on_map) AS (
+    VALUES
+      (
+        E'michaelzick+tacticsbend@gmail.com',
+        E'Burton 3D Fish',
+        E'snowboards',
+        E'Tactics Bend lists the Burton 3D Fish in its official demo snowboard fleet. The official demo board rate is 40 USD per day, with an additional-day board rate of 20 USD.',
+        40.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        44.0593762, -121.3139605,
+        E'933 NW Wall St, Bend, OR 97703',
+        E'powder', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+tacticsbend@gmail.com',
+        E'Burton Family Tree Hometown Hero',
+        E'snowboards',
+        E'Tactics Bend lists the Burton Family Tree Hometown Hero in its official demo snowboard fleet. It is an all-mountain directional board available under the 40 USD daily board rate.',
+        40.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        44.0593762, -121.3139605,
+        E'933 NW Wall St, Bend, OR 97703',
+        E'all-mountain freeride', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+tacticsbend@gmail.com',
+        E'CAPiTA DOA',
+        E'snowboards',
+        E'Tactics Bend lists the CAPiTA DOA in its official demo snowboard fleet in multiple sizes. It is a freestyle-friendly all-mountain board available under the 40 USD daily board rate.',
+        40.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        44.0593762, -121.3139605,
+        E'933 NW Wall St, Bend, OR 97703',
+        E'all-mountain freestyle', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+tacticsbend@gmail.com',
+        E'CAPiTA Mega Mercury',
+        E'snowboards',
+        E'Tactics Bend lists the CAPiTA Mega Mercury in its official demo snowboard fleet. It is a high-performance all-mountain board available under the 40 USD daily board rate.',
+        40.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        44.0593762, -121.3139605,
+        E'933 NW Wall St, Bend, OR 97703',
+        E'all-mountain freeride', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+tacticsbend@gmail.com',
+        E'CAPiTA Mercury',
+        E'snowboards',
+        E'Tactics Bend lists the CAPiTA Mercury in its official demo snowboard fleet in multiple sizes. It is an all-mountain directional twin available under the 40 USD daily board rate.',
+        40.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        44.0593762, -121.3139605,
+        E'933 NW Wall St, Bend, OR 97703',
+        E'all-mountain', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+tacticsbend@gmail.com',
+        E'Jones Frontier',
+        E'snowboards',
+        E'Tactics Bend lists the Jones Frontier in its official demo snowboard fleet. It is an all-mountain freeride board available under the 40 USD daily board rate.',
+        40.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        44.0593762, -121.3139605,
+        E'933 NW Wall St, Bend, OR 97703',
+        E'all-mountain freeride', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+tacticsbend@gmail.com',
+        E'Korua Shapes Cafe Racer Classic',
+        E'snowboards',
+        E'Tactics Bend lists the Korua Shapes Cafe Racer Classic in its official demo snowboard fleet. It is a carving-focused directional board available under the 40 USD daily board rate.',
+        40.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        44.0593762, -121.3139605,
+        E'933 NW Wall St, Bend, OR 97703',
+        E'carving freeride', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+tacticsbend@gmail.com',
+        E'Lib Tech Cold Brew C2',
+        E'snowboards',
+        E'Tactics Bend lists the Lib Tech Cold Brew C2 in its official demo snowboard fleet. It is a directional all-mountain board available under the 40 USD daily board rate.',
+        40.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        44.0593762, -121.3139605,
+        E'933 NW Wall St, Bend, OR 97703',
+        E'all-mountain', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+tacticsbend@gmail.com',
+        E'Lib Tech T.Rice Orca C2X HP',
+        E'snowboards',
+        E'Tactics Bend lists the Lib Tech T.Rice Orca C2X HP in its official demo snowboard fleet. It is a short-wide powder and freeride board available under the 40 USD daily board rate.',
+        40.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced, Expert',
+        'available',
+        44.0593762, -121.3139605,
+        E'933 NW Wall St, Bend, OR 97703',
+        E'powder freeride', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+tacticsbend@gmail.com',
+        E'Ride Warpig',
+        E'snowboards',
+        E'Tactics Bend lists the Ride Warpig in its official demo snowboard fleet. It is a volume-shifted all-mountain and powder board available under the 40 USD daily board rate.',
+        40.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        44.0593762, -121.3139605,
+        E'933 NW Wall St, Bend, OR 97703',
+        E'all-mountain powder', NULL::numeric, true
+      )
+  ),
+  inserted AS (
+    INSERT INTO public.equipment (
+      id, user_id, name, category, description,
+      price_per_day, price_per_hour, price_per_week,
+      size, weight, material, suitable_skill_level, status,
+      location_lat, location_lng, location_address, subcategory,
+      damage_deposit, visible_on_map
+    )
+    SELECT
+      gen_random_uuid(),
+      au.id,
+      s.name, s.category, s.description,
+      s.price_per_day, s.price_per_hour, s.price_per_week,
+      s.size, s.weight, s.material, s.suitable_skill_level, s.status,
+      s.location_lat, s.location_lng, s.location_address, s.subcategory,
+      s.damage_deposit, s.visible_on_map
+    FROM seed_equipment s
+    JOIN auth.users au ON au.email = s.seed_email
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment e
+      WHERE e.user_id = au.id
+        AND e.category = s.category
+        AND lower(btrim(e.name)) = lower(btrim(s.name))
+    )
+    RETURNING id
+  ),
+  ins1 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT id, 'https://images.pexels.com/photos/7406683/pexels-photo-7406683.jpeg', 0, true
+    FROM inserted
+    RETURNING equipment_id
+  ),
+  ins2 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT id, 'https://images.pexels.com/photos/7166118/pexels-photo-7166118.jpeg', 1, false
+    FROM inserted
+    RETURNING equipment_id
+  )
+  SELECT (SELECT count(*) FROM inserted), (SELECT count(*) FROM ins1), (SELECT count(*) FROM ins2)
+  INTO v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+
+  RAISE NOTICE 'North America coverage snowboard gear inserted=%, primary_images_added=%, secondary_images_added=%',
+    v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+END $seed_migration$;

--- a/supabase/migrations/20260601120400_seed_north_america_coverage_fill_mountain_bikes_gear.sql
+++ b/supabase/migrations/20260601120400_seed_north_america_coverage_fill_mountain_bikes_gear.sql
@@ -2,7 +2,7 @@
 -- Batch: north_america_coverage_fill
 -- Created: 2026-06-01
 -- Depends on: 20260601120000_seed_north_america_coverage_fill_shops.sql
--- Remote status: files only; not pushed, applied, or deployed.
+-- Remote status: applied to linked Supabase project on 2026-06-01.
 -- Image URLs (mountain-bikes): https://images.pexels.com/photos/30447388/pexels-photo-30447388.jpeg and https://images.pexels.com/photos/25753440/pexels-photo-25753440.jpeg
 
 DO $seed_migration$

--- a/supabase/migrations/20260601120400_seed_north_america_coverage_fill_mountain_bikes_gear.sql
+++ b/supabase/migrations/20260601120400_seed_north_america_coverage_fill_mountain_bikes_gear.sql
@@ -1,0 +1,193 @@
+-- Seed migration: North America coverage fill mountain-bike gear
+-- Batch: north_america_coverage_fill
+-- Created: 2026-06-01
+-- Depends on: 20260601120000_seed_north_america_coverage_fill_shops.sql
+-- Remote status: files only; not pushed, applied, or deployed.
+-- Image URLs (mountain-bikes): https://images.pexels.com/photos/30447388/pexels-photo-30447388.jpeg and https://images.pexels.com/photos/25753440/pexels-photo-25753440.jpeg
+
+DO $seed_migration$
+DECLARE
+  missing_email text;
+  v_equipment_inserted int := 0;
+  v_primary_images_added int := 0;
+  v_secondary_images_added int := 0;
+BEGIN
+  SELECT seed_email INTO missing_email
+  FROM (
+    VALUES
+      (E'michaelzick+bikeflowoaxaca@gmail.com'),
+      (E'michaelzick+bikedenali@gmail.com'),
+      (E'michaelzick+dismounttoronto@gmail.com')
+  ) AS planned(seed_email)
+  WHERE NOT EXISTS (SELECT 1 FROM auth.users au WHERE au.email = planned.seed_email)
+  LIMIT 1;
+
+  IF missing_email IS NOT NULL THEN
+    RAISE EXCEPTION 'User not found for email: %', missing_email;
+  END IF;
+
+  WITH seed_equipment (seed_email, name, category, description, price_per_day, price_per_hour, price_per_week, size, weight, material, suitable_skill_level, status, location_lat, location_lng, location_address, subcategory, damage_deposit, visible_on_map) AS (
+    VALUES
+      (
+        E'michaelzick+bikeflowoaxaca@gmail.com',
+        E'Trek Marlin',
+        E'mountain-bikes',
+        E'BikeFlow Oaxaca lists the Trek Marlin as a 24-hour mountain-bike rental starting from 600 MXN. It is presented as a hardtail for local trails and scenic paths.',
+        600.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        17.0621249, -96.7179305,
+        E'Martires de Tacubaya #101, Centro, Oaxaca de Juarez, Oax., Mexico',
+        E'hardtail trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+bikeflowoaxaca@gmail.com',
+        E'Specialized Rockhopper',
+        E'mountain-bikes',
+        E'BikeFlow Oaxaca lists the Specialized Rockhopper as a 24-hour mountain-bike rental starting from 600 MXN. It is a trail-capable hardtail for Oaxaca routes and mixed terrain.',
+        600.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        17.0621249, -96.7179305,
+        E'Martires de Tacubaya #101, Centro, Oaxaca de Juarez, Oax., Mexico',
+        E'hardtail trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+bikeflowoaxaca@gmail.com',
+        E'Scott Aspect',
+        E'mountain-bikes',
+        E'BikeFlow Oaxaca lists the Scott Aspect as a 24-hour mountain-bike rental starting from 600 MXN. It is described as a lightweight option for cross-country rides and valley exploration.',
+        600.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        17.0621249, -96.7179305,
+        E'Martires de Tacubaya #101, Centro, Oaxaca de Juarez, Oax., Mexico',
+        E'cross-country hardtail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+bikeflowoaxaca@gmail.com',
+        E'Cube Access WS EAZ',
+        E'mountain-bikes',
+        E'BikeFlow Oaxaca lists the Cube Access WS EAZ as a 24-hour mountain-bike rental starting from 600 MXN. It is described as a responsive trail bike for climbing and descending.',
+        600.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        17.0621249, -96.7179305,
+        E'Martires de Tacubaya #101, Centro, Oaxaca de Juarez, Oax., Mexico',
+        E'hardtail trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+bikeflowoaxaca@gmail.com',
+        E'Belfort Alom',
+        E'mountain-bikes',
+        E'BikeFlow Oaxaca lists the Belfort Alom as a 24-hour mountain-bike rental starting from 600 MXN. It is described as a versatile Mexican-designed bike for Oaxaca terrain.',
+        600.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        17.0621249, -96.7179305,
+        E'Martires de Tacubaya #101, Centro, Oaxaca de Juarez, Oax., Mexico',
+        E'hardtail trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+bikedenali@gmail.com',
+        E'Trek Marlin 5',
+        E'mountain-bikes',
+        E'Bike Denali lists Trek Marlin 5 mountain bikes for Denali Park rides. Alaska.org publishes the single-day package rate at 85 USD for one day, with helmet, lock, rear rack, day pannier, bear spray, repair kit, rain poncho, and car rack if needed.',
+        85.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        63.7453222, -148.9011115,
+        E'Mile 238.5 Parks Hwy, Denali Park, AK 99755',
+        E'hardtail trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+dismounttoronto@gmail.com',
+        E'Norco Fluid FS A2',
+        E'mountain-bikes',
+        E'Dismount Bike Shop lists the Norco Fluid FS A2 in its public rental inventory and pricing page. The published bike daily rate is 80 CAD for same-day pickup and return.',
+        80.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        43.6798533, -79.4352123,
+        E'936 St Clair Ave W, Toronto, ON M6C 1C8, Canada',
+        E'full-suspension trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+dismounttoronto@gmail.com',
+        E'Norco Bigfoot 2',
+        E'mountain-bikes',
+        E'Dismount Bike Shop lists the Norco Bigfoot 2 in its public rental inventory and pricing page. The published bike daily rate is 80 CAD for same-day pickup and return.',
+        80.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        43.6798533, -79.4352123,
+        E'936 St Clair Ave W, Toronto, ON M6C 1C8, Canada',
+        E'fat bike', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+dismounttoronto@gmail.com',
+        E'Salsa Heyday Advent',
+        E'mountain-bikes',
+        E'Dismount Bike Shop lists the Salsa Heyday Advent in its public rental inventory and pricing page. The published bike daily rate is 80 CAD for same-day pickup and return.',
+        80.00::numeric, NULL::numeric, NULL::numeric,
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        43.6798533, -79.4352123,
+        E'936 St Clair Ave W, Toronto, ON M6C 1C8, Canada',
+        E'fat bike', NULL::numeric, true
+      )
+  ),
+  inserted AS (
+    INSERT INTO public.equipment (
+      id, user_id, name, category, description,
+      price_per_day, price_per_hour, price_per_week,
+      size, weight, material, suitable_skill_level, status,
+      location_lat, location_lng, location_address, subcategory,
+      damage_deposit, visible_on_map
+    )
+    SELECT
+      gen_random_uuid(),
+      au.id,
+      s.name, s.category, s.description,
+      s.price_per_day, s.price_per_hour, s.price_per_week,
+      s.size, s.weight, s.material, s.suitable_skill_level, s.status,
+      s.location_lat, s.location_lng, s.location_address, s.subcategory,
+      s.damage_deposit, s.visible_on_map
+    FROM seed_equipment s
+    JOIN auth.users au ON au.email = s.seed_email
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment e
+      WHERE e.user_id = au.id
+        AND e.category = s.category
+        AND lower(btrim(e.name)) = lower(btrim(s.name))
+    )
+    RETURNING id
+  ),
+  ins1 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT id, 'https://images.pexels.com/photos/30447388/pexels-photo-30447388.jpeg', 0, true
+    FROM inserted
+    RETURNING equipment_id
+  ),
+  ins2 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT id, 'https://images.pexels.com/photos/25753440/pexels-photo-25753440.jpeg', 1, false
+    FROM inserted
+    RETURNING equipment_id
+  )
+  SELECT (SELECT count(*) FROM inserted), (SELECT count(*) FROM ins1), (SELECT count(*) FROM ins2)
+  INTO v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+
+  RAISE NOTICE 'North America coverage mountain-bike gear inserted=%, primary_images_added=%, secondary_images_added=%',
+    v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+END $seed_migration$;


### PR DESCRIPTION
## Summary

Adds a new North America coverage seed batch and its supporting audit docs.

- **6 new non-duplicate shops** across Mexico, Alaska, Canada, and the mainland U.S.
- **4 category-specific gear migrations** for surfboards, skis, snowboards, and mountain-bikes.
- **Local audit package** with discovery notes, rejected candidates, sources, validation SQL, and runbooks.
- **Repo memory updates** in `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` so the batch is tracked as an applied seed set.

## Testing

- Read-only linked DB duplicate checks returned no existing matches for the selected shops.
- Rollback dry run against the linked database succeeded before apply.
- Linked apply completed successfully, with validation confirming the expected gear and image counts and migration history repaired.