### PR TITLE
Seed Central and South America gear shops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,6 +335,13 @@ These files exist locally but have **not** been pushed/applied to the linked Dem
   - audit folder: `demostoke_seed_batches/eastern_time_zone_all_categories/`
   - shops: Belleayre Mountain; Highland Mountain Bike Park; Thunder Mountain Bike Park; Ride Kanuga; REAL Watersports; Warm Winds Surf Shop; Cinnamon Rainbows Surf Co.
   - planned gear counts: surfboards 14, skis 5, snowboards 2, mountain-bikes 19
+- Central and South America gear batch, status `local pending`, created June 6, 2026:
+  - shops migration: `supabase/migrations/20260606120000_seed_central_south_america_gear_shops.sql`
+  - gear migrations: `20260606120100_seed_central_south_america_surfboards_gear.sql`, `20260606120200_seed_central_south_america_mountain_bikes_gear.sql`
+  - audit folder: `demostoke_seed_batches/central_south_america_gear/`
+  - shops: MTB Guatemala; Bike Arenal; Nosara MTB; Buen Camino Bike Park; Line Up Surf Shop; Santa Catalina Surf Shop; Sunzal Surf Company
+  - planned gear counts: surfboards 57, mountain-bikes 17, skis 0, snowboards 0
+  - no ski/snowboard rows were seeded because reviewed Central/South America candidates lacked public model-level priced inventory
 
 ## Seed Data — Historical Hermes Migration Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,7 +258,7 @@ Do not substitute other image sources for seed data. If new categories are added
 
 ## Seed Data — Current Seeded Shops
 
-This summary reflects read-only linked DemoStoke data checks after the June 7, 2026 Central and South America gear seed apply. The Wax Bench row is an existing live profile retargeted by the Canada batch; its gear count is the current profile count after 17 inserts and 11 updates, not a newly created shop.
+This summary reflects read-only linked DemoStoke data checks after the June 7, 2026 Central and South America surfboards follow-up seed apply. The Wax Bench row is an existing live profile retargeted by the Canada batch; its gear count is the current profile count after 17 inserts and 11 updates, not a newly created shop.
 
 | # | Shop | Region | Category | Gear | Status |
 |---|---|---|---|---|---|
@@ -327,8 +327,9 @@ This summary reflects read-only linked DemoStoke data checks after the June 7, 2
 | 63 | Buen Camino Bike Park | San Mateo, Costa Rica | mountain-bikes | 1 | applied |
 | 64 | Line Up Surf Shop | Coronado, Panama | surfboards | 22 | applied |
 | 65 | Santa Catalina Surf Shop | Santa Catalina, Panama | surfboards | 2 | applied |
-| 66 | Sunzal Surf Company | El Tunco, El Salvador | surfboards | 33 | applied |
-| | **Total** | | | **720** | |
+| 66 | Sunzal Surf Company | El Tunco, El Salvador | surfboards | 36 | applied |
+| 67 | Nosara Surfboards | Nosara, Costa Rica | surfboards | 9 | applied |
+| | **Total** | | | **732** | |
 
 Do not re-seed any shop already in this table. Do not seed Hawaii Surfboard Rentals under any Hawaii discovery task.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,7 +258,7 @@ Do not substitute other image sources for seed data. If new categories are added
 
 ## Seed Data — Current Seeded Shops
 
-This summary reflects read-only linked DemoStoke data checks after the June 1, 2026 U.S. Eastern, Hawaii, Mountain, Central, and North America coverage fill seed applies. The Wax Bench row is an existing live profile retargeted by the Canada batch; its gear count is the current profile count after 17 inserts and 11 updates, not a newly created shop.
+This summary reflects read-only linked DemoStoke data checks after the June 7, 2026 Central and South America gear seed apply. The Wax Bench row is an existing live profile retargeted by the Canada batch; its gear count is the current profile count after 17 inserts and 11 updates, not a newly created shop.
 
 | # | Shop | Region | Category | Gear | Status |
 |---|---|---|---|---|---|
@@ -321,7 +321,14 @@ This summary reflects read-only linked DemoStoke data checks after the June 1, 2
 | 57 | Dismount Bike Shop | Toronto, ON | mountain-bikes | 3 | applied |
 | 58 | Willi's Ski and Board Seven Springs | Champion, PA | skis | 10 | applied |
 | 59 | Tactics Bend | Bend, OR | snowboards | 10 | applied |
-| | **Total** | | | **646** | |
+| 60 | MTB Guatemala | Tecpan, Guatemala | mountain-bikes | 9 | applied |
+| 61 | Bike Arenal | La Fortuna, Costa Rica | mountain-bikes | 3 | applied |
+| 62 | Nosara MTB | Nosara, Costa Rica | mountain-bikes | 4 | applied |
+| 63 | Buen Camino Bike Park | San Mateo, Costa Rica | mountain-bikes | 1 | applied |
+| 64 | Line Up Surf Shop | Coronado, Panama | surfboards | 22 | applied |
+| 65 | Santa Catalina Surf Shop | Santa Catalina, Panama | surfboards | 2 | applied |
+| 66 | Sunzal Surf Company | El Tunco, El Salvador | surfboards | 33 | applied |
+| | **Total** | | | **720** | |
 
 Do not re-seed any shop already in this table. Do not seed Hawaii Surfboard Rentals under any Hawaii discovery task.
 
@@ -335,13 +342,6 @@ These files exist locally but have **not** been pushed/applied to the linked Dem
   - audit folder: `demostoke_seed_batches/eastern_time_zone_all_categories/`
   - shops: Belleayre Mountain; Highland Mountain Bike Park; Thunder Mountain Bike Park; Ride Kanuga; REAL Watersports; Warm Winds Surf Shop; Cinnamon Rainbows Surf Co.
   - planned gear counts: surfboards 14, skis 5, snowboards 2, mountain-bikes 19
-- Central and South America gear batch, status `local pending`, created June 6, 2026:
-  - shops migration: `supabase/migrations/20260606120000_seed_central_south_america_gear_shops.sql`
-  - gear migrations: `20260606120100_seed_central_south_america_surfboards_gear.sql`, `20260606120200_seed_central_south_america_mountain_bikes_gear.sql`
-  - audit folder: `demostoke_seed_batches/central_south_america_gear/`
-  - shops: MTB Guatemala; Bike Arenal; Nosara MTB; Buen Camino Bike Park; Line Up Surf Shop; Santa Catalina Surf Shop; Sunzal Surf Company
-  - planned gear counts: surfboards 57, mountain-bikes 17, skis 0, snowboards 0
-  - no ski/snowboard rows were seeded because reviewed Central/South America candidates lacked public model-level priced inventory
 
 ## Seed Data — Historical Hermes Migration Notes
 

--- a/demostoke_seed_batches/central_south_america_gear/discovery_audit.md
+++ b/demostoke_seed_batches/central_south_america_gear/discovery_audit.md
@@ -1,6 +1,6 @@
 # Central and South America Gear Discovery Audit
 
-Status: local pending. These migrations have not been applied to the linked DemoStoke Supabase project.
+Status: applied to the linked DemoStoke Supabase project on 2026-06-07 after a rollback dry run succeeded.
 
 Created: 2026-06-06
 

--- a/demostoke_seed_batches/central_south_america_gear/discovery_audit.md
+++ b/demostoke_seed_batches/central_south_america_gear/discovery_audit.md
@@ -1,0 +1,136 @@
+# Central and South America Gear Discovery Audit
+
+Status: local pending. These migrations have not been applied to the linked DemoStoke Supabase project.
+
+Created: 2026-06-06
+
+Branch: `codex/central-south-america-gear-seeds`
+
+## Scope
+
+The user requested a `demostoke-gear-adder` run for all qualifying mountain-bike, surf, ski, and snowboard shops in Central and South America, with Hermes files updated as well.
+
+This batch adds seven non-duplicate shops and 74 planned gear rows:
+
+| Region | Shop | Category | Planned gear |
+| --- | --- | --- | ---: |
+| Guatemala | MTB Guatemala | mountain-bikes | 9 |
+| Costa Rica | Bike Arenal | mountain-bikes | 3 |
+| Costa Rica | Nosara MTB | mountain-bikes | 4 |
+| Costa Rica | Buen Camino Bike Park | mountain-bikes | 1 |
+| Panama | Line Up Surf Shop | surfboards | 22 |
+| Panama | Santa Catalina Surf Shop | surfboards | 2 |
+| El Salvador | Sunzal Surf Company | surfboards | 33 |
+| **Total** | | | **74** |
+
+No ski or snowboard shop passed the seed criteria during this pass. The ski/snowboard pages found were package-level, brand-only, price-only, or aggregator pages without public model-level rentable inventory.
+
+## Duplicate Checks
+
+Read-only linked DB checks must be run before remote execution. During authoring, the target batch was checked against the known live seed registry and existing linked seed summary; no existing Central or South America shops overlapped this batch. Existing Mexico shops (`Surf Mexico` and `BikeFlow Oaxaca`) are North America coverage rows and were not re-seeded.
+
+Representative linked DB query:
+
+```sql
+SELECT p.name, p.website, p.address, u.email, COUNT(DISTINCT e.id) AS gear_count
+FROM public.profiles p
+LEFT JOIN auth.users u ON u.id = p.id
+LEFT JOIN public.equipment e ON e.user_id = p.id
+WHERE lower(p.name) IN (
+  'mtb guatemala',
+  'bike arenal',
+  'nosara mtb',
+  'buen camino bike park',
+  'line up surf shop',
+  'santa catalina surf shop',
+  'sunzal surf company'
+)
+OR lower(coalesce(u.email, '')) IN (
+  'michaelzick+mtbguatemala@gmail.com',
+  'michaelzick+bikearenal@gmail.com',
+  'michaelzick+nosaramtb@gmail.com',
+  'michaelzick+buencamino@gmail.com',
+  'michaelzick+lineuptrade@gmail.com',
+  'michaelzick+santacatalinasurfshop@gmail.com',
+  'michaelzick+sunzalsurfcompany@gmail.com'
+)
+OR lower(coalesce(p.website, '')) LIKE '%mtbguatemala.com%'
+OR lower(coalesce(p.website, '')) LIKE '%bikearenal.com%'
+OR lower(coalesce(p.website, '')) LIKE '%nosaramtb.com%'
+OR lower(coalesce(p.website, '')) LIKE '%buencaminocr.com%'
+OR lower(coalesce(p.website, '')) LIKE '%lineuptrade.com%'
+OR lower(coalesce(p.website, '')) LIKE '%santacatalinasurfshop.com%'
+OR lower(coalesce(p.website, '')) LIKE '%sunzal.com%'
+GROUP BY p.name, p.website, p.address, u.email
+ORDER BY p.name;
+```
+
+Expected before apply: `rows: []`.
+
+## Accepted Sources
+
+### MTB Guatemala
+
+- Official rental catalog: `https://www.mtbguatemala.com/product-category/mountain-bike-rentals/`
+- Official Tecpan tour/contact page: `https://www.mtbguatemala.com/tours/tecpan-enduro-mtb-day-rides/`
+- Evidence: official catalog lists Commencal and Giant model-level mountain-bike rentals with USD daily pricing.
+- Accepted gear: Commencal T.E.M.P.O, Commencal META TR Premium, Commencal T.E.M.P.O Premium, Commencal Meta TR 29, Commencal Meta AM 29, Commencal Meta Power 29, Giant Trance E+ 2 Pro, Giant Talon 29er, Giant Trance 27.5.
+- Location basis: official Tecpan text and mapped Tecpan base coordinates.
+
+### Bike Arenal
+
+- Official rental page: `https://www.bikearenal.com/bike-rentals/`
+- Official contact page: `https://www.bikearenal.com/contact/`
+- Evidence: official page lists Cannondale Rush, Depro M2 Carbon Fiber, and Scott Scale model-level mountain-bike rentals at 65 USD per day.
+- Accepted gear: Cannondale Rush 27.5, Depro M2 Carbon Fiber 29, Scott Scale 980.
+- Location basis: official La Fortuna address and embedded map coordinate.
+
+### Nosara MTB
+
+- Official rental page: `https://nosaramtb.com/rentals/`
+- Evidence: official page lists Specialized and Rocky Mountain model-level mountain-bike rentals with day and week USD pricing.
+- Accepted gear: Specialized Turbo Levo SL, Rocky Mountain Growler Power Play, Rocky Mountain Instinct A50, Rocky Mountain Fusion 10.
+- Location basis: official Gilded Iguana Athletic Center address; coordinates are approximate to Playa Guiones north.
+
+### Buen Camino Bike Park
+
+- Official ride/rental page: `https://buencaminocr.com/es/ride/`
+- Evidence: official page lists Specialized Turbo Levo rentals in all sizes at 130 USD and provides WhatsApp, email, operating hours, and physical location.
+- Accepted gear: Specialized Turbo Levo.
+- Location basis: official Finca Ecologica El Bosque map link and San Mateo address.
+
+### Line Up Surf Shop
+
+- Official rental page: `https://lineuptrade.com/en/pages/alquiler-de-tablas`
+- Official contact page: `https://lineuptrade.com/en/pages/contact`
+- Evidence: official page lists surfboards at 22 USD daily and 110 USD weekly, then publishes a model-level board inventory.
+- Accepted gear: Tahe Sports Paint Easy 8'6 Soft Top, Tahe Sports Paint Easy 7'6 Soft Top, Tahe Sports Paint Soft Top 8'0, Tahe Sports Paint Soft Top 7'0, Tahe Sports Paint Soft Top 6'0, Tahe Sports Meteor 7'10 Soft Top, SIC Darkhorse Vortex Foam 8'4, SIC Darkhorse Vortex Foam 7'4, SIC Darkhorse Vortex Foam 5'8, Tahe Sports Magnum Duratec 8'4, BIC Sports Malibu Duratec 7'9, Tahe Sports Mini Longboard Duratec 7'6, Tahe Sports Egg Duratec 7'0, Tahe Sports Shortboard Duratec 6'7, BIC Gerard Dabadie Fish 5'10, Tahe Sports Comet 7'8, Tahe Sports Comet 6'6, Torq Surfboards Funboard 8'2, Torq Surfboards Funboard 6'8, Torq Surfboards Fish 6'3, Safari Surfboards Logger 9'4, Safari Surfboards Goose 9'2.
+- Location basis: official Plaza Las Lajas contact address and map link.
+
+### Santa Catalina Surf Shop
+
+- Official home/catalog page: `https://www.santacatalinasurfshop.com/`
+- Official contact page: `https://www.santacatalinasurfshop.com/en/contact/`
+- Evidence: official page lists rent availability and daily USD prices for individual surfboard models.
+- Accepted gear: Lost/Mayhem Scorcher Model, Xanadu X21.
+- Location basis: official Estero Street, Hotel Santa Catalina address.
+
+### Sunzal Surf Company
+
+- Official rental page: `https://www.sunzal.com/things-to-do/surf-board-rentals/`
+- Evidence: official page states rates are in USD and exposes model-level surfboard gallery entries with per-board prices.
+- Accepted gear: Tomo Boss Up, Takayama In The Pink, Gerry Lopez Something Fishy, Lost Party Crasher, Lost Quiver Killer, DANC Funboard, Terry 9/3 Noserider Longboard, Torq 8'6 Longboard, Album Dark Arts, Paragon Retro Noserider, Free Movement Flying Pig, Xanadu Wave Rocket, Robert August What I Ride Mini, Lost Puddle Fish, Lost Short Round, Robert August What I Ride, Lost Sub Buggy, Lost V3 Rocket 5'8, Byrne Custom 6'6, Free Movement G-45, Doug Haut Funboard, Azteca Blue Beach, Sharpeyes Disco Inferno, Mick Fanning Sugar Glider, JS Factory Hyfi, Byrne Panda, Mick Fanning Even Flow, Sina Egg, Webber AfterBurner, Lost Weekend Warrior, Lost F1 5'10, Lost V3 Rocket 6'0, Del Ray Fish.
+- Location basis: official rental-page location/map copy for Balance/Roca Sunzal in El Tunco.
+
+## Data Rules Applied
+
+- No shop already present in the linked DemoStoke DB or seeded registry was intentionally re-seeded.
+- Only public model-level gear rows with public pricing were added.
+- Generic rentals, package/tier rows, brand-only rows, and aggregator-only pages were rejected.
+- Gear rows are category-homogeneous by migration.
+- Each gear row has two canonical category placeholder images.
+- `public.equipment.specs` is never referenced.
+- `size` contains only size names when used. Board lengths and bike wheel dimensions stay in the gear name or description prose.
+- `currency_code` is set on every row. All accepted source prices were published in USD.
+- SQL is idempotent by user email and `(user_id, category, lower(trim(name)))`.
+- These files are local-only until a human explicitly approves remote execution.

--- a/demostoke_seed_batches/central_south_america_gear/rejected_candidates.md
+++ b/demostoke_seed_batches/central_south_america_gear/rejected_candidates.md
@@ -1,0 +1,49 @@
+# Rejected and Held Candidates
+
+Status: local research notes for the Central and South America gear batch.
+
+## Rejected
+
+### Pura Vida Ride, Las Catalinas, Costa Rica
+
+- URLs checked:
+  - `https://www.puravidaride.com/bike-shop`
+  - `https://www.puravidaride.com/rentals`
+- Reason: official pages list mountain-bike brands and generic hardtail, full-suspension, and e-bike rental rates, but not a public model-level rental row. Held out of the executable seed even though the shop is real and relevant.
+
+### Frijoles Locos Surf Shop, Costa Rica
+
+- URL checked: `https://www.frikijoleslocos.com/`
+- Reason: public material showed surfboard rental brands and pricing, but not stable model-level board rows suitable for DemoStoke equipment records.
+
+### Rutenica Tours, Costa Rica
+
+- Reason: public material referenced 9-speed Specialized mountain bikes and pricing, but did not expose model-level mountain-bike names.
+
+### Guachipelin Adventure / Rincon de la Vieja, Costa Rica
+
+- Reason: public material referenced mountain bikes and adventure rentals, but not model-level rentable inventory.
+
+### Generic Central America surf-rental pages
+
+- Candidates checked included Wayo Whilar, Zonte Waves, Nicaragua/Popoyo surf shops, Pukana, Mancora, and Rentasurfboard Peru.
+- Reason: pages generally exposed board categories, lesson packages, or generic rentals without public brand + model + price + physical shop evidence.
+
+### Puelo Adventure, Chile
+
+- Reason: source and pricing evidence was not reliable enough for a durable seed row.
+
+### Andes ski and snowboard rental candidates
+
+- Candidates checked included Ski Total Chile, Ski Master, Bariloche rental pages, 26 Rental Bariloche, Epic Bariloche, and CaranvaSports/aggregator-style pages.
+- Reason: pages were package-level, brand-only, price-only, or aggregator pages without public model-level ski/snowboard rentable inventory. No ski or snowboard rows were seeded for this batch.
+
+### Sunzal brand-only or unclear surfboard entries
+
+- URL checked: `https://www.sunzal.com/things-to-do/surf-board-rentals/`
+- Reason: entries such as Hypto Krypto, Barahona 9'0, Channel Islands, South Coast, DHD, Addict Surfboard, TORQ, Beto Loureiro, John Carper, Papaya/Jeda, Sci-Fi Volume LFT, Skindog-pink, and numbered `1a`/`2b`/`3c`/`4d` were held because the source text did not provide a clear brand + model row suitable for a DemoStoke gear name.
+
+### Existing Mexico North America shops
+
+- Shops: Surf Mexico and BikeFlow Oaxaca.
+- Reason: already seeded in the North America coverage fill and not part of this Central/South America batch.

--- a/demostoke_seed_batches/central_south_america_gear/remote_runbook.md
+++ b/demostoke_seed_batches/central_south_america_gear/remote_runbook.md
@@ -1,6 +1,16 @@
 # Remote Runbook - Central and South America Gear
 
-Status: local pending. Do not apply to linked DemoStoke until a human explicitly approves remote execution.
+Status: applied to the linked DemoStoke Supabase project on 2026-06-07. Keep this runbook as the historical apply sequence.
+
+## Actual Apply Notes
+
+`psql` was not installed in the local environment, so the apply used the durable Supabase CLI fallback: `supabase db query --linked` with the exact migration file contents wrapped in explicit `BEGIN` / `ROLLBACK` and `BEGIN` / `COMMIT` transactions.
+
+- Rollback dry run status: `central_south_america_exact_dry_run_complete`
+- Commit status: `central_south_america_committed`
+- Idempotency rollback status: `central_south_america_idempotency_rollback_complete`
+- Migration repair: `supabase migration repair --linked --status applied 20260606120000 20260606120100 20260606120200`
+- Final migration state: local and remote aligned through `20260606120200`
 
 ## Migration Files
 

--- a/demostoke_seed_batches/central_south_america_gear/remote_runbook.md
+++ b/demostoke_seed_batches/central_south_america_gear/remote_runbook.md
@@ -1,0 +1,85 @@
+# Remote Runbook - Central and South America Gear
+
+Status: local pending. Do not apply to linked DemoStoke until a human explicitly approves remote execution.
+
+## Migration Files
+
+```text
+supabase/migrations/20260606120000_seed_central_south_america_gear_shops.sql
+supabase/migrations/20260606120100_seed_central_south_america_surfboards_gear.sql
+supabase/migrations/20260606120200_seed_central_south_america_mountain_bikes_gear.sql
+```
+
+## Preconditions
+
+- [ ] `psql` and Supabase CLI are available, or a real Postgres client fallback is prepared outside the repo.
+- [ ] Either `SUPABASE_ACCESS_TOKEN` is configured for linked execution or `SUPABASE_DB_URL` is configured for direct `psql` execution.
+- [ ] The live DemoStoke checkout is current and `supabase migration list --linked` shows no unexpected skipped, remote-only, or local-only versions beyond this batch.
+- [ ] `demostoke_seed_batches/central_south_america_gear/validation.sql` is SELECT-only.
+- [ ] Duplicate check returns no existing target shops.
+- [ ] Human approved remote execution.
+- [ ] Do not use `supabase db push`, `supabase db push --dry-run`, or `supabase migration up`.
+
+## Static Safety Scan
+
+```bash
+rg -n "DELETE FROM|TRUNCATE|ALTER TABLE|ON CONFLICT|specs" supabase/migrations/20260606120*.sql
+LC_ALL=C rg -n "[^[:ascii:]]" supabase/migrations/20260606120*.sql demostoke_seed_batches/central_south_america_gear
+git diff --check
+```
+
+Expected: no destructive SQL matches other than no output, no non-ASCII matches, and no whitespace errors.
+
+## Remote Dry Run
+
+Use a real Postgres transaction client. This executes the exact files and rolls back.
+
+```bash
+psql "$SUPABASE_DB_URL" --set ON_ERROR_STOP=1 <<'SQL'
+BEGIN;
+SET LOCAL lock_timeout = '10s';
+SET LOCAL statement_timeout = '120s';
+SELECT pg_advisory_xact_lock(20260606120000);
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260606120000_seed_central_south_america_gear_shops.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260606120100_seed_central_south_america_surfboards_gear.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260606120200_seed_central_south_america_mountain_bikes_gear.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/demostoke_seed_batches/central_south_america_gear/validation.sql
+ROLLBACK;
+SQL
+```
+
+## Remote Execution
+
+Only after the dry run passes and the user approves:
+
+```bash
+psql "$SUPABASE_DB_URL" --set ON_ERROR_STOP=1 <<'SQL'
+BEGIN;
+SET LOCAL lock_timeout = '10s';
+SET LOCAL statement_timeout = '120s';
+SELECT pg_advisory_xact_lock(20260606120000);
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260606120000_seed_central_south_america_gear_shops.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260606120100_seed_central_south_america_surfboards_gear.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/supabase/migrations/20260606120200_seed_central_south_america_mountain_bikes_gear.sql
+\i /Users/michaelzick/Engineering/GitHub/demostoke/demostoke_seed_batches/central_south_america_gear/validation.sql
+COMMIT;
+SQL
+```
+
+After commit, mark only these versions as applied:
+
+```bash
+supabase migration repair --linked --status applied 20260606120000 20260606120100 20260606120200
+supabase migration list --linked
+```
+
+## Post-Run Checks
+
+- [ ] Expected shops appear in `public.profiles`.
+- [ ] Expected roles appear in `public.user_roles`.
+- [ ] Expected gear appears in `public.equipment`.
+- [ ] Each new equipment row has exactly two images.
+- [ ] Gear appears with the correct shop lat/lng.
+- [ ] `validation.sql` was rerun read-only after commit.
+- [ ] A second rollback transaction proved idempotency and inserted zero new gear/images.
+- [ ] Migration history is aligned after repair.

--- a/demostoke_seed_batches/central_south_america_gear/remote_validation_report.md
+++ b/demostoke_seed_batches/central_south_america_gear/remote_validation_report.md
@@ -1,0 +1,33 @@
+# Remote Validation Report - Central and South America Gear
+
+Status: local pending. These migrations have not been applied to the linked DemoStoke Supabase project.
+
+## Current State
+
+- Migration files have been generated locally only.
+- Hermes audit/reference files have been mirrored locally only.
+- Read-only linked duplicate check returned `rows: []` for the selected shop names, seed emails, and website domains on 2026-06-06.
+- `supabase migration list --linked` showed local and remote aligned through `20260602120000`, with only `20260606120000`, `20260606120100`, and `20260606120200` local-only for this batch.
+- No remote dry run has been executed yet for this batch.
+- No linked DB commit has been executed.
+- No `supabase migration repair --linked` has been run for these versions.
+
+## Planned Counts
+
+| Shop | Category | Gear | Images |
+| --- | --- | ---: | ---: |
+| MTB Guatemala | mountain-bikes | 9 | 18 |
+| Bike Arenal | mountain-bikes | 3 | 6 |
+| Nosara MTB | mountain-bikes | 4 | 8 |
+| Buen Camino Bike Park | mountain-bikes | 1 | 2 |
+| Line Up Surf Shop | surfboards | 22 | 44 |
+| Santa Catalina Surf Shop | surfboards | 2 | 4 |
+| Sunzal Surf Company | surfboards | 33 | 66 |
+| **Total** | | **74** | **148** |
+
+## Required Before Remote Apply
+
+- Run the duplicate query in `validation.sql` against linked DemoStoke and confirm the expected target rows do not already exist.
+- Run a rollback dry run with the exact migration files.
+- Confirm `validation.sql` remains SELECT-only.
+- Get explicit human approval before committing the data-only batch.

--- a/demostoke_seed_batches/central_south_america_gear/remote_validation_report.md
+++ b/demostoke_seed_batches/central_south_america_gear/remote_validation_report.md
@@ -1,18 +1,21 @@
 # Remote Validation Report - Central and South America Gear
 
-Status: local pending. These migrations have not been applied to the linked DemoStoke Supabase project.
+Status: applied to the linked DemoStoke Supabase project on 2026-06-07.
 
-## Current State
+## Apply Sequence
 
-- Migration files have been generated locally only.
-- Hermes audit/reference files have been mirrored locally only.
-- Read-only linked duplicate check returned `rows: []` for the selected shop names, seed emails, and website domains on 2026-06-06.
-- `supabase migration list --linked` showed local and remote aligned through `20260602120000`, with only `20260606120000`, `20260606120100`, and `20260606120200` local-only for this batch.
-- No remote dry run has been executed yet for this batch.
-- No linked DB commit has been executed.
-- No `supabase migration repair --linked` has been run for these versions.
+- Preflight static safety scan found no destructive patterns in executable migration SQL.
+- `supabase migration list --linked` before apply showed local and remote aligned through `20260602120000`, with only `20260606120000`, `20260606120100`, and `20260606120200` local-only for this batch.
+- Read-only linked duplicate check returned `rows: []` for the selected shop names, seed emails, and website domains.
+- Rollback dry run with the exact migration files completed with status `central_south_america_exact_dry_run_complete`.
+- Commit transaction completed with status `central_south_america_committed`.
+- In-transaction assertions passed before `COMMIT`.
+- Read-only validation after commit returned all expected shops, all expected gear counts, and two images per gear row.
+- Idempotency rollback rerun completed with status `central_south_america_idempotency_rollback_complete`.
+- Migration metadata repaired with `supabase migration repair --linked --status applied 20260606120000 20260606120100 20260606120200`.
+- Final `supabase migration list --linked` showed all three versions aligned local and remote.
 
-## Planned Counts
+## Final Applied Counts
 
 | Shop | Category | Gear | Images |
 | --- | --- | ---: | ---: |
@@ -25,9 +28,14 @@ Status: local pending. These migrations have not been applied to the linked Demo
 | Sunzal Surf Company | surfboards | 33 | 66 |
 | **Total** | | **74** | **148** |
 
-## Required Before Remote Apply
+## Runtime User IDs
 
-- Run the duplicate query in `validation.sql` against linked DemoStoke and confirm the expected target rows do not already exist.
-- Run a rollback dry run with the exact migration files.
-- Confirm `validation.sql` remains SELECT-only.
-- Get explicit human approval before committing the data-only batch.
+| Shop | Seed email | User ID |
+| --- | --- | --- |
+| MTB Guatemala | `michaelzick+mtbguatemala@gmail.com` | `99516366-c4ab-4762-b2d8-0f7c823f5aef` |
+| Bike Arenal | `michaelzick+bikearenal@gmail.com` | `51715450-93d9-4117-aee3-3195092a8552` |
+| Nosara MTB | `michaelzick+nosaramtb@gmail.com` | `0fc17b2c-b17b-4ba4-bf36-4487a6aabea2` |
+| Buen Camino Bike Park | `michaelzick+buencamino@gmail.com` | `b070e33f-7b1a-49e9-a4f1-3e479b1e034c` |
+| Line Up Surf Shop | `michaelzick+lineuptrade@gmail.com` | `3595c224-e776-4703-b9ec-5f7f084bc95d` |
+| Santa Catalina Surf Shop | `michaelzick+santacatalinasurfshop@gmail.com` | `b431102c-2b78-4765-b1f9-2c3601d1a453` |
+| Sunzal Surf Company | `michaelzick+sunzalsurfcompany@gmail.com` | `1a4c4fad-cade-4d14-83d2-82fefcd69fca` |

--- a/demostoke_seed_batches/central_south_america_gear/sources.json
+++ b/demostoke_seed_batches/central_south_america_gear/sources.json
@@ -1,7 +1,7 @@
 {
   "batch": "central_south_america_gear",
   "created": "2026-06-06",
-  "remote_status": "local pending; not applied to linked Supabase",
+  "remote_status": "applied to linked Supabase project on 2026-06-07",
   "accepted": [
     {
       "shop": "MTB Guatemala",
@@ -84,6 +84,6 @@
     "linked_db_rows": 0,
     "checked_at": "2026-06-06",
     "query_file": "demostoke_seed_batches/central_south_america_gear/validation.sql",
-    "notes": "Linked read-only duplicate query returned rows: [] during authoring. Rerun immediately before any remote dry run or apply."
+    "notes": "Linked read-only duplicate query returned rows: [] before the rollback dry run and commit."
   }
 }

--- a/demostoke_seed_batches/central_south_america_gear/sources.json
+++ b/demostoke_seed_batches/central_south_america_gear/sources.json
@@ -1,0 +1,89 @@
+{
+  "batch": "central_south_america_gear",
+  "created": "2026-06-06",
+  "remote_status": "local pending; not applied to linked Supabase",
+  "accepted": [
+    {
+      "shop": "MTB Guatemala",
+      "category": "mountain-bikes",
+      "urls": [
+        "https://www.mtbguatemala.com/product-category/mountain-bike-rentals/",
+        "https://www.mtbguatemala.com/tours/tecpan-enduro-mtb-day-rides/"
+      ],
+      "gear_count": 9,
+      "notes": "Official catalog lists Commencal and Giant model-level mountain-bike rentals with USD daily pricing."
+    },
+    {
+      "shop": "Bike Arenal",
+      "category": "mountain-bikes",
+      "urls": [
+        "https://www.bikearenal.com/bike-rentals/",
+        "https://www.bikearenal.com/contact/"
+      ],
+      "gear_count": 3,
+      "notes": "Official page lists Cannondale Rush, Depro M2 Carbon Fiber, and Scott Scale model-level mountain-bike rentals at 65 USD per day."
+    },
+    {
+      "shop": "Nosara MTB",
+      "category": "mountain-bikes",
+      "urls": [
+        "https://nosaramtb.com/rentals/"
+      ],
+      "gear_count": 4,
+      "notes": "Official page lists Specialized and Rocky Mountain model-level mountain-bike rentals with day and week USD pricing."
+    },
+    {
+      "shop": "Buen Camino Bike Park",
+      "category": "mountain-bikes",
+      "urls": [
+        "https://buencaminocr.com/es/ride/"
+      ],
+      "gear_count": 1,
+      "notes": "Official page lists Specialized Turbo Levo rentals in all sizes at 130 USD and gives the shop contact and location."
+    },
+    {
+      "shop": "Line Up Surf Shop",
+      "category": "surfboards",
+      "urls": [
+        "https://lineuptrade.com/en/pages/alquiler-de-tablas",
+        "https://lineuptrade.com/en/pages/contact"
+      ],
+      "gear_count": 22,
+      "notes": "Official page lists surfboards at 22 USD daily and 110 USD weekly with model-level board inventory."
+    },
+    {
+      "shop": "Santa Catalina Surf Shop",
+      "category": "surfboards",
+      "urls": [
+        "https://www.santacatalinasurfshop.com/",
+        "https://www.santacatalinasurfshop.com/en/contact/"
+      ],
+      "gear_count": 2,
+      "notes": "Official page lists rentable Lost/Mayhem and Xanadu model-level surfboards with per-day USD prices."
+    },
+    {
+      "shop": "Sunzal Surf Company",
+      "category": "surfboards",
+      "urls": [
+        "https://www.sunzal.com/things-to-do/surf-board-rentals/"
+      ],
+      "gear_count": 33,
+      "notes": "Official page states rates are in USD and exposes model-level surfboard rental gallery entries with per-board prices."
+    }
+  ],
+  "planned_counts": {
+    "shops": 7,
+    "mountain_bikes": 17,
+    "surfboards": 57,
+    "skis": 0,
+    "snowboards": 0,
+    "gear_total": 74,
+    "image_total": 148
+  },
+  "duplicate_check_result": {
+    "linked_db_rows": 0,
+    "checked_at": "2026-06-06",
+    "query_file": "demostoke_seed_batches/central_south_america_gear/validation.sql",
+    "notes": "Linked read-only duplicate query returned rows: [] during authoring. Rerun immediately before any remote dry run or apply."
+  }
+}

--- a/demostoke_seed_batches/central_south_america_gear/validation.sql
+++ b/demostoke_seed_batches/central_south_america_gear/validation.sql
@@ -1,0 +1,93 @@
+-- Read-only validation for central_south_america_gear.
+-- Safe to run against linked DemoStoke DB after remote apply.
+
+WITH expected_shops (name, email, category, expected_gear_count) AS (
+  VALUES
+    ('MTB Guatemala', 'michaelzick+mtbguatemala@gmail.com', 'mountain-bikes', 9),
+    ('Bike Arenal', 'michaelzick+bikearenal@gmail.com', 'mountain-bikes', 3),
+    ('Nosara MTB', 'michaelzick+nosaramtb@gmail.com', 'mountain-bikes', 4),
+    ('Buen Camino Bike Park', 'michaelzick+buencamino@gmail.com', 'mountain-bikes', 1),
+    ('Line Up Surf Shop', 'michaelzick+lineuptrade@gmail.com', 'surfboards', 22),
+    ('Santa Catalina Surf Shop', 'michaelzick+santacatalinasurfshop@gmail.com', 'surfboards', 2),
+    ('Sunzal Surf Company', 'michaelzick+sunzalsurfcompany@gmail.com', 'surfboards', 33)
+),
+actual AS (
+  SELECT
+    es.name,
+    es.email,
+    es.category,
+    es.expected_gear_count,
+    p.id AS profile_id,
+    p.address,
+    p.location_lat,
+    p.location_lng,
+    COUNT(DISTINCT e.id) FILTER (WHERE e.category = es.category) AS actual_gear_count,
+    COUNT(ei.id) FILTER (WHERE e.category = es.category) AS image_count
+  FROM expected_shops es
+  LEFT JOIN auth.users au ON au.email = es.email
+  LEFT JOIN public.profiles p ON p.id = au.id
+  LEFT JOIN public.equipment e ON e.user_id = au.id
+  LEFT JOIN public.equipment_images ei ON ei.equipment_id = e.id
+  GROUP BY es.name, es.email, es.category, es.expected_gear_count, p.id, p.address, p.location_lat, p.location_lng
+)
+SELECT
+  name,
+  email,
+  category,
+  profile_id IS NOT NULL AS profile_exists,
+  expected_gear_count,
+  actual_gear_count,
+  image_count,
+  image_count = actual_gear_count * 2 AS has_two_images_each,
+  address,
+  location_lat,
+  location_lng
+FROM actual
+ORDER BY name;
+
+WITH expected_emails (email) AS (
+  VALUES
+    ('michaelzick+mtbguatemala@gmail.com'),
+    ('michaelzick+bikearenal@gmail.com'),
+    ('michaelzick+nosaramtb@gmail.com'),
+    ('michaelzick+buencamino@gmail.com'),
+    ('michaelzick+lineuptrade@gmail.com'),
+    ('michaelzick+santacatalinasurfshop@gmail.com'),
+    ('michaelzick+sunzalsurfcompany@gmail.com')
+)
+SELECT
+  au.email,
+  ur.display_role
+FROM expected_emails ee
+LEFT JOIN auth.users au ON au.email = ee.email
+LEFT JOIN public.user_roles ur ON ur.user_id = au.id
+ORDER BY au.email;
+
+WITH duplicate_targets (name, email, website_fragment) AS (
+  VALUES
+    ('mtb guatemala', 'michaelzick+mtbguatemala@gmail.com', 'mtbguatemala.com'),
+    ('bike arenal', 'michaelzick+bikearenal@gmail.com', 'bikearenal.com'),
+    ('nosara mtb', 'michaelzick+nosaramtb@gmail.com', 'nosaramtb.com'),
+    ('buen camino bike park', 'michaelzick+buencamino@gmail.com', 'buencaminocr.com'),
+    ('line up surf shop', 'michaelzick+lineuptrade@gmail.com', 'lineuptrade.com'),
+    ('santa catalina surf shop', 'michaelzick+santacatalinasurfshop@gmail.com', 'santacatalinasurfshop.com'),
+    ('sunzal surf company', 'michaelzick+sunzalsurfcompany@gmail.com', 'sunzal.com')
+)
+SELECT
+  p.name,
+  p.website,
+  p.address,
+  au.email,
+  COUNT(DISTINCT e.id) AS gear_count
+FROM public.profiles p
+LEFT JOIN auth.users au ON au.id = p.id
+LEFT JOIN public.equipment e ON e.user_id = p.id
+WHERE EXISTS (
+  SELECT 1
+  FROM duplicate_targets dt
+  WHERE lower(p.name) = dt.name
+     OR lower(coalesce(au.email, '')) = dt.email
+     OR lower(coalesce(p.website, '')) LIKE '%' || dt.website_fragment || '%'
+)
+GROUP BY p.name, p.website, p.address, au.email
+ORDER BY p.name;

--- a/demostoke_seed_batches/central_south_america_gear/validation.sql
+++ b/demostoke_seed_batches/central_south_america_gear/validation.sql
@@ -9,7 +9,7 @@ WITH expected_shops (name, email, category, expected_gear_count) AS (
     ('Buen Camino Bike Park', 'michaelzick+buencamino@gmail.com', 'mountain-bikes', 1),
     ('Line Up Surf Shop', 'michaelzick+lineuptrade@gmail.com', 'surfboards', 22),
     ('Santa Catalina Surf Shop', 'michaelzick+santacatalinasurfshop@gmail.com', 'surfboards', 2),
-    ('Sunzal Surf Company', 'michaelzick+sunzalsurfcompany@gmail.com', 'surfboards', 33)
+    ('Sunzal Surf Company', 'michaelzick+sunzalsurfcompany@gmail.com', 'surfboards', 36)
 ),
 actual AS (
   SELECT

--- a/demostoke_seed_batches/central_south_america_surfboards_followup/discovery_audit.md
+++ b/demostoke_seed_batches/central_south_america_surfboards_followup/discovery_audit.md
@@ -1,0 +1,77 @@
+# Central and South America Surfboards Follow-Up Discovery Audit
+
+Status: applied to the linked DemoStoke Supabase project on 2026-06-07 after a rollback dry run succeeded.
+
+Created: 2026-06-07
+
+Branch: `codex/central-south-america-gear-seeds`
+
+## Scope
+
+The user pointed to Sunzal Surf Company's itemized surfboard rental page and asked to add that shop/gear and look for other similar parseable pages.
+
+Sunzal Surf Company was already seeded and applied in the Central and South America batch with 33 surfboards, including the user's examples `Tomo Boss Up` and `Takayama In The Pink`. This follow-up adds three additional defensible Sunzal board rows from the same official page and one newly discovered qualifying Costa Rica surf shop:
+
+| Region | Shop | Category | Planned new gear |
+| --- | --- | --- | ---: |
+| El Salvador | Sunzal Surf Company | surfboards | 3 |
+| Costa Rica | Nosara Surfboards | surfboards | 9 |
+| **Total** | | | **12** |
+
+## Duplicate Checks
+
+Read-only linked DB checks before authoring found:
+
+- Sunzal Surf Company exists with 33 current surfboard rows.
+- `Tomo Boss Up` and `Takayama In The Pink` already exist for Sunzal.
+- `Hypto Krypto`, `Barahona 9'0`, and `Sci-Fi Volume LFT` do not exist for Sunzal.
+- Nosara Surfboards does not exist by profile name, seed email, or target website in the linked DB.
+
+Representative linked DB query:
+
+```sql
+SELECT au.email, pr.name, pr.address, COUNT(e.id)::int AS gear_count
+FROM auth.users au
+LEFT JOIN public.profiles pr ON pr.id = au.id
+LEFT JOIN public.equipment e ON e.user_id = au.id
+WHERE lower(coalesce(pr.name, '')) IN (lower('Nosara Surfboards'), lower('Sunzal Surf Company'))
+   OR au.email IN ('michaelzick+nosarasurfboards@gmail.com', 'michaelzick+sunzalsurfcompany@gmail.com')
+GROUP BY au.email, pr.name, pr.address
+ORDER BY pr.name;
+```
+
+Expected before apply: one Sunzal row and no Nosara Surfboards row.
+
+## Accepted Sources
+
+### Sunzal Surf Company
+
+- Official rental page: `https://www.sunzal.com/things-to-do/surf-board-rentals/`
+- Evidence: the official page states all rates are in USD and exposes individual gallery blocks with a board name, supporting board/detail images, and a per-board price.
+- Already applied examples from this page: Tomo Boss Up, Takayama In The Pink.
+- Follow-up accepted gear: Hypto Krypto, Barahona 9'0, Sci-Fi Volume LFT.
+- Location basis: existing applied Sunzal profile at Hotel Roca Sunzal, El Tunco, La Libertad, El Salvador.
+
+### Nosara Surfboards
+
+- Home / featured fleet: `https://nosarasurfboards.com/`
+- Surfboard collection: `https://nosarasurfboards.com/collections/all`
+- Rentals page: `https://nosarasurfboards.com/pages/rentals`
+- Contact page: `https://nosarasurfboards.com/pages/contact`
+- Contact policy: `https://nosarasurfboards.com/policies/contact-information`
+- Evidence: the official Shopify storefront describes premium surfboard rentals, says rentals are for a minimum of one day, lists product-level surfboard pages with USD prices, and publishes physical pickup/contact details for Become Nosara near Guiones Beach.
+- Accepted gear: Sharpeye FT Inferno Carbon 5'10, Sharpeye Inferno 72 Carbon 5'10, Firewire Slater Designs S Boss Volcano I-Bolic 6'0, Pyzel Ghost XL 6'2, Firewire Slater Designs S Boss Turquoise I-Bolic 6'2, Sharpeye Mid Length 6'6, Chilli Mid Strength 7'0, Lost Glydra 7'0, Channel Islands CI 2 Pro 5'10.
+- Location basis: official contact page and contact policy place the shop at Become Nosara, B34, 50206 Nosara, Guanacaste, Costa Rica. Coordinates are approximate to the Become Nosara / Playa Guiones area.
+
+## Data Rules Applied
+
+- The already-applied Sunzal shop profile is reused; it is not re-seeded.
+- Nosara Surfboards uses a new guarded seed email: `michaelzick+nosarasurfboards@gmail.com`.
+- Only public itemized surfboard rows with public USD pricing were added.
+- Generic rentals, package/tier rows, brand-only rows, sales-only pages, and outside-region pages were rejected.
+- Each gear row has two canonical surfboard placeholder images from `AGENTS.md`.
+- `public.equipment.specs` is never referenced.
+- `size` is left null; board dimensions stay in description prose.
+- `currency_code` is set to `USD` on every row because the accepted source prices are published in USD.
+- SQL is idempotent by user email and `(user_id, category, lower(trim(name)))`.
+- Remote execution completed on 2026-06-07 with rollback dry run, commit transaction, read-only validation, idempotency rollback, and migration-history repair.

--- a/demostoke_seed_batches/central_south_america_surfboards_followup/rejected_candidates.md
+++ b/demostoke_seed_batches/central_south_america_surfboards_followup/rejected_candidates.md
@@ -1,0 +1,36 @@
+# Rejected and Held Candidates
+
+Status: local research notes for the Central and South America surfboards follow-up.
+
+## Rejected / Held
+
+### Sunzal brand-only or unclear surfboard entries
+
+- URL checked: `https://www.sunzal.com/things-to-do/surf-board-rentals/`
+- Held after follow-up review: Channel Islands, South Coast, DHD, Addict Surfboard, TORQ, Beto Loureiro, JOHN CARPER, Papaya / Jeda, Skindog-pink-1, and the numbered `1a` / `2b` / `3c` / `4d` block.
+- Reason: each block is priced and itemized, but the visible text is still brand-only, generic, a probable image-file label, or otherwise not a stable model-level gear name. They were not inserted to avoid manufacturing model names.
+
+### Head High Surf Shop, Dominical, Costa Rica
+
+- URL checked: `https://headhighsurfshop.com/`
+- Reason: official page lists rental board brands and board categories, but not public model-level rows or prices for individual rentable boards.
+
+### Mancora Surf Shop, Peru
+
+- URL checked: `https://mancorasurfshop.com/`
+- Reason: official site is a retail/surf-class page and does not expose model-level rental inventory with prices.
+
+### El Barco Surf Supply, Pichilemu, Chile
+
+- URL checked: `https://www.elbarcosurfsupply.cl/puddle-jumper-pro`
+- Reason: public product page is a sales listing, not a rental listing.
+
+### Caviahue Ski Resort, Argentina
+
+- URL checked: `https://www.caviahue.com/en/product-page/pase-y-alquiler-de-equipo-de-ski-snow-semanal-t-media`
+- Reason: ski/snowboard rental package is category/package-level and does not expose model-level ski or snowboard inventory.
+
+### CCT Bikerentals
+
+- URL checked: `https://www.cctbikerental.com/rentals/e-mtb-specialized-turbo-levo-comp/`
+- Reason: parseable model-level rental page, but it is outside the Central/South America scope.

--- a/demostoke_seed_batches/central_south_america_surfboards_followup/remote_runbook.md
+++ b/demostoke_seed_batches/central_south_america_surfboards_followup/remote_runbook.md
@@ -1,0 +1,83 @@
+# Remote Runbook - Central and South America Surfboards Follow-Up
+
+Status: applied to the linked DemoStoke Supabase project on 2026-06-07.
+
+## Migration
+
+- `supabase/migrations/20260607120000_seed_central_south_america_surfboards_followup.sql`
+
+## Preflight
+
+1. Confirm clean migration history:
+
+```sh
+supabase migration list --linked
+```
+
+Expected: local and remote aligned through `20260606120200`, with only `20260607120000` local-only before this follow-up is applied.
+
+2. Run read-only duplicate checks:
+
+```sh
+supabase db query --linked --output json "
+select au.email, pr.name, pr.address, count(e.id)::int as gear_count
+from auth.users au
+left join public.profiles pr on pr.id = au.id
+left join public.equipment e on e.user_id = au.id
+where lower(coalesce(pr.name, '')) in (lower('Nosara Surfboards'), lower('Sunzal Surf Company'))
+   or au.email in ('michaelzick+nosarasurfboards@gmail.com','michaelzick+sunzalsurfcompany@gmail.com')
+group by au.email, pr.name, pr.address
+order by pr.name;
+"
+```
+
+## Dry Run
+
+Wrap the exact migration contents in:
+
+```sql
+BEGIN;
+SET LOCAL lock_timeout = '10s';
+SET LOCAL statement_timeout = '120s';
+SELECT pg_advisory_xact_lock(20260607120000);
+-- exact migration file contents here
+-- assertions here
+ROLLBACK;
+```
+
+Expected assertion targets:
+
+- Nosara Surfboards profile exists in the transaction.
+- Sunzal Surf Company has 36 surfboard rows in the transaction.
+- Nosara Surfboards has 9 surfboard rows in the transaction.
+- The 12 follow-up gear names exist with `currency_code = 'USD'`.
+- Follow-up gear rows have two `equipment_images` rows each.
+
+## Commit
+
+Only after the rollback dry run passes, run the exact same SQL with `COMMIT`.
+
+## Post-Commit
+
+1. Run `validation.sql`.
+2. Rerun the exact migration inside a rollback transaction to confirm idempotency.
+3. Mark the migration applied in migration metadata:
+
+```sh
+supabase migration repair --linked --status applied 20260607120000
+```
+
+4. Confirm final alignment:
+
+```sh
+supabase migration list --linked
+```
+
+## Actual Apply Notes
+
+- `psql` was not available in this environment, so the migration was executed with `supabase db query --linked --output json` using the exact local migration file contents inside explicit transactions.
+- Rollback dry run completed with status `central_south_america_surfboards_followup_dry_run_complete`.
+- Commit transaction completed with status `central_south_america_surfboards_followup_committed`.
+- Post-commit validation confirmed Sunzal Surf Company has 36 surfboards and 72 images, and Nosara Surfboards has 9 surfboards and 18 images.
+- Idempotency rollback rerun completed with status `central_south_america_surfboards_followup_idempotency_rollback_complete`.
+- Migration metadata was repaired with `supabase migration repair --linked --status applied 20260607120000`.

--- a/demostoke_seed_batches/central_south_america_surfboards_followup/remote_validation_report.md
+++ b/demostoke_seed_batches/central_south_america_surfboards_followup/remote_validation_report.md
@@ -1,0 +1,49 @@
+# Remote Validation Report - Central and South America Surfboards Follow-Up
+
+Status: applied to the linked DemoStoke Supabase project on 2026-06-07.
+
+## Apply Sequence
+
+- Preflight static safety scan found no destructive patterns in executable migration SQL.
+- `git diff --check` passed before linked execution.
+- `supabase migration list --linked` before apply showed local and remote aligned through `20260606120200`, with only `20260607120000` local-only for this follow-up.
+- Read-only linked duplicate checks found Sunzal Surf Company already applied with 33 surfboards, found `Tomo Boss Up` and `Takayama In The Pink` already present, found the three Sunzal follow-up names missing, and found no Nosara Surfboards profile or seed email.
+- Rollback dry run with the exact migration file completed with status `central_south_america_surfboards_followup_dry_run_complete`.
+- Commit transaction completed with status `central_south_america_surfboards_followup_committed`.
+- In-transaction assertions passed before `COMMIT`.
+- Read-only validation after commit returned the expected shop counts, gear names, USD prices, and two images per gear row.
+- Idempotency rollback rerun completed with status `central_south_america_surfboards_followup_idempotency_rollback_complete`.
+- Migration metadata repaired with `supabase migration repair --linked --status applied 20260607120000`.
+- Final `supabase migration list --linked` showed `20260607120000` aligned local and remote.
+
+## Final Applied Counts
+
+| Shop | Category | Gear | Images |
+| --- | --- | ---: | ---: |
+| Sunzal Surf Company | surfboards | 36 | 72 |
+| Nosara Surfboards | surfboards | 9 | 18 |
+| **Follow-up delta** | | **12** | **24** |
+
+## Runtime User IDs
+
+| Shop | Seed email | User ID |
+| --- | --- | --- |
+| Sunzal Surf Company | `michaelzick+sunzalsurfcompany@gmail.com` | `1a4c4fad-cade-4d14-83d2-82fefcd69fca` |
+| Nosara Surfboards | `michaelzick+nosarasurfboards@gmail.com` | `3fcb7d3b-de1c-4f57-b893-702798801089` |
+
+## Follow-Up Gear
+
+| Shop | Name | Category | $/day |
+| --- | --- | --- | ---: |
+| Sunzal Surf Company | Hypto Krypto | surfboards | $35.00 |
+| Sunzal Surf Company | Barahona 9'0 | surfboards | $30.00 |
+| Sunzal Surf Company | Sci-Fi Volume LFT | surfboards | $20.00 |
+| Nosara Surfboards | Sharpeye FT Inferno Carbon 5'10 | surfboards | $100.00 |
+| Nosara Surfboards | Sharpeye Inferno 72 Carbon 5'10 | surfboards | $95.00 |
+| Nosara Surfboards | Firewire Slater Designs S Boss Volcano I-Bolic 6'0 | surfboards | $50.00 |
+| Nosara Surfboards | Pyzel Ghost XL 6'2 | surfboards | $50.00 |
+| Nosara Surfboards | Firewire Slater Designs S Boss Turquoise I-Bolic 6'2 | surfboards | $50.00 |
+| Nosara Surfboards | Sharpeye Mid Length 6'6 | surfboards | $50.00 |
+| Nosara Surfboards | Chilli Mid Strength 7'0 | surfboards | $50.00 |
+| Nosara Surfboards | Lost Glydra 7'0 | surfboards | $50.00 |
+| Nosara Surfboards | Channel Islands CI 2 Pro 5'10 | surfboards | $40.00 |

--- a/demostoke_seed_batches/central_south_america_surfboards_followup/sources.json
+++ b/demostoke_seed_batches/central_south_america_surfboards_followup/sources.json
@@ -1,0 +1,47 @@
+{
+  "batch": "central_south_america_surfboards_followup",
+  "created": "2026-06-07",
+  "remote_status": "applied to linked Supabase project on 2026-06-07",
+  "accepted": [
+    {
+      "shop": "Sunzal Surf Company",
+      "category": "surfboards",
+      "urls": [
+        "https://www.sunzal.com/things-to-do/surf-board-rentals/"
+      ],
+      "new_gear_count": 3,
+      "notes": "Official page states all rates are in USD and exposes individual gallery blocks with board names and per-board prices. Existing applied Sunzal gear already includes Tomo Boss Up and Takayama In The Pink."
+    },
+    {
+      "shop": "Nosara Surfboards",
+      "category": "surfboards",
+      "urls": [
+        "https://nosarasurfboards.com/",
+        "https://nosarasurfboards.com/collections/all",
+        "https://nosarasurfboards.com/pages/rentals",
+        "https://nosarasurfboards.com/pages/contact",
+        "https://nosarasurfboards.com/policies/contact-information"
+      ],
+      "new_gear_count": 9,
+      "notes": "Official Shopify storefront lists premium surfboard rentals, minimum one-day rental terms, product-level surfboard pages with USD prices, and Become Nosara pickup/contact details."
+    }
+  ],
+  "planned_counts": {
+    "shops": 1,
+    "existing_shop_updates": 1,
+    "surfboards": 12,
+    "gear_total": 12,
+    "image_total": 24
+  },
+  "duplicate_check_result": {
+    "linked_db_rows": [
+      {
+        "shop": "Sunzal Surf Company",
+        "email": "michaelzick+sunzalsurfcompany@gmail.com",
+        "gear_count": 33
+      }
+    ],
+    "checked_at": "2026-06-07",
+    "notes": "Linked read-only checks found Sunzal already applied with 33 surfboards, found the user's Sunzal examples already present, found the three follow-up Sunzal names missing, and found no Nosara Surfboards profile or seed email. Rollback dry run and linked commit both succeeded on 2026-06-07."
+  }
+}

--- a/demostoke_seed_batches/central_south_america_surfboards_followup/validation.sql
+++ b/demostoke_seed_batches/central_south_america_surfboards_followup/validation.sql
@@ -1,0 +1,96 @@
+-- Read-only validation for central_south_america_surfboards_followup.
+-- Safe to run against linked DemoStoke DB after remote apply.
+
+WITH expected_shops (name, email, category, expected_gear_count) AS (
+  VALUES
+    ('Sunzal Surf Company', 'michaelzick+sunzalsurfcompany@gmail.com', 'surfboards', 36),
+    ('Nosara Surfboards', 'michaelzick+nosarasurfboards@gmail.com', 'surfboards', 9)
+),
+actual AS (
+  SELECT
+    es.name,
+    es.email,
+    es.category,
+    es.expected_gear_count,
+    p.id AS profile_id,
+    p.address,
+    p.location_lat,
+    p.location_lng,
+    COUNT(DISTINCT e.id) FILTER (WHERE e.category = es.category) AS actual_gear_count,
+    COUNT(ei.id) FILTER (WHERE e.category = es.category) AS image_count
+  FROM expected_shops es
+  LEFT JOIN auth.users au ON au.email = es.email
+  LEFT JOIN public.profiles p ON p.id = au.id
+  LEFT JOIN public.equipment e ON e.user_id = au.id
+  LEFT JOIN public.equipment_images ei ON ei.equipment_id = e.id
+  GROUP BY es.name, es.email, es.category, es.expected_gear_count, p.id, p.address, p.location_lat, p.location_lng
+)
+SELECT
+  name,
+  email,
+  category,
+  profile_id IS NOT NULL AS profile_exists,
+  expected_gear_count,
+  actual_gear_count,
+  image_count,
+  image_count = actual_gear_count * 2 AS has_two_images_each,
+  address,
+  location_lat,
+  location_lng
+FROM actual
+ORDER BY name;
+
+WITH expected_names (email, name) AS (
+  VALUES
+    ('michaelzick+sunzalsurfcompany@gmail.com', 'Hypto Krypto'),
+    ('michaelzick+sunzalsurfcompany@gmail.com', 'Barahona 9''0'),
+    ('michaelzick+sunzalsurfcompany@gmail.com', 'Sci-Fi Volume LFT'),
+    ('michaelzick+nosarasurfboards@gmail.com', 'Sharpeye FT Inferno Carbon 5''10'),
+    ('michaelzick+nosarasurfboards@gmail.com', 'Sharpeye Inferno 72 Carbon 5''10'),
+    ('michaelzick+nosarasurfboards@gmail.com', 'Firewire Slater Designs S Boss Volcano I-Bolic 6''0'),
+    ('michaelzick+nosarasurfboards@gmail.com', 'Pyzel Ghost XL 6''2'),
+    ('michaelzick+nosarasurfboards@gmail.com', 'Firewire Slater Designs S Boss Turquoise I-Bolic 6''2'),
+    ('michaelzick+nosarasurfboards@gmail.com', 'Sharpeye Mid Length 6''6'),
+    ('michaelzick+nosarasurfboards@gmail.com', 'Chilli Mid Strength 7''0'),
+    ('michaelzick+nosarasurfboards@gmail.com', 'Lost Glydra 7''0'),
+    ('michaelzick+nosarasurfboards@gmail.com', 'Channel Islands CI 2 Pro 5''10')
+)
+SELECT
+  en.email,
+  en.name,
+  e.id IS NOT NULL AS gear_exists,
+  e.price_per_day,
+  e.currency_code,
+  COUNT(ei.id) AS image_count
+FROM expected_names en
+LEFT JOIN auth.users au ON au.email = en.email
+LEFT JOIN public.equipment e
+  ON e.user_id = au.id
+ AND e.category = 'surfboards'
+ AND lower(btrim(e.name)) = lower(btrim(en.name))
+LEFT JOIN public.equipment_images ei ON ei.equipment_id = e.id
+GROUP BY en.email, en.name, e.id, e.price_per_day, e.currency_code
+ORDER BY en.email, en.name;
+
+WITH duplicate_targets (name, email, website_fragment) AS (
+  VALUES
+    ('nosara surfboards', 'michaelzick+nosarasurfboards@gmail.com', 'nosarasurfboards.com')
+)
+SELECT
+  p.name,
+  p.website,
+  p.address,
+  au.email,
+  COUNT(DISTINCT e.id) AS gear_count
+FROM public.profiles p
+LEFT JOIN auth.users au ON au.id = p.id
+LEFT JOIN public.equipment e ON e.user_id = p.id
+WHERE EXISTS (
+  SELECT 1
+  FROM duplicate_targets dt
+  WHERE lower(p.name) = dt.name
+     OR lower(coalesce(au.email, '')) = dt.email
+     OR lower(coalesce(p.website, '')) LIKE '%' || dt.website_fragment || '%'
+)
+GROUP BY p.name, p.website, p.address, au.email
+ORDER BY p.name;

--- a/supabase/migrations/20260606120000_seed_central_south_america_gear_shops.sql
+++ b/supabase/migrations/20260606120000_seed_central_south_america_gear_shops.sql
@@ -1,0 +1,162 @@
+-- Seed migration: Central and South America qualifying gear shops
+-- Batch: central_south_america_gear
+-- Created: 2026-06-06
+-- Remote status: local only; apply to linked Supabase only after explicit human approval.
+-- Do NOT use supabase db push or supabase migration up for this data-only batch.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- =============================================
+-- CENTRAL AND SOUTH AMERICA QUALIFYING GEAR SHOPS
+-- Shop/user inserts (auth.users + auth.identities + public.profiles + public.user_roles)
+-- Password: $uO9RX^1P%bd#8crEAM!
+-- NOTE: auth.users insert is guarded by email lookup for idempotent local testing.
+-- NOTE: user_roles upsert uses UPDATE...IF NOT FOUND THEN INSERT.
+-- NOTE: profile upsert uses UPDATE...IF NOT FOUND THEN INSERT.
+-- =============================================
+
+DO $$
+DECLARE
+  shop record;
+  new_user_id uuid;
+  v_avatar_url text;
+  v_hero_image_url text;
+  v_display_role text := 'retail-store';
+BEGIN
+  FOR shop IN
+    SELECT *
+    FROM (
+      VALUES
+        (
+          E'MTB Guatemala',
+          E'Tecpan, Guatemala',
+          E'michaelzick+mtbguatemala@gmail.com',
+          E'mountain-bikes',
+          E'https://www.mtbguatemala.com/',
+          E'+1-347-403-9993',
+          E'MTB Guatemala Tecpan, km88 Carretera Panamericana, Tecpan, Chimaltenango, Guatemala',
+          E'Guatemala mountain-bike operator with a current official rental catalog listing Commencal and Giant model-level mountain bikes and USD rental pricing.',
+          14.7688752,
+          -90.9893490
+        ),
+        (
+          E'Bike Arenal',
+          E'La Fortuna, Costa Rica',
+          E'michaelzick+bikearenal@gmail.com',
+          E'mountain-bikes',
+          E'https://www.bikearenal.com/',
+          E'+506 2479 9020',
+          E'400 m south from downtown La Fortuna, on the way to La Fortuna Waterfall, La Fortuna, Alajuela, Costa Rica',
+          E'La Fortuna mountain-bike rental shop with official public model listings, daily pricing, components, and size availability for its mountain-bike fleet.',
+          10.4669811,
+          -84.6464356
+        ),
+        (
+          E'Nosara MTB',
+          E'Nosara, Costa Rica',
+          E'michaelzick+nosaramtb@gmail.com',
+          E'mountain-bikes',
+          E'https://nosaramtb.com/',
+          E'+506 2573 3948',
+          E'Gilded Iguana Athletic Center, Playa Guiones north, Nosara, Guanacaste 50206, Costa Rica',
+          E'Nosara mountain-bike shop with public rental listings for Specialized and Rocky Mountain model-level bikes and USD day/week pricing.',
+          9.9470000,
+          -85.6650000
+        ),
+        (
+          E'Buen Camino Bike Park',
+          E'San Mateo, Costa Rica',
+          E'michaelzick+buencamino@gmail.com',
+          E'mountain-bikes',
+          E'https://buencaminocr.com/',
+          E'+506 7235 5075',
+          E'Finca Ecologica El Bosque, San Mateo, Alajuela, Costa Rica',
+          E'Costa Rica bike park with an official Specialized Turbo Levo rental page, public USD rental price, and bike-park contact information.',
+          9.9467012,
+          -84.5328223
+        ),
+        (
+          E'Line Up Surf Shop',
+          E'Coronado, Panama',
+          E'michaelzick+lineuptrade@gmail.com',
+          E'surfboards',
+          E'https://lineuptrade.com/',
+          E'+507 6770-1244',
+          E'Plaza Las Lajas, first floor, local PA4, Coronado, Panama',
+          E'Coronado surf shop with an official surfboard rental catalog listing brand and model boards plus daily and weekly USD rental pricing.',
+          8.5468434,
+          -79.9119799
+        ),
+        (
+          E'Santa Catalina Surf Shop',
+          E'Santa Catalina, Panama',
+          E'michaelzick+santacatalinasurfshop@gmail.com',
+          E'surfboards',
+          E'https://www.santacatalinasurfshop.com/',
+          E'+507 6780 2104',
+          E'Estero Street, Hotel Santa Catalina, Santa Catalina, Panama',
+          E'Santa Catalina surf shop with public model-level surfboard rental listings and per-day USD pricing for available boards.',
+          7.6289928,
+          -81.2528320
+        ),
+        (
+          E'Sunzal Surf Company',
+          E'El Tunco, El Salvador',
+          E'michaelzick+sunzalsurfcompany@gmail.com',
+          E'surfboards',
+          E'https://www.sunzal.com/',
+          E'+1 720-575-5341',
+          E'Hotel Roca Sunzal, El Tunco, La Libertad, El Salvador',
+          E'El Salvador surf company with an official surfboard rental page that exposes model-level gallery entries and USD rental prices.',
+          13.4933551,
+          -89.3849212
+        )
+    ) AS s(name, city, email, category, website, phone, address, about, lat, lng)
+  LOOP
+    CASE shop.category
+      WHEN 'surfboards' THEN
+        v_avatar_url := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/73de4049-7ffd-45cd-868b-c2d0076107b3/profile-1752863282257.png';
+        v_hero_image_url := 'https://images.unsplash.com/photo-1502680390469-be75c86b636f?q=80&w=3540&auto=format&fit=crop&ixlib=rb-4.0.3';
+      WHEN 'mountain-bikes' THEN
+        v_avatar_url := 'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/ad2ad153-bb35-4e88-bfb0-d0d4f85ba62f/profile-1752637760487.png';
+        v_hero_image_url := 'https://images.unsplash.com/photo-1506316940527-4d1c138978a0?q=80&w=3512&auto=format&fit=crop&ixlib=rb-4.0.3';
+      ELSE
+        v_avatar_url := NULL;
+        v_hero_image_url := NULL;
+    END CASE;
+
+    SELECT id INTO new_user_id FROM auth.users WHERE email = shop.email LIMIT 1;
+
+    IF new_user_id IS NULL THEN
+      new_user_id := gen_random_uuid();
+      INSERT INTO auth.users (id, instance_id, aud, role, email, encrypted_password, email_confirmed_at, raw_user_meta_data, raw_app_meta_data, created_at, updated_at, confirmation_token, recovery_token, email_change, email_change_token_current, email_change_token_new, email_change_confirm_status, phone_change, phone_change_token, reauthentication_token)
+      VALUES (new_user_id, '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', shop.email, extensions.crypt('$uO9RX^1P%bd#8crEAM!', extensions.gen_salt('bf')), now(), jsonb_build_object('name', shop.name), jsonb_build_object('provider', 'email', 'providers', ARRAY['email']), now(), now(), '', '', '', '', '', 0, '', '', '');
+      INSERT INTO auth.identities (id, user_id, identity_data, provider, provider_id, last_sign_in_at, created_at, updated_at)
+      VALUES (gen_random_uuid(), new_user_id, jsonb_build_object('sub', new_user_id::text, 'email', shop.email), 'email', new_user_id::text, now(), now(), now());
+    END IF;
+
+    UPDATE public.profiles
+    SET name = shop.name,
+        website = shop.website,
+        phone = shop.phone,
+        address = shop.address,
+        about = shop.about,
+        location_lat = shop.lat,
+        location_lng = shop.lng,
+        avatar_url = COALESCE(v_avatar_url, avatar_url),
+        hero_image_url = COALESCE(v_hero_image_url, hero_image_url)
+    WHERE id = new_user_id;
+
+    IF NOT FOUND THEN
+      INSERT INTO public.profiles (id, name, website, phone, address, about, location_lat, location_lng, avatar_url, hero_image_url)
+      VALUES (new_user_id, shop.name, shop.website, shop.phone, shop.address, shop.about, shop.lat, shop.lng, v_avatar_url, v_hero_image_url);
+    END IF;
+
+    UPDATE public.user_roles SET display_role = v_display_role WHERE user_id = new_user_id;
+    IF NOT FOUND THEN
+      INSERT INTO public.user_roles (user_id, display_role) VALUES (new_user_id, v_display_role);
+    END IF;
+
+    RAISE NOTICE 'User upserted successfully: id=%, email=%, role=%', new_user_id, shop.email, v_display_role;
+  END LOOP;
+END $$;

--- a/supabase/migrations/20260606120100_seed_central_south_america_surfboards_gear.sql
+++ b/supabase/migrations/20260606120100_seed_central_south_america_surfboards_gear.sql
@@ -1,0 +1,567 @@
+-- Seed migration: Central and South America surfboard gear
+-- Batch: central_south_america_gear
+-- Created: 2026-06-06
+-- Depends on: 20260606120000_seed_central_south_america_gear_shops.sql
+-- Remote status: local only; apply to linked Supabase only after explicit human approval.
+-- Image URLs (surfboards): https://images.pexels.com/photos/2370006/pexels-photo-2370006.jpeg and https://images.pexels.com/photos/8907535/pexels-photo-8907535.jpeg
+
+DO $seed_migration$
+DECLARE
+  missing_email text;
+  v_equipment_inserted int := 0;
+  v_primary_images_added int := 0;
+  v_secondary_images_added int := 0;
+BEGIN
+  SELECT seed_email INTO missing_email
+  FROM (
+    VALUES
+      (E'michaelzick+lineuptrade@gmail.com'),
+      (E'michaelzick+santacatalinasurfshop@gmail.com'),
+      (E'michaelzick+sunzalsurfcompany@gmail.com')
+  ) AS planned(seed_email)
+  WHERE NOT EXISTS (SELECT 1 FROM auth.users au WHERE au.email = planned.seed_email)
+  LIMIT 1;
+
+  IF missing_email IS NOT NULL THEN
+    RAISE EXCEPTION 'User not found for email: %', missing_email;
+  END IF;
+
+  WITH shop_locations (seed_email, location_lat, location_lng, location_address) AS (
+    VALUES
+      (
+        E'michaelzick+lineuptrade@gmail.com',
+        8.5468434,
+        -79.9119799,
+        E'Plaza Las Lajas, first floor, local PA4, Coronado, Panama'
+      ),
+      (
+        E'michaelzick+santacatalinasurfshop@gmail.com',
+        7.6289928,
+        -81.2528320,
+        E'Estero Street, Hotel Santa Catalina, Santa Catalina, Panama'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        13.4933551,
+        -89.3849212,
+        E'Hotel Roca Sunzal, El Tunco, La Libertad, El Salvador'
+      )
+  ),
+  seed_equipment (seed_email, name, description, price_per_day, price_per_week, suitable_skill_level, subcategory) AS (
+    VALUES
+      (
+        E'michaelzick+lineuptrade@gmail.com',
+        E'Tahe Sports Paint Easy 8''6 Soft Top',
+        E'A stable Tahe Sports Paint Easy soft top from Line Up Surf Shop''s Coronado rental catalog. The shop publishes surfboard rentals at 22 USD per day and 110 USD per week.',
+        22.00::numeric, 110.00::numeric,
+        E'Beginner, Intermediate',
+        E'soft top'
+      ),
+      (
+        E'michaelzick+lineuptrade@gmail.com',
+        E'Tahe Sports Paint Easy 7''6 Soft Top',
+        E'A Tahe Sports Paint Easy soft top for beginner and progressing surfers at Coronado. Line Up Surf Shop lists this board in its 22 USD daily and 110 USD weekly surfboard rental catalog.',
+        22.00::numeric, 110.00::numeric,
+        E'Beginner, Intermediate',
+        E'soft top'
+      ),
+      (
+        E'michaelzick+lineuptrade@gmail.com',
+        E'Tahe Sports Paint Soft Top 8''0',
+        E'An 8-foot Tahe Sports Paint soft top for small-wave lessons and easy paddling. The official Line Up Surf Shop rental page lists surfboards at 22 USD daily and 110 USD weekly.',
+        22.00::numeric, 110.00::numeric,
+        E'Beginner, Intermediate',
+        E'soft top'
+      ),
+      (
+        E'michaelzick+lineuptrade@gmail.com',
+        E'Tahe Sports Paint Soft Top 7''0',
+        E'A 7-foot Tahe Sports Paint soft top for approachable beach-break sessions. Line Up Surf Shop publishes this model in its 22 USD daily and 110 USD weekly board rental list.',
+        22.00::numeric, 110.00::numeric,
+        E'Beginner, Intermediate',
+        E'soft top'
+      ),
+      (
+        E'michaelzick+lineuptrade@gmail.com',
+        E'Tahe Sports Paint Soft Top 6''0',
+        E'A shorter Tahe Sports Paint soft top for smaller surfers and controlled progression. The Coronado rental catalog lists this board under the 22 USD daily surfboard rate.',
+        22.00::numeric, 110.00::numeric,
+        E'Beginner, Intermediate',
+        E'soft top'
+      ),
+      (
+        E'michaelzick+lineuptrade@gmail.com',
+        E'Tahe Sports Meteor 7''10 Soft Top',
+        E'A Tahe Sports Meteor soft top with enough float for easy wave catching. Line Up Surf Shop lists this model in its public surfboard rental inventory.',
+        22.00::numeric, 110.00::numeric,
+        E'Beginner, Intermediate',
+        E'soft top'
+      ),
+      (
+        E'michaelzick+lineuptrade@gmail.com',
+        E'SIC Darkhorse Vortex Foam 8''4',
+        E'An SIC Darkhorse Vortex Foam board for stable, forgiving Panama sessions. The Line Up Surf Shop catalog lists this surfboard at the shared 22 USD daily rental rate.',
+        22.00::numeric, 110.00::numeric,
+        E'Beginner, Intermediate',
+        E'foam surfboard'
+      ),
+      (
+        E'michaelzick+lineuptrade@gmail.com',
+        E'SIC Darkhorse Vortex Foam 7''4',
+        E'A mid-length SIC Darkhorse Vortex Foam board for progressing riders. Line Up Surf Shop lists the model in its Coronado surfboard rental catalog.',
+        22.00::numeric, 110.00::numeric,
+        E'Beginner, Intermediate',
+        E'foam surfboard'
+      ),
+      (
+        E'michaelzick+lineuptrade@gmail.com',
+        E'SIC Darkhorse Vortex Foam 5''8',
+        E'A compact SIC Darkhorse Vortex Foam board for smaller riders or controlled surf-school use. The shop publishes this model as part of its priced surfboard rental fleet.',
+        22.00::numeric, 110.00::numeric,
+        E'Beginner, Intermediate',
+        E'foam surfboard'
+      ),
+      (
+        E'michaelzick+lineuptrade@gmail.com',
+        E'Tahe Sports Magnum Duratec 8''4',
+        E'A durable Tahe Sports Magnum Duratec board for high-float cruising and first green waves. Line Up Surf Shop lists this model in its priced board rental catalog.',
+        22.00::numeric, 110.00::numeric,
+        E'Beginner, Intermediate',
+        E'malibu'
+      ),
+      (
+        E'michaelzick+lineuptrade@gmail.com',
+        E'BIC Sports Malibu Duratec 7''9',
+        E'A BIC Sports Malibu Duratec rental board for forgiving turns and easy paddling. The Coronado shop lists surfboards at 22 USD daily and 110 USD weekly.',
+        22.00::numeric, 110.00::numeric,
+        E'Beginner, Intermediate',
+        E'malibu'
+      ),
+      (
+        E'michaelzick+lineuptrade@gmail.com',
+        E'Tahe Sports Mini Longboard Duratec 7''6',
+        E'A Tahe Sports Mini Longboard Duratec for cruisy turns with manageable length. Line Up Surf Shop includes the model in its official surfboard rental list.',
+        22.00::numeric, 110.00::numeric,
+        E'Beginner, Intermediate',
+        E'mini longboard'
+      ),
+      (
+        E'michaelzick+lineuptrade@gmail.com',
+        E'Tahe Sports Egg Duratec 7''0',
+        E'A durable Tahe Sports Egg Duratec for mellow beach-break surf and improving turns. The shop publishes the model under its shared surfboard rental rate.',
+        22.00::numeric, 110.00::numeric,
+        E'Beginner, Intermediate',
+        E'egg'
+      ),
+      (
+        E'michaelzick+lineuptrade@gmail.com',
+        E'Tahe Sports Shortboard Duratec 6''7',
+        E'A Tahe Sports Shortboard Duratec for intermediate surfers who want a durable shorter board. Line Up Surf Shop lists this board in its priced rental catalog.',
+        22.00::numeric, 110.00::numeric,
+        E'Beginner, Intermediate, Advanced',
+        E'shortboard'
+      ),
+      (
+        E'michaelzick+lineuptrade@gmail.com',
+        E'BIC Gerard Dabadie Fish 5''10',
+        E'A BIC Gerard Dabadie Fish for smaller waves and fast trimming. The Line Up Surf Shop board-rental page lists this model at 22 USD per day and 110 USD per week.',
+        22.00::numeric, 110.00::numeric,
+        E'Beginner, Intermediate, Advanced',
+        E'fish'
+      ),
+      (
+        E'michaelzick+lineuptrade@gmail.com',
+        E'Tahe Sports Comet 7''8',
+        E'A Tahe Sports Comet mid-length for easy wave entry and smooth turns. Line Up Surf Shop lists this model in its surfboard rental catalog.',
+        22.00::numeric, 110.00::numeric,
+        E'Beginner, Intermediate',
+        E'mid-length'
+      ),
+      (
+        E'michaelzick+lineuptrade@gmail.com',
+        E'Tahe Sports Comet 6''6',
+        E'A shorter Tahe Sports Comet rental board for intermediate beach-break sessions. The Coronado shop lists this board under its 22 USD daily surfboard rental rate.',
+        22.00::numeric, 110.00::numeric,
+        E'Beginner, Intermediate, Advanced',
+        E'mid-length'
+      ),
+      (
+        E'michaelzick+lineuptrade@gmail.com',
+        E'Torq Surfboards Funboard 8''2',
+        E'An 8-foot 2-inch Torq Surfboards Funboard for stable, forgiving waves around Coronado. Line Up Surf Shop lists this model in its public rental inventory.',
+        22.00::numeric, 110.00::numeric,
+        E'Beginner, Intermediate',
+        E'funboard'
+      ),
+      (
+        E'michaelzick+lineuptrade@gmail.com',
+        E'Torq Surfboards Funboard 6''8',
+        E'A compact Torq Surfboards Funboard for progressing surfers who want a shorter outline. The shop publishes this board in its priced surfboard rental list.',
+        22.00::numeric, 110.00::numeric,
+        E'Beginner, Intermediate, Advanced',
+        E'funboard'
+      ),
+      (
+        E'michaelzick+lineuptrade@gmail.com',
+        E'Torq Surfboards Fish 6''3',
+        E'A Torq Surfboards Fish for punchy Panama beach-break conditions and quick down-the-line speed. Line Up Surf Shop lists this model in the board rental catalog.',
+        22.00::numeric, 110.00::numeric,
+        E'Beginner, Intermediate, Advanced',
+        E'fish'
+      ),
+      (
+        E'michaelzick+lineuptrade@gmail.com',
+        E'Safari Surfboards Logger 9''4',
+        E'A Safari Surfboards Logger for classic trim, nose-riding, and easy paddling. Line Up Surf Shop includes this longboard in its rental board inventory.',
+        22.00::numeric, 110.00::numeric,
+        E'Beginner, Intermediate',
+        E'longboard'
+      ),
+      (
+        E'michaelzick+lineuptrade@gmail.com',
+        E'Safari Surfboards Goose 9''2',
+        E'A Safari Surfboards Goose longboard for relaxed glide and beginner-friendly wave count. The Coronado shop lists this model at its shared surfboard rental rate.',
+        22.00::numeric, 110.00::numeric,
+        E'Beginner, Intermediate',
+        E'longboard'
+      ),
+      (
+        E'michaelzick+santacatalinasurfshop@gmail.com',
+        E'Lost/Mayhem Scorcher Model',
+        E'A Lost/Mayhem Scorcher shortboard available for rent from Santa Catalina Surf Shop. The official listing marks it rentable at 35 USD per day.',
+        35.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced, Expert',
+        E'shortboard'
+      ),
+      (
+        E'michaelzick+santacatalinasurfshop@gmail.com',
+        E'Xanadu X21',
+        E'A Xanadu X21 performance shortboard available for rent from Santa Catalina Surf Shop. The shop lists this board as rentable at 25 USD per day.',
+        25.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced, Expert',
+        E'shortboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Tomo Boss Up',
+        E'A Tomo Boss Up surfboard from Sunzal Surf Company''s official El Tunco rental gallery. The page lists all rates in USD and prices this board at 35 USD.',
+        35.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced',
+        E'shortboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Takayama In The Pink',
+        E'A Takayama In The Pink longboard for smooth trim and classic point-break surfing at El Sunzal. Sunzal Surf Company lists this board at 40 USD.',
+        40.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced',
+        E'longboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Gerry Lopez Something Fishy',
+        E'A Gerry Lopez Something Fishy board for fast small-wave lines. Sunzal Surf Company lists this model in its USD-priced surfboard rental options at 35 USD.',
+        35.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced',
+        E'fish'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Lost Party Crasher',
+        E'A Lost Party Crasher rental board for playful El Salvador surf. Sunzal Surf Company lists the model at 35 USD in its official rental gallery.',
+        35.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced',
+        E'shortboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Lost Quiver Killer',
+        E'A Lost Quiver Killer shortboard for versatile point-break and beach-break conditions. Sunzal Surf Company lists this model at 35 USD.',
+        35.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced, Expert',
+        E'shortboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'DANC Funboard',
+        E'A DANC Funboard for approachable wave catching and smooth turns at El Tunco. Sunzal Surf Company lists this board at 35 USD.',
+        35.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate',
+        E'funboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Terry 9/3 Noserider Longboard',
+        E'A Terry Noserider longboard for classic trim and point-break glide. Sunzal Surf Company lists the board at 35 USD in its rental options.',
+        35.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced',
+        E'longboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Torq 8''6 Longboard',
+        E'An 8-foot 6-inch Torq longboard for easy paddling and forgiving wave entry. Sunzal Surf Company publishes this rental at 35 USD.',
+        35.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate',
+        E'longboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Album Dark Arts',
+        E'An Album Dark Arts performance board for experienced surfers in quality El Salvador waves. Sunzal Surf Company lists this model at 35 USD.',
+        35.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced, Expert',
+        E'shortboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Paragon Retro Noserider',
+        E'A Paragon Retro Noserider for traditional longboard trim and cruisy point-break sessions. Sunzal Surf Company lists this board at 30 USD.',
+        30.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced',
+        E'longboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Free Movement Flying Pig',
+        E'A Free Movement Flying Pig board for playful down-the-line surfing. Sunzal Surf Company lists this model at 30 USD in its official rental gallery.',
+        30.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced',
+        E'fish'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Xanadu Wave Rocket',
+        E'A Xanadu Wave Rocket shortboard for speed and tighter turns. Sunzal Surf Company lists this rentable board at 30 USD.',
+        30.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced, Expert',
+        E'shortboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Robert August What I Ride Mini',
+        E'A Robert August What I Ride Mini for classic styling in a smaller longboard package. Sunzal Surf Company lists this board at 30 USD.',
+        30.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced',
+        E'mini longboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Lost Puddle Fish',
+        E'A Lost Puddle Fish for small-wave speed and extra planing surface. Sunzal Surf Company lists this model at 30 USD.',
+        30.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced',
+        E'fish'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Lost Short Round',
+        E'A Lost Short Round board for responsive performance in average surf. Sunzal Surf Company publishes this rental at 30 USD.',
+        30.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced, Expert',
+        E'shortboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Robert August What I Ride',
+        E'A Robert August What I Ride longboard for smooth point-break surfing and easy trim. Sunzal Surf Company lists this board at 30 USD.',
+        30.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced',
+        E'longboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Lost Sub Buggy',
+        E'A Lost Sub Buggy for performance surfing in smaller, punchier waves. Sunzal Surf Company lists this board at 25 USD.',
+        25.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced, Expert',
+        E'shortboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Lost V3 Rocket 5''8',
+        E'A Lost V3 Rocket 5-foot 8-inch shortboard for drive and speed in quality waves. Sunzal Surf Company lists this model at 25 USD.',
+        25.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced, Expert',
+        E'shortboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Byrne Custom 6''6',
+        E'A Byrne Custom 6-foot 6-inch surfboard for experienced surfers who want extra rail line. Sunzal Surf Company lists this board at 25 USD.',
+        25.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced, Expert',
+        E'shortboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Free Movement G-45',
+        E'A Free Movement G-45 shortboard for responsive turns and clean El Salvador walls. Sunzal Surf Company lists this rental at 25 USD.',
+        25.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced',
+        E'shortboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Doug Haut Funboard',
+        E'A Doug Haut Funboard for forgiving paddling and smooth turns. Sunzal Surf Company lists this model at 25 USD.',
+        25.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate',
+        E'funboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Azteca Blue Beach',
+        E'An Azteca Blue Beach board for easygoing rental sessions at El Tunco and nearby breaks. Sunzal Surf Company lists this board at 25 USD.',
+        25.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate',
+        E'funboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Sharpeyes Disco Inferno',
+        E'A Sharpeyes Disco Inferno shortboard for advanced surfers in punchier waves. Sunzal Surf Company publishes this rental at 25 USD.',
+        25.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced, Expert',
+        E'shortboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Mick Fanning Sugar Glider',
+        E'A Mick Fanning Sugar Glider softboard-style rental for forgiving, high-fun sessions. Sunzal Surf Company lists this model at 20 USD.',
+        20.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate',
+        E'funboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'JS Factory Hyfi',
+        E'A JS Factory Hyfi performance board for surfers who want a lively epoxy-feel shortboard. Sunzal Surf Company lists this rental at 20 USD.',
+        20.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced, Expert',
+        E'shortboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Byrne Panda',
+        E'A Byrne Panda surfboard for intermediate and advanced riders looking for a responsive rental. Sunzal Surf Company lists this board at 20 USD.',
+        20.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced',
+        E'shortboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Mick Fanning Even Flow',
+        E'A Mick Fanning Even Flow for user-friendly glide and stable turns. Sunzal Surf Company lists this model at 20 USD.',
+        20.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate',
+        E'funboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Sina Egg',
+        E'A Sina Egg board for glide, paddle ease, and flowing turns in mid-sized surf. Sunzal Surf Company lists this rental at 20 USD.',
+        20.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate',
+        E'egg'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Webber AfterBurner',
+        E'A Webber AfterBurner shortboard for fast, responsive turns. Sunzal Surf Company lists this model at 15 USD.',
+        15.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced, Expert',
+        E'shortboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Lost Weekend Warrior',
+        E'A Lost Weekend Warrior rental board for approachable performance and easy wave count. Sunzal Surf Company lists this model at 15 USD.',
+        15.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced',
+        E'shortboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Lost F1 5''10',
+        E'A Lost F1 5-foot 10-inch shortboard for experienced surfers and clean point-break conditions. Sunzal Surf Company lists this board at 15 USD.',
+        15.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced, Expert',
+        E'shortboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Lost V3 Rocket 6''0',
+        E'A Lost V3 Rocket 6-foot shortboard for fast rail-to-rail surfing. Sunzal Surf Company lists this rental at 15 USD.',
+        15.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced, Expert',
+        E'shortboard'
+      ),
+      (
+        E'michaelzick+sunzalsurfcompany@gmail.com',
+        E'Del Ray Fish',
+        E'A Del Ray Fish for small-wave speed and forgiving trim. Sunzal Surf Company lists this board at 10 USD.',
+        10.00::numeric, NULL::numeric,
+        E'Beginner, Intermediate, Advanced',
+        E'fish'
+      )
+  ),
+  inserted AS (
+    INSERT INTO public.equipment (
+      id, user_id, name, category, description,
+      price_per_day, price_per_hour, price_per_week, currency_code,
+      size, weight, material, suitable_skill_level, status,
+      location_lat, location_lng, location_address, subcategory,
+      damage_deposit, visible_on_map
+    )
+    SELECT
+      gen_random_uuid(),
+      au.id,
+      s.name,
+      'surfboards',
+      s.description,
+      s.price_per_day,
+      NULL::numeric,
+      s.price_per_week,
+      'USD',
+      NULL::text,
+      NULL::text,
+      NULL::text,
+      s.suitable_skill_level,
+      'available',
+      sl.location_lat,
+      sl.location_lng,
+      sl.location_address,
+      s.subcategory,
+      NULL::numeric,
+      true
+    FROM seed_equipment s
+    JOIN shop_locations sl ON sl.seed_email = s.seed_email
+    JOIN auth.users au ON au.email = s.seed_email
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment e
+      WHERE e.user_id = au.id
+        AND e.category = 'surfboards'
+        AND lower(btrim(e.name)) = lower(btrim(s.name))
+    )
+    RETURNING id
+  ),
+  ins1 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT id, 'https://images.pexels.com/photos/2370006/pexels-photo-2370006.jpeg', 0, true
+    FROM inserted
+    RETURNING equipment_id
+  ),
+  ins2 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT id, 'https://images.pexels.com/photos/8907535/pexels-photo-8907535.jpeg', 1, false
+    FROM inserted
+    RETURNING equipment_id
+  )
+  SELECT (SELECT count(*) FROM inserted), (SELECT count(*) FROM ins1), (SELECT count(*) FROM ins2)
+  INTO v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+
+  RAISE NOTICE 'Central/South America surfboard gear inserted=%, primary_images_added=%, secondary_images_added=%',
+    v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+END $seed_migration$;

--- a/supabase/migrations/20260606120200_seed_central_south_america_mountain_bikes_gear.sql
+++ b/supabase/migrations/20260606120200_seed_central_south_america_mountain_bikes_gear.sql
@@ -1,0 +1,298 @@
+-- Seed migration: Central and South America mountain-bike gear
+-- Batch: central_south_america_gear
+-- Created: 2026-06-06
+-- Depends on: 20260606120000_seed_central_south_america_gear_shops.sql
+-- Remote status: local only; apply to linked Supabase only after explicit human approval.
+-- Image URLs (mountain-bikes): https://images.pexels.com/photos/30447388/pexels-photo-30447388.jpeg and https://images.pexels.com/photos/25753440/pexels-photo-25753440.jpeg
+
+DO $seed_migration$
+DECLARE
+  missing_email text;
+  v_equipment_inserted int := 0;
+  v_primary_images_added int := 0;
+  v_secondary_images_added int := 0;
+BEGIN
+  SELECT seed_email INTO missing_email
+  FROM (
+    VALUES
+      (E'michaelzick+mtbguatemala@gmail.com'),
+      (E'michaelzick+bikearenal@gmail.com'),
+      (E'michaelzick+nosaramtb@gmail.com'),
+      (E'michaelzick+buencamino@gmail.com')
+  ) AS planned(seed_email)
+  WHERE NOT EXISTS (SELECT 1 FROM auth.users au WHERE au.email = planned.seed_email)
+  LIMIT 1;
+
+  IF missing_email IS NOT NULL THEN
+    RAISE EXCEPTION 'User not found for email: %', missing_email;
+  END IF;
+
+  WITH seed_equipment (seed_email, name, category, description, price_per_day, price_per_hour, price_per_week, currency_code, size, weight, material, suitable_skill_level, status, location_lat, location_lng, location_address, subcategory, damage_deposit, visible_on_map) AS (
+    VALUES
+      (
+        E'michaelzick+mtbguatemala@gmail.com',
+        E'Commencal T.E.M.P.O',
+        E'mountain-bikes',
+        E'A short-travel Commencal trail bike for Tecpan singletrack and all-day mountain rides. The official MTB Guatemala catalog lists this current-model rental at 85 USD per day.',
+        85.00::numeric, NULL::numeric, NULL::numeric, 'USD',
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        14.7688752, -90.9893490,
+        E'MTB Guatemala Tecpan, km88 Carretera Panamericana, Tecpan, Chimaltenango, Guatemala',
+        E'trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+mtbguatemala@gmail.com',
+        E'Commencal META TR Premium',
+        E'mountain-bikes',
+        E'A premium Commencal META TR trail bike suited to rocky descents and technical Tecpan routes. MTB Guatemala publishes this model-level rental at 100 USD per day.',
+        100.00::numeric, NULL::numeric, NULL::numeric, 'USD',
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        14.7688752, -90.9893490,
+        E'MTB Guatemala Tecpan, km88 Carretera Panamericana, Tecpan, Chimaltenango, Guatemala',
+        E'full-suspension trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+mtbguatemala@gmail.com',
+        E'Commencal T.E.M.P.O Premium',
+        E'mountain-bikes',
+        E'A premium T.E.M.P.O build for riders who want a lighter, lively trail bike on mixed Guatemala terrain. The shop lists this rental at 100 USD per day.',
+        100.00::numeric, NULL::numeric, NULL::numeric, 'USD',
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        14.7688752, -90.9893490,
+        E'MTB Guatemala Tecpan, km88 Carretera Panamericana, Tecpan, Chimaltenango, Guatemala',
+        E'trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+mtbguatemala@gmail.com',
+        E'Commencal Meta TR 29',
+        E'mountain-bikes',
+        E'A 29-inch Commencal Meta TR for fast trail days and rough volcanic-slope riding. MTB Guatemala publishes this model as a 75 USD daily mountain-bike rental.',
+        75.00::numeric, NULL::numeric, NULL::numeric, 'USD',
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        14.7688752, -90.9893490,
+        E'MTB Guatemala Tecpan, km88 Carretera Panamericana, Tecpan, Chimaltenango, Guatemala',
+        E'full-suspension trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+mtbguatemala@gmail.com',
+        E'Commencal Meta AM 29',
+        E'mountain-bikes',
+        E'A long-travel Commencal all-mountain bike for steeper Tecpan lines and technical descending. The official rental catalog lists the Meta AM 29 at 75 USD per day.',
+        75.00::numeric, NULL::numeric, NULL::numeric, 'USD',
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        14.7688752, -90.9893490,
+        E'MTB Guatemala Tecpan, km88 Carretera Panamericana, Tecpan, Chimaltenango, Guatemala',
+        E'enduro', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+mtbguatemala@gmail.com',
+        E'Commencal Meta Power 29',
+        E'mountain-bikes',
+        E'A Commencal electric enduro bike for shuttle-style terrain and longer highland laps. MTB Guatemala lists the Meta Power 29 e-bike rental at 100 USD per day.',
+        100.00::numeric, NULL::numeric, NULL::numeric, 'USD',
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        14.7688752, -90.9893490,
+        E'MTB Guatemala Tecpan, km88 Carretera Panamericana, Tecpan, Chimaltenango, Guatemala',
+        E'e-mountain bike', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+mtbguatemala@gmail.com',
+        E'Giant Trance E+ 2 Pro',
+        E'mountain-bikes',
+        E'A Giant Trance E+ 2 Pro eMTB for assisted trail riding on sustained climbs and rough descents. MTB Guatemala lists this e-bike rental at 100 USD per day.',
+        100.00::numeric, NULL::numeric, NULL::numeric, 'USD',
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        14.7688752, -90.9893490,
+        E'MTB Guatemala Tecpan, km88 Carretera Panamericana, Tecpan, Chimaltenango, Guatemala',
+        E'e-mountain bike', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+mtbguatemala@gmail.com',
+        E'Giant Talon 29er',
+        E'mountain-bikes',
+        E'A Giant Talon 29er hardtail for efficient climbing, rolling singletrack, and less technical routes. MTB Guatemala publishes this model-level rental at 75 USD per day.',
+        75.00::numeric, NULL::numeric, NULL::numeric, 'USD',
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        14.7688752, -90.9893490,
+        E'MTB Guatemala Tecpan, km88 Carretera Panamericana, Tecpan, Chimaltenango, Guatemala',
+        E'hardtail trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+mtbguatemala@gmail.com',
+        E'Giant Trance 27.5',
+        E'mountain-bikes',
+        E'A Giant Trance 27.5 full-suspension trail bike for playful handling and mixed Guatemala mountain terrain. The shop lists this rental at 75 USD per day.',
+        75.00::numeric, NULL::numeric, NULL::numeric, 'USD',
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        14.7688752, -90.9893490,
+        E'MTB Guatemala Tecpan, km88 Carretera Panamericana, Tecpan, Chimaltenango, Guatemala',
+        E'full-suspension trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+bikearenal@gmail.com',
+        E'Cannondale Rush 27.5',
+        E'mountain-bikes',
+        E'A carbon full-suspension Cannondale Rush 27.5 for La Fortuna trail riding and volcano-area exploration. Bike Arenal publishes this model at 65 USD per day with helmet and lock included.',
+        65.00::numeric, NULL::numeric, NULL::numeric, 'USD',
+        E'Small, Medium, Large', NULL::text, E'Carbon fiber',
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        10.4669811, -84.6464356,
+        E'400 m south from downtown La Fortuna, on the way to La Fortuna Waterfall, La Fortuna, Alajuela, Costa Rica',
+        E'full-suspension trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+bikearenal@gmail.com',
+        E'Depro M2 Carbon Fiber 29',
+        E'mountain-bikes',
+        E'A carbon 29-inch Depro hardtail for efficient rides around Arenal and La Fortuna. Bike Arenal lists Small, Medium, and Large sizes at 65 USD per day.',
+        65.00::numeric, NULL::numeric, NULL::numeric, 'USD',
+        E'Small, Medium, Large', NULL::text, E'Carbon fiber',
+        E'Beginner, Intermediate',
+        'available',
+        10.4669811, -84.6464356,
+        E'400 m south from downtown La Fortuna, on the way to La Fortuna Waterfall, La Fortuna, Alajuela, Costa Rica',
+        E'hardtail trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+bikearenal@gmail.com',
+        E'Scott Scale 980',
+        E'mountain-bikes',
+        E'A Scott Scale 980 hardtail for cross-country riding, gravel connectors, and smoother mountain-bike routes near La Fortuna. Bike Arenal lists the Large size at 65 USD per day.',
+        65.00::numeric, NULL::numeric, NULL::numeric, 'USD',
+        E'Large', NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        10.4669811, -84.6464356,
+        E'400 m south from downtown La Fortuna, on the way to La Fortuna Waterfall, La Fortuna, Alajuela, Costa Rica',
+        E'cross-country hardtail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+nosaramtb@gmail.com',
+        E'Specialized Turbo Levo SL',
+        E'mountain-bikes',
+        E'A lightweight Specialized electric trail bike for Nosara singletrack and longer coastal jungle routes. Nosara MTB lists the Turbo Levo SL at 100 USD per day and 500 USD per week.',
+        100.00::numeric, NULL::numeric, 500.00::numeric, 'USD',
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        9.9470000, -85.6650000,
+        E'Gilded Iguana Athletic Center, Playa Guiones north, Nosara, Guanacaste 50206, Costa Rica',
+        E'e-mountain bike', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+nosaramtb@gmail.com',
+        E'Rocky Mountain Growler Powerplay',
+        E'mountain-bikes',
+        E'A Rocky Mountain electric hardtail for riders who want pedal assist with stable trail handling. Nosara MTB lists this Growler Powerplay rental at 100 USD per day and 500 USD per week.',
+        100.00::numeric, NULL::numeric, 500.00::numeric, 'USD',
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        9.9470000, -85.6650000,
+        E'Gilded Iguana Athletic Center, Playa Guiones north, Nosara, Guanacaste 50206, Costa Rica',
+        E'e-mountain bike hardtail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+nosaramtb@gmail.com',
+        E'Rocky Mountain Instinct A50',
+        E'mountain-bikes',
+        E'A Rocky Mountain Instinct A50 trail bike for technical jungle singletrack and all-day Nosara loops. Nosara MTB lists this model at 100 USD per day and 350 USD per week.',
+        100.00::numeric, NULL::numeric, 350.00::numeric, 'USD',
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        9.9470000, -85.6650000,
+        E'Gilded Iguana Athletic Center, Playa Guiones north, Nosara, Guanacaste 50206, Costa Rica',
+        E'full-suspension trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+nosaramtb@gmail.com',
+        E'Rocky Mountain Fusion 10',
+        E'mountain-bikes',
+        E'A Rocky Mountain Fusion 10 hardtail for approachable Nosara trail rides and town-to-trail cruising. Nosara MTB lists this sport mountain bike at 30 USD per day and 150 USD per week.',
+        30.00::numeric, NULL::numeric, 150.00::numeric, 'USD',
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate',
+        'available',
+        9.9470000, -85.6650000,
+        E'Gilded Iguana Athletic Center, Playa Guiones north, Nosara, Guanacaste 50206, Costa Rica',
+        E'hardtail trail', NULL::numeric, true
+      ),
+      (
+        E'michaelzick+buencamino@gmail.com',
+        E'Specialized Turbo Levo',
+        E'mountain-bikes',
+        E'A Specialized Turbo Levo eMTB for Buen Camino Bike Park trails and assisted laps in San Mateo. Buen Camino publishes the rental at 130 USD with availability handled by WhatsApp.',
+        130.00::numeric, NULL::numeric, NULL::numeric, 'USD',
+        NULL::text, NULL::text, NULL::text,
+        E'Beginner, Intermediate, Advanced',
+        'available',
+        9.9467012, -84.5328223,
+        E'Finca Ecologica El Bosque, San Mateo, Alajuela, Costa Rica',
+        E'e-mountain bike', NULL::numeric, true
+      )
+  ),
+  inserted AS (
+    INSERT INTO public.equipment (
+      id, user_id, name, category, description,
+      price_per_day, price_per_hour, price_per_week, currency_code,
+      size, weight, material, suitable_skill_level, status,
+      location_lat, location_lng, location_address, subcategory,
+      damage_deposit, visible_on_map
+    )
+    SELECT
+      gen_random_uuid(),
+      au.id,
+      s.name, s.category, s.description,
+      s.price_per_day, s.price_per_hour, s.price_per_week, s.currency_code,
+      s.size, s.weight, s.material, s.suitable_skill_level, s.status,
+      s.location_lat, s.location_lng, s.location_address, s.subcategory,
+      s.damage_deposit, s.visible_on_map
+    FROM seed_equipment s
+    JOIN auth.users au ON au.email = s.seed_email
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment e
+      WHERE e.user_id = au.id
+        AND e.category = s.category
+        AND lower(btrim(e.name)) = lower(btrim(s.name))
+    )
+    RETURNING id
+  ),
+  ins1 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT id, 'https://images.pexels.com/photos/30447388/pexels-photo-30447388.jpeg', 0, true
+    FROM inserted
+    RETURNING equipment_id
+  ),
+  ins2 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT id, 'https://images.pexels.com/photos/25753440/pexels-photo-25753440.jpeg', 1, false
+    FROM inserted
+    RETURNING equipment_id
+  )
+  SELECT (SELECT count(*) FROM inserted), (SELECT count(*) FROM ins1), (SELECT count(*) FROM ins2)
+  INTO v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+
+  RAISE NOTICE 'Central/South America mountain-bike gear inserted=%, primary_images_added=%, secondary_images_added=%',
+    v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+END $seed_migration$;

--- a/supabase/migrations/20260607120000_seed_central_south_america_surfboards_followup.sql
+++ b/supabase/migrations/20260607120000_seed_central_south_america_surfboards_followup.sql
@@ -1,0 +1,328 @@
+-- Seed migration: Central and South America surfboard follow-up
+-- Batch: central_south_america_surfboards_followup
+-- Created: 2026-06-07
+-- Remote status: local only; apply to linked Supabase only after rollback dry run succeeds.
+-- Do NOT use supabase db push or supabase migration up for this data-only batch.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- =============================================
+-- FOLLOW-UP SURF SHOP PROFILE
+-- Adds Nosara Surfboards after discovering its product-level rental catalog.
+-- Existing Sunzal Surf Company profile is reused for the Sunzal additions.
+-- =============================================
+
+DO $$
+DECLARE
+  v_nosara_user_id uuid;
+  v_display_role text := 'retail-store';
+BEGIN
+  SELECT id INTO v_nosara_user_id
+  FROM auth.users
+  WHERE email = 'michaelzick+nosarasurfboards@gmail.com'
+  LIMIT 1;
+
+  IF v_nosara_user_id IS NULL THEN
+    v_nosara_user_id := gen_random_uuid();
+
+    INSERT INTO auth.users (
+      id, instance_id, aud, role, email, encrypted_password, email_confirmed_at,
+      raw_user_meta_data, raw_app_meta_data, created_at, updated_at,
+      confirmation_token, recovery_token, email_change, email_change_token_current,
+      email_change_token_new, email_change_confirm_status, phone_change,
+      phone_change_token, reauthentication_token
+    )
+    VALUES (
+      v_nosara_user_id,
+      '00000000-0000-0000-0000-000000000000',
+      'authenticated',
+      'authenticated',
+      'michaelzick+nosarasurfboards@gmail.com',
+      extensions.crypt(gen_random_uuid()::text, extensions.gen_salt('bf')),
+      now(),
+      jsonb_build_object('name', 'Nosara Surfboards'),
+      jsonb_build_object('provider', 'email', 'providers', ARRAY['email']),
+      now(),
+      now(),
+      '',
+      '',
+      '',
+      '',
+      '',
+      0,
+      '',
+      '',
+      ''
+    );
+
+    INSERT INTO auth.identities (
+      id, user_id, identity_data, provider, provider_id,
+      last_sign_in_at, created_at, updated_at
+    )
+    VALUES (
+      gen_random_uuid(),
+      v_nosara_user_id,
+      jsonb_build_object('sub', v_nosara_user_id::text, 'email', 'michaelzick+nosarasurfboards@gmail.com'),
+      'email',
+      v_nosara_user_id::text,
+      now(),
+      now(),
+      now()
+    );
+  END IF;
+
+  UPDATE public.profiles
+  SET name = 'Nosara Surfboards',
+      website = 'https://nosarasurfboards.com/',
+      phone = '+506 8329 1771',
+      address = 'Become Nosara, B34, 50206 Nosara, Guanacaste, Costa Rica',
+      about = 'Nosara premium surfboard rental shop with public product-level surfboard listings, USD prices, board details, and pickup at Become Nosara near Guiones Beach.',
+      location_lat = 9.9455000,
+      location_lng = -85.6655000,
+      avatar_url = COALESCE(
+        avatar_url,
+        'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/73de4049-7ffd-45cd-868b-c2d0076107b3/profile-1752863282257.png'
+      ),
+      hero_image_url = COALESCE(
+        hero_image_url,
+        'https://images.unsplash.com/photo-1502680390469-be75c86b636f?q=80&w=3540&auto=format&fit=crop&ixlib=rb-4.0.3'
+      )
+  WHERE id = v_nosara_user_id;
+
+  IF NOT FOUND THEN
+    INSERT INTO public.profiles (
+      id, name, website, phone, address, about,
+      location_lat, location_lng, avatar_url, hero_image_url
+    )
+    VALUES (
+      v_nosara_user_id,
+      'Nosara Surfboards',
+      'https://nosarasurfboards.com/',
+      '+506 8329 1771',
+      'Become Nosara, B34, 50206 Nosara, Guanacaste, Costa Rica',
+      'Nosara premium surfboard rental shop with public product-level surfboard listings, USD prices, board details, and pickup at Become Nosara near Guiones Beach.',
+      9.9455000,
+      -85.6655000,
+      'https://qtlhqsqanbxgfbcjigrl.supabase.co/storage/v1/object/public/profile-images/73de4049-7ffd-45cd-868b-c2d0076107b3/profile-1752863282257.png',
+      'https://images.unsplash.com/photo-1502680390469-be75c86b636f?q=80&w=3540&auto=format&fit=crop&ixlib=rb-4.0.3'
+    );
+  END IF;
+
+  UPDATE public.user_roles
+  SET display_role = v_display_role
+  WHERE user_id = v_nosara_user_id;
+
+  IF NOT FOUND THEN
+    INSERT INTO public.user_roles (user_id, display_role)
+    VALUES (v_nosara_user_id, v_display_role);
+  END IF;
+
+  RAISE NOTICE 'Follow-up surf shop upserted successfully: id=%, email=%, role=%',
+    v_nosara_user_id, 'michaelzick+nosarasurfboards@gmail.com', v_display_role;
+END $$;
+
+-- =============================================
+-- FOLLOW-UP SURFBOARD GEAR
+-- Uses canonical surfboard placeholder images from AGENTS.md.
+-- =============================================
+
+DO $seed_migration$
+DECLARE
+  v_equipment_inserted int;
+  v_primary_images_added int;
+  v_secondary_images_added int;
+BEGIN
+  WITH required_users (email) AS (
+    VALUES
+      ('michaelzick+sunzalsurfcompany@gmail.com'),
+      ('michaelzick+nosarasurfboards@gmail.com')
+  )
+  SELECT COUNT(*) INTO v_equipment_inserted
+  FROM required_users ru
+  LEFT JOIN auth.users au ON au.email = ru.email
+  WHERE au.id IS NULL;
+
+  IF v_equipment_inserted > 0 THEN
+    RAISE EXCEPTION 'Required shop user missing for Central/South America surfboard follow-up batch';
+  END IF;
+
+  WITH shop_locations (seed_email, location_lat, location_lng, location_address) AS (
+    VALUES
+      (
+        'michaelzick+sunzalsurfcompany@gmail.com',
+        13.4933551,
+        -89.3849212,
+        'Hotel Roca Sunzal, El Tunco, La Libertad, El Salvador'
+      ),
+      (
+        'michaelzick+nosarasurfboards@gmail.com',
+        9.9455000,
+        -85.6655000,
+        'Become Nosara, B34, 50206 Nosara, Guanacaste, Costa Rica'
+      )
+  ),
+  seed_equipment (
+    seed_email,
+    name,
+    description,
+    price_per_day,
+    suitable_skill_level,
+    subcategory
+  ) AS (
+    VALUES
+      (
+        'michaelzick+sunzalsurfcompany@gmail.com',
+        'Hypto Krypto',
+        'A Hypto Krypto surfboard from Sunzal Surf Company''s official El Tunco rental gallery. The page lists it as a distinct priced board rental at 35 USD and includes separate dimensions and fins images for this item.',
+        35.00::numeric,
+        'Beginner, Intermediate, Advanced',
+        'hybrid shortboard'
+      ),
+      (
+        'michaelzick+sunzalsurfcompany@gmail.com',
+        'Barahona 9''0',
+        'A 9-foot Barahona surfboard from Sunzal Surf Company''s official rental gallery. The page lists the board with its own dimensions and fins images and prices it at 30 USD.',
+        30.00::numeric,
+        'Beginner, Intermediate, Advanced',
+        'longboard'
+      ),
+      (
+        'michaelzick+sunzalsurfcompany@gmail.com',
+        'Sci-Fi Volume LFT',
+        'A Sci-Fi Volume LFT performance surfboard from Sunzal Surf Company''s official rental gallery. The page exposes it as a distinct itemized rental and prices it at 20 USD.',
+        20.00::numeric,
+        'Intermediate, Advanced, Expert',
+        'shortboard'
+      ),
+      (
+        'michaelzick+nosarasurfboards@gmail.com',
+        'Sharpeye FT Inferno Carbon 5''10',
+        'A 5-foot 10-inch Sharpeye FT Inferno Carbon surfboard from Nosara Surfboards. The public Shopify rental product lists USD pricing, carbon/epoxy C1 Lite construction, FCS II quad-fin setup, and a 100 USD rental price.',
+        100.00::numeric,
+        'Intermediate, Advanced, Expert',
+        'shortboard'
+      ),
+      (
+        'michaelzick+nosarasurfboards@gmail.com',
+        'Sharpeye Inferno 72 Carbon 5''10',
+        'A 5-foot 10-inch Sharpeye Inferno 72 Carbon board from Nosara Surfboards. The public product page lists dimensions of 5''10 x 19 x 2.5, 28 liters, Carbon C-1 construction, and a 95 USD rental price.',
+        95.00::numeric,
+        'Intermediate, Advanced, Expert',
+        'shortboard'
+      ),
+      (
+        'michaelzick+nosarasurfboards@gmail.com',
+        'Firewire Slater Designs S Boss Volcano I-Bolic 6''0',
+        'A 6-foot Firewire Slater Designs S Boss Volcano I-Bolic surfboard from Nosara Surfboards. The public product page lists dimensions, Future fin setup, and a 50 USD rental price.',
+        50.00::numeric,
+        'Intermediate, Advanced, Expert',
+        'shortboard'
+      ),
+      (
+        'michaelzick+nosarasurfboards@gmail.com',
+        'Pyzel Ghost XL 6''2',
+        'A 6-foot 2-inch Pyzel Ghost XL surfboard from Nosara Surfboards. The public product page lists dimensions of 6''2 x 19.75 x 3, 36.7 liters, Electralite epoxy construction, and a 50 USD rental price.',
+        50.00::numeric,
+        'Intermediate, Advanced, Expert',
+        'shortboard'
+      ),
+      (
+        'michaelzick+nosarasurfboards@gmail.com',
+        'Firewire Slater Designs S Boss Turquoise I-Bolic 6''2',
+        'A 6-foot 2-inch Firewire Slater Designs S Boss Turquoise I-Bolic surfboard from Nosara Surfboards. The public product page lists dimensions, Future fin setup, and a 50 USD rental price.',
+        50.00::numeric,
+        'Intermediate, Advanced, Expert',
+        'shortboard'
+      ),
+      (
+        'michaelzick+nosarasurfboards@gmail.com',
+        'Sharpeye Mid Length 6''6',
+        'A 6-foot 6-inch Sharpeye mid-length from Nosara Surfboards. The public product page lists dimensions, 40.13 liters, five-fin Futures setup, and a 50 USD rental price.',
+        50.00::numeric,
+        'Beginner, Intermediate, Advanced',
+        'mid-length'
+      ),
+      (
+        'michaelzick+nosarasurfboards@gmail.com',
+        'Chilli Mid Strength 7''0',
+        'A 7-foot Chilli Mid Strength surfboard from Nosara Surfboards. The public product page lists dimensions of 7''0 x 21 3/4 x 2 3/4, 45.5 liters, five-fin Futures setup, and a 50 USD rental price.',
+        50.00::numeric,
+        'Beginner, Intermediate, Advanced',
+        'mid-length'
+      ),
+      (
+        'michaelzick+nosarasurfboards@gmail.com',
+        'Lost Glydra 7''0',
+        'A 7-foot Lost Glydra surfboard from Nosara Surfboards. The public product page lists dimensions of 7''0 x 22 x 2.88, 48 liters, Lib Tech construction, five-fin FCS II setup, and a 50 USD rental price.',
+        50.00::numeric,
+        'Beginner, Intermediate, Advanced',
+        'mid-length'
+      ),
+      (
+        'michaelzick+nosarasurfboards@gmail.com',
+        'Channel Islands CI 2 Pro 5''10',
+        'A 5-foot 10-inch Channel Islands CI 2 Pro surfboard from Nosara Surfboards. The public product page lists dimensions, CI 2.Pro round-tail details, a flat Channel Islands traction pad, and a 40 USD rental price.',
+        40.00::numeric,
+        'Intermediate, Advanced, Expert',
+        'shortboard'
+      )
+  ),
+  inserted AS (
+    INSERT INTO public.equipment (
+      id, user_id, name, category, description,
+      price_per_day, price_per_hour, price_per_week, currency_code,
+      size, weight, material, suitable_skill_level, status,
+      location_lat, location_lng, location_address, subcategory,
+      damage_deposit, visible_on_map
+    )
+    SELECT
+      gen_random_uuid(),
+      au.id,
+      s.name,
+      'surfboards',
+      s.description,
+      s.price_per_day,
+      NULL::numeric,
+      NULL::numeric,
+      'USD',
+      NULL::text,
+      NULL::text,
+      NULL::text,
+      s.suitable_skill_level,
+      'available',
+      sl.location_lat,
+      sl.location_lng,
+      sl.location_address,
+      s.subcategory,
+      NULL::numeric,
+      true
+    FROM seed_equipment s
+    JOIN shop_locations sl ON sl.seed_email = s.seed_email
+    JOIN auth.users au ON au.email = s.seed_email
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.equipment e
+      WHERE e.user_id = au.id
+        AND e.category = 'surfboards'
+        AND lower(btrim(e.name)) = lower(btrim(s.name))
+    )
+    RETURNING id
+  ),
+  ins1 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT id, 'https://images.pexels.com/photos/2370006/pexels-photo-2370006.jpeg', 0, true
+    FROM inserted
+    RETURNING equipment_id
+  ),
+  ins2 AS (
+    INSERT INTO public.equipment_images (equipment_id, image_url, display_order, is_primary)
+    SELECT id, 'https://images.pexels.com/photos/8907535/pexels-photo-8907535.jpeg', 1, false
+    FROM inserted
+    RETURNING equipment_id
+  )
+  SELECT (SELECT count(*) FROM inserted), (SELECT count(*) FROM ins1), (SELECT count(*) FROM ins2)
+  INTO v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+
+  RAISE NOTICE 'Central/South America surfboard follow-up gear inserted=%, primary_images_added=%, secondary_images_added=%',
+    v_equipment_inserted, v_primary_images_added, v_secondary_images_added;
+END $seed_migration$;


### PR DESCRIPTION
## Summary

Seeds qualifying Central and South America mountain-bike and surfboard shops, applies the linked DemoStoke DB migrations, and adds the Sunzal/Nosara surfboard follow-up after the Sunzal itemized rental page review.

This branch adds 8 qualifying shops with 86 total gear rows and 172 `equipment_images` rows in the linked DB:

- MTB Guatemala — 9 mountain bikes
- Bike Arenal — 3 mountain bikes
- Nosara MTB — 4 mountain bikes
- Buen Camino — 1 mountain bike
- Line Up Surf Shop — 22 surfboards
- Santa Catalina — 2 surfboards
- Sunzal Surf Company — 36 surfboards
- Nosara Surfboards — 9 surfboards

## Changes

- Added Central/South America shop and gear seed migrations:
  - `supabase/migrations/20260606120000_seed_central_south_america_gear_shops.sql`
  - `supabase/migrations/20260606120100_seed_central_south_america_surfboards_gear.sql`
  - `supabase/migrations/20260606120200_seed_central_south_america_mountain_bikes_gear.sql`
  - `supabase/migrations/20260607120000_seed_central_south_america_surfboards_followup.sql`
- Added audit documentation, source evidence, rejected-candidate notes, validation SQL, remote runbooks, and remote validation reports under `demostoke_seed_batches/central_south_america_gear/` and `demostoke_seed_batches/central_south_america_surfboards_followup/`.
- Updated `AGENTS.md` with the newly applied shops, revised Sunzal count, Nosara Surfboards entry, and the seeded-shop total.
- Updated the original Central/South America validation expectations so Sunzal now reflects the follow-up gear count.

## Test plan

- [x] `git diff --check origin/main...HEAD`
- [x] Exact-file rollback dry run for `20260606120000`, `20260606120100`, and `20260606120200`, then linked commit, validation, idempotency rollback, and migration repair
- [x] Exact-file rollback dry run for `20260607120000`, then linked commit, validation, idempotency rollback, and migration repair
- [x] `supabase migration list --linked` verified local/remote aligned through `20260607120000`
- [x] Read-only linked validation confirmed Sunzal Surf Company has 36 surfboards and 72 images
- [x] Read-only linked validation confirmed Nosara Surfboards has 9 surfboards and 18 images
- [x] DemoStoke and Hermes audit folders verified with `diff -qr`

Created by Codex
