### PR TITLE
Import FleetOps into main DemoStoke

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@
   - `profiles`, `public_profiles`, `user_roles`
   - `blog_posts`
   - `gear_review_blog_generation_config`, `gear_review_blog_generation_runs`
-  - `fleetops_pos_inventory_seed_config`
+  - imported FleetOps tables: `fleetops_shops`, `fleetops_shop_viewers`, `fleetops_user_roles`, `fleetops_equipment`, `fleetops_equipment_images`, `fleetops_pricing_options`, `fleetops_add_ons`, `fleetops_bookings`, `fleetops_pos_connections`, `fleetops_lightspeed_inventory_items`, `fleetops_booqable_inventory_items`, `fleetops_pos_inventory_seed_runs`, `fleetops_pos_inventory_seed_config`
   - `demo_calendar`, `demo_event_candidates`, `demo_event_discovery_config`
   - `app_settings`, `app_privacy_settings`
   - `shop_gear_feed_mappings`, `scraped_retailers`, `downloaded_images`
@@ -188,6 +188,15 @@ If a grant is missing, PostgREST returns error code `42501` with the exact GRANT
   - `crawl-retailer-details`
   - `extract-gear-from-html`
   - `insert-equipment-from-sql`
+- Imported FleetOps:
+  - `fleetops-admin-create-shop`
+  - `fleetops-ai-analytics`
+  - `fleetops-create-payment-intent`
+  - `fleetops-refund-payment`
+  - `fleetops-send-booking-email`
+  - `fleetops-shop-gear-feed`
+  - `fleetops-stripe-webhook`
+  - `fleetops-seed-pos-inventory`
 
 ## Env and Integration Surface
 - Browser/public runtime uses `VITE_SUPABASE_URL` plus `VITE_SUPABASE_PUBLISHABLE_KEY` or `VITE_SUPABASE_ANON_KEY` when provided, and otherwise falls back to checked-in values in `src/integrations/supabase/config.js` for the Supabase URL and publishable key.
@@ -203,7 +212,8 @@ If a grant is missing, PostgREST returns error code `42501` with the exact GRANT
 - Theme flicker fix can be disabled with `VITE_ENABLE_THEME_FLICKER_FIX=false`.
 - Edge functions rely on combinations of `SUPABASE_SERVICE_ROLE_KEY`, `OPENAI_API_KEY`, `MAPBOX_TOKEN`, `GOOGLE_API_KEY`, `GOOGLE_CSE_ID`, `GOOGLE_SEARCH_API_KEY`, `GOOGLE_SEARCH_ENGINE_ID`, and `HCAPTCHA_SECRET`.
 - `generate-gear-review-blog-draft` also relies on `SUPABASE_SERVICE_ROLE_KEY`, `OPENAI_API_KEY`, and the Google Custom Search image/web keys. It is protected by the `gear_review_blog_generation_config.cron_secret` value passed as `x-cron-secret`.
-- The FleetOps POS demo inventory cron runs from the main DemoStoke DB via `trigger_fleetops_pos_inventory_seed_cron()` and posts to `https://imdhbnfgrrckwoboodox.supabase.co/functions/v1/seed-pos-inventory`; keep `fleetops_pos_inventory_seed_config.cron_secret` synchronized with the FleetOps `POS_INVENTORY_SEED_CRON_SECRET` function secret.
+- Imported FleetOps storage uses public buckets `fleetops-equipment-images` and `fleetops-shop-logos`.
+- Imported FleetOps Edge Functions use prefixed secrets where available: `FLEETOPS_STRIPE_SECRET_KEY`, `FLEETOPS_STRIPE_WEBHOOK_SECRET`, `FLEETOPS_SENDGRID_API_KEY`, `FLEETOPS_FROM_EMAIL`, `FLEETOPS_PUBLIC_SUPABASE_URL`, and `FLEETOPS_POS_INVENTORY_SEED_CRON_SECRET`. The retained `fleetops_pos_inventory_seed_config.cron_secret` should stay synchronized with the prefixed POS function secret if the disabled seed flow is ever re-enabled.
 - Do not introduce new hardcoded secrets. Keep public browser tokens and service secrets clearly separated.
 
 ## Critical Invariants and Gotchas
@@ -216,7 +226,7 @@ If a grant is missing, PostgREST returns error code `42501` with the exact GRANT
 - Search/explore/profile visibility behavior is tightly coupled to `equipmentDataService`, `searchService`, `useEquipmentWithDynamicDistance`, and advanced filter helpers.
 - Automated gear-review drafts must not create `equipment_reviews` rows or mutate `equipment.rating` / `equipment.review_count`. Hidden factual evidence belongs in `gear_review_blog_generation_runs.hidden_evidence`, not in public blog copy, tags, excerpts, or analytics payloads.
 - Cron-generated gear-review drafts use the evergreen model-review prompt `Write a comprehensive evergreen product review of the [gear brand/model] [category]`. Drafts should read like standalone product reviews, not listing, rental, shop, travel, or local availability pages. They must not use listing metadata such as owner/shop details, pickup or booking details, listing locations, city/state/region copy, daily or weekly rates, rental prices, dollar amounts, or rate structures in public copy. They must include category-specific review structure such as design/construction, ride/use profile, natural language headings like `Who it's for` instead of `Who it is for`, setup guidance, strengths, tradeoffs, care/tuning, and a final `<h2>Final Call</h2>` section with a natural relative `/gear/...` link to the reviewed DemoStoke gear detail page. Draft tags must be exactly the post category, gear category, and brand, for example `gear reviews`, `skis`, `stockli`. The generator must deterministically normalize Final Thoughts/Verdict style headings to Final Call, normalize formal `Who it is for` phrasing to `Who it's for`, and insert that gear-detail link before saving if the model omits it. They must not use em dashes in public copy, must target about 1200 visible body words after stripping HTML tags with a 1000-1400 word guardrail, and must store a selected gear image URL for the blog thumbnail instead of a small Google `thumbnailLink`.
-- FleetOps POS inventory seeding is queued by `pg_net` from the main DemoStoke project at the daily 9/10 UTC schedule, gated to 2 AM Pacific and a 2-day cadence. The FleetOps `seed-pos-inventory` function performs the actual inserts and read-back verification in the FleetOps DB; use `trigger_fleetops_pos_inventory_seed_cron(true)` for a live forced validation run.
+- As of June 8, 2026, FleetOps has been imported into the main DemoStoke project with prefixed `fleetops_` tables, `fleetops-` storage buckets, and `fleetops-` Edge Functions. The old main cron job `fleetops-pos-inventory-seed-2am-pt` was unscheduled, `fleetops_pos_inventory_seed_config.enabled` is false, and `trigger_fleetops_pos_inventory_seed_cron(boolean)` was dropped. Do not recreate the old cron or post to the separate FleetOps project unless the user explicitly requests it.
 - Generated gear-review analytics must use safe metadata only: post id/slug, category, source equipment id, gear category, author, generated flag, and preview/published mode. Never send hidden evidence, source snippets, credentials, or raw prompts to Amplitude or Google Analytics.
 - `DemoStokeWidget` is a local-dev artifact right now. Treat it as unfinished unless you intentionally wire it to production.
 - There is a large amount of existing debug logging. Remove or preserve it intentionally, not accidentally.

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -654,6 +654,440 @@ export type Database = {
           },
         ]
       }
+      fleetops_add_ons: {
+        Row: {
+          category: string
+          created_at: string | null
+          id: string
+          image_url: string | null
+          name: string
+          price_per_day: number
+          shop_id: string
+        }
+        Insert: {
+          category: string
+          created_at?: string | null
+          id?: string
+          image_url?: string | null
+          name: string
+          price_per_day: number
+          shop_id: string
+        }
+        Update: {
+          category?: string
+          created_at?: string | null
+          id?: string
+          image_url?: string | null
+          name?: string
+          price_per_day?: number
+          shop_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fleetops_add_ons_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "fleetops_shops"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      fleetops_bookings: {
+        Row: {
+          add_ons_price: number | null
+          add_ons_snapshot: Json | null
+          base_price: number
+          created_at: string | null
+          customer_email: string
+          customer_name: string
+          customer_phone: string | null
+          damage_deposit: number | null
+          end_date: string
+          equipment_id: string
+          id: string
+          notes: string | null
+          num_days: number
+          refunded_at: string | null
+          service_fee: number | null
+          shop_id: string
+          start_date: string
+          status: string | null
+          stripe_charge_id: string | null
+          stripe_payment_intent_id: string | null
+          stripe_refund_id: string | null
+          total_price: number
+          updated_at: string | null
+        }
+        Insert: {
+          add_ons_price?: number | null
+          add_ons_snapshot?: Json | null
+          base_price: number
+          created_at?: string | null
+          customer_email: string
+          customer_name: string
+          customer_phone?: string | null
+          damage_deposit?: number | null
+          end_date: string
+          equipment_id: string
+          id?: string
+          notes?: string | null
+          num_days: number
+          refunded_at?: string | null
+          service_fee?: number | null
+          shop_id: string
+          start_date: string
+          status?: string | null
+          stripe_charge_id?: string | null
+          stripe_payment_intent_id?: string | null
+          stripe_refund_id?: string | null
+          total_price: number
+          updated_at?: string | null
+        }
+        Update: {
+          add_ons_price?: number | null
+          add_ons_snapshot?: Json | null
+          base_price?: number
+          created_at?: string | null
+          customer_email?: string
+          customer_name?: string
+          customer_phone?: string | null
+          damage_deposit?: number | null
+          end_date?: string
+          equipment_id?: string
+          id?: string
+          notes?: string | null
+          num_days?: number
+          refunded_at?: string | null
+          service_fee?: number | null
+          shop_id?: string
+          start_date?: string
+          status?: string | null
+          stripe_charge_id?: string | null
+          stripe_payment_intent_id?: string | null
+          stripe_refund_id?: string | null
+          total_price?: number
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fleetops_bookings_equipment_id_fkey"
+            columns: ["equipment_id"]
+            isOneToOne: false
+            referencedRelation: "fleetops_equipment"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fleetops_bookings_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "fleetops_shops"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      fleetops_booqable_inventory_items: {
+        Row: {
+          base_price_in_cents: number
+          booking_story: string
+          created_at: string
+          description: string | null
+          group_name: string
+          id: string
+          location: Json | null
+          mock_shop_id: string
+          name: string
+          owner_id: string
+          photo_url: string
+          pos_connection_id: string
+          product_id: string
+          product_type: string
+          raw_payload: Json
+          shop_id: string
+          sku: string | null
+          updated_at: string
+        }
+        Insert: {
+          base_price_in_cents: number
+          booking_story?: string
+          created_at?: string
+          description?: string | null
+          group_name: string
+          id?: string
+          location?: Json | null
+          mock_shop_id: string
+          name: string
+          owner_id: string
+          photo_url: string
+          pos_connection_id: string
+          product_id: string
+          product_type?: string
+          raw_payload?: Json
+          shop_id: string
+          sku?: string | null
+          updated_at?: string
+        }
+        Update: {
+          base_price_in_cents?: number
+          booking_story?: string
+          created_at?: string
+          description?: string | null
+          group_name?: string
+          id?: string
+          location?: Json | null
+          mock_shop_id?: string
+          name?: string
+          owner_id?: string
+          photo_url?: string
+          pos_connection_id?: string
+          product_id?: string
+          product_type?: string
+          raw_payload?: Json
+          shop_id?: string
+          sku?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fleetops_booqable_inventory_items_pos_connection_id_fkey"
+            columns: ["pos_connection_id"]
+            isOneToOne: false
+            referencedRelation: "fleetops_pos_connections"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fleetops_booqable_inventory_items_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "fleetops_shops"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      fleetops_equipment: {
+        Row: {
+          availability: Json | null
+          category: string
+          created_at: string | null
+          damage_deposit: number | null
+          description: string | null
+          id: string
+          image_url: string | null
+          is_featured: boolean | null
+          location: Json | null
+          name: string
+          price_per_day: number
+          price_per_hour: number | null
+          price_per_week: number | null
+          rating: number | null
+          review_count: number | null
+          shop_id: string
+          specifications: Json | null
+          status: string | null
+          subcategory: string | null
+          updated_at: string | null
+          visible: boolean | null
+        }
+        Insert: {
+          availability?: Json | null
+          category: string
+          created_at?: string | null
+          damage_deposit?: number | null
+          description?: string | null
+          id?: string
+          image_url?: string | null
+          is_featured?: boolean | null
+          location?: Json | null
+          name: string
+          price_per_day: number
+          price_per_hour?: number | null
+          price_per_week?: number | null
+          rating?: number | null
+          review_count?: number | null
+          shop_id: string
+          specifications?: Json | null
+          status?: string | null
+          subcategory?: string | null
+          updated_at?: string | null
+          visible?: boolean | null
+        }
+        Update: {
+          availability?: Json | null
+          category?: string
+          created_at?: string | null
+          damage_deposit?: number | null
+          description?: string | null
+          id?: string
+          image_url?: string | null
+          is_featured?: boolean | null
+          location?: Json | null
+          name?: string
+          price_per_day?: number
+          price_per_hour?: number | null
+          price_per_week?: number | null
+          rating?: number | null
+          review_count?: number | null
+          shop_id?: string
+          specifications?: Json | null
+          status?: string | null
+          subcategory?: string | null
+          updated_at?: string | null
+          visible?: boolean | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fleetops_equipment_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "fleetops_shops"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      fleetops_equipment_images: {
+        Row: {
+          created_at: string | null
+          display_order: number | null
+          equipment_id: string
+          id: string
+          image_url: string
+        }
+        Insert: {
+          created_at?: string | null
+          display_order?: number | null
+          equipment_id: string
+          id?: string
+          image_url: string
+        }
+        Update: {
+          created_at?: string | null
+          display_order?: number | null
+          equipment_id?: string
+          id?: string
+          image_url?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fleetops_equipment_images_equipment_id_fkey"
+            columns: ["equipment_id"]
+            isOneToOne: false
+            referencedRelation: "fleetops_equipment"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      fleetops_lightspeed_inventory_items: {
+        Row: {
+          booking_story: string
+          category: string
+          created_at: string
+          description: string
+          id: string
+          image_url: string
+          item_id: string
+          location: Json | null
+          manufacturer: string | null
+          mock_shop_id: string
+          owner_id: string
+          pos_connection_id: string
+          price: number
+          raw_payload: Json
+          shop_id: string
+          updated_at: string
+        }
+        Insert: {
+          booking_story?: string
+          category: string
+          created_at?: string
+          description: string
+          id?: string
+          image_url: string
+          item_id: string
+          location?: Json | null
+          manufacturer?: string | null
+          mock_shop_id: string
+          owner_id: string
+          pos_connection_id: string
+          price: number
+          raw_payload?: Json
+          shop_id: string
+          updated_at?: string
+        }
+        Update: {
+          booking_story?: string
+          category?: string
+          created_at?: string
+          description?: string
+          id?: string
+          image_url?: string
+          item_id?: string
+          location?: Json | null
+          manufacturer?: string | null
+          mock_shop_id?: string
+          owner_id?: string
+          pos_connection_id?: string
+          price?: number
+          raw_payload?: Json
+          shop_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fleetops_lightspeed_inventory_items_pos_connection_id_fkey"
+            columns: ["pos_connection_id"]
+            isOneToOne: false
+            referencedRelation: "fleetops_pos_connections"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fleetops_lightspeed_inventory_items_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "fleetops_shops"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      fleetops_pos_connections: {
+        Row: {
+          created_at: string | null
+          credentials: Json | null
+          field_mapping: Json | null
+          id: string
+          is_connected: boolean | null
+          last_sync_at: string | null
+          provider: string
+          shop_id: string
+        }
+        Insert: {
+          created_at?: string | null
+          credentials?: Json | null
+          field_mapping?: Json | null
+          id?: string
+          is_connected?: boolean | null
+          last_sync_at?: string | null
+          provider: string
+          shop_id: string
+        }
+        Update: {
+          created_at?: string | null
+          credentials?: Json | null
+          field_mapping?: Json | null
+          id?: string
+          is_connected?: boolean | null
+          last_sync_at?: string | null
+          provider?: string
+          shop_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fleetops_pos_connections_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "fleetops_shops"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       fleetops_pos_inventory_seed_config: {
         Row: {
           created_at: string
@@ -687,6 +1121,241 @@ export type Database = {
           last_queued_at?: string | null
           last_request_id?: number | null
           updated_at?: string
+        }
+        Relationships: []
+      }
+      fleetops_pos_inventory_seed_runs: {
+        Row: {
+          booqable_inventory_item_id: string | null
+          booqable_pos_connection_id: string | null
+          booqable_product_id: string | null
+          completed_at: string | null
+          created_at: string
+          error_message: string | null
+          generated_sequence: number
+          id: string
+          lightspeed_inventory_item_id: string | null
+          lightspeed_item_id: string | null
+          lightspeed_pos_connection_id: string | null
+          mock_shop_id: string | null
+          raw_result: Json
+          source: string
+          started_at: string
+          status: string
+          target_owner_id: string | null
+          target_shop_id: string | null
+          verification_counts: Json
+        }
+        Insert: {
+          booqable_inventory_item_id?: string | null
+          booqable_pos_connection_id?: string | null
+          booqable_product_id?: string | null
+          completed_at?: string | null
+          created_at?: string
+          error_message?: string | null
+          generated_sequence: number
+          id?: string
+          lightspeed_inventory_item_id?: string | null
+          lightspeed_item_id?: string | null
+          lightspeed_pos_connection_id?: string | null
+          mock_shop_id?: string | null
+          raw_result?: Json
+          source: string
+          started_at?: string
+          status: string
+          target_owner_id?: string | null
+          target_shop_id?: string | null
+          verification_counts?: Json
+        }
+        Update: {
+          booqable_inventory_item_id?: string | null
+          booqable_pos_connection_id?: string | null
+          booqable_product_id?: string | null
+          completed_at?: string | null
+          created_at?: string
+          error_message?: string | null
+          generated_sequence?: number
+          id?: string
+          lightspeed_inventory_item_id?: string | null
+          lightspeed_item_id?: string | null
+          lightspeed_pos_connection_id?: string | null
+          mock_shop_id?: string | null
+          raw_result?: Json
+          source?: string
+          started_at?: string
+          status?: string
+          target_owner_id?: string | null
+          target_shop_id?: string | null
+          verification_counts?: Json
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fleetops_pos_inventory_seed_r_lightspeed_inventory_item_id_fkey"
+            columns: ["lightspeed_inventory_item_id"]
+            isOneToOne: false
+            referencedRelation: "fleetops_lightspeed_inventory_items"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fleetops_pos_inventory_seed_r_lightspeed_pos_connection_id_fkey"
+            columns: ["lightspeed_pos_connection_id"]
+            isOneToOne: false
+            referencedRelation: "fleetops_pos_connections"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fleetops_pos_inventory_seed_run_booqable_inventory_item_id_fkey"
+            columns: ["booqable_inventory_item_id"]
+            isOneToOne: false
+            referencedRelation: "fleetops_booqable_inventory_items"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fleetops_pos_inventory_seed_run_booqable_pos_connection_id_fkey"
+            columns: ["booqable_pos_connection_id"]
+            isOneToOne: false
+            referencedRelation: "fleetops_pos_connections"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fleetops_pos_inventory_seed_runs_target_shop_id_fkey"
+            columns: ["target_shop_id"]
+            isOneToOne: false
+            referencedRelation: "fleetops_shops"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      fleetops_pricing_options: {
+        Row: {
+          created_at: string | null
+          duration: string
+          equipment_id: string
+          id: string
+          price: number
+        }
+        Insert: {
+          created_at?: string | null
+          duration: string
+          equipment_id: string
+          id?: string
+          price: number
+        }
+        Update: {
+          created_at?: string | null
+          duration?: string
+          equipment_id?: string
+          id?: string
+          price?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fleetops_pricing_options_equipment_id_fkey"
+            columns: ["equipment_id"]
+            isOneToOne: false
+            referencedRelation: "fleetops_equipment"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      fleetops_shop_viewers: {
+        Row: {
+          id: string
+          shop_id: string
+          viewer_user_id: string
+        }
+        Insert: {
+          id?: string
+          shop_id: string
+          viewer_user_id: string
+        }
+        Update: {
+          id?: string
+          shop_id?: string
+          viewer_user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fleetops_shop_viewers_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "fleetops_shops"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      fleetops_shops: {
+        Row: {
+          contact_email: string | null
+          contact_phone: string | null
+          created_at: string | null
+          description: string | null
+          id: string
+          location: Json | null
+          logo_url: string | null
+          name: string
+          owner_id: string
+          slug: string
+          stripe_account_id: string | null
+          updated_at: string | null
+          website_url: string | null
+          widget_config: Json | null
+        }
+        Insert: {
+          contact_email?: string | null
+          contact_phone?: string | null
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          location?: Json | null
+          logo_url?: string | null
+          name: string
+          owner_id: string
+          slug: string
+          stripe_account_id?: string | null
+          updated_at?: string | null
+          website_url?: string | null
+          widget_config?: Json | null
+        }
+        Update: {
+          contact_email?: string | null
+          contact_phone?: string | null
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          location?: Json | null
+          logo_url?: string | null
+          name?: string
+          owner_id?: string
+          slug?: string
+          stripe_account_id?: string | null
+          updated_at?: string | null
+          website_url?: string | null
+          widget_config?: Json | null
+        }
+        Relationships: []
+      }
+      fleetops_user_roles: {
+        Row: {
+          assigned_at: string
+          assigned_by: string | null
+          id: string
+          role: Database["public"]["Enums"]["fleetops_app_role"]
+          user_id: string
+        }
+        Insert: {
+          assigned_at?: string
+          assigned_by?: string | null
+          id?: string
+          role: Database["public"]["Enums"]["fleetops_app_role"]
+          user_id: string
+        }
+        Update: {
+          assigned_at?: string
+          assigned_by?: string | null
+          id?: string
+          role?: Database["public"]["Enums"]["fleetops_app_role"]
+          user_id?: string
         }
         Relationships: []
       }
@@ -1245,6 +1914,11 @@ export type Database = {
           reason: string
         }[]
       }
+      fleetops_is_admin: { Args: { target_user_id?: string }; Returns: boolean }
+      fleetops_is_shop_viewer: {
+        Args: { target_shop_id: string }
+        Returns: boolean
+      }
       get_app_setting: { Args: { key: string }; Returns: Json }
       get_public_generated_gear_review_metadata: {
         Args: { p_blog_post_ids: string[] }
@@ -1289,14 +1963,461 @@ export type Database = {
         Returns: undefined
       }
       trigger_demo_event_discovery_cron: { Args: never; Returns: Json }
-      trigger_fleetops_pos_inventory_seed_cron: {
-        Args: { p_force?: boolean }
-        Returns: Json
-      }
       trigger_gear_review_blog_generation_cron: { Args: never; Returns: Json }
     }
     Enums: {
       app_role: "admin" | "user"
+      fleetops_app_role: "shop" | "admin" | "guest"
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+  storage: {
+    Tables: {
+      buckets: {
+        Row: {
+          allowed_mime_types: string[] | null
+          avif_autodetection: boolean | null
+          created_at: string | null
+          file_size_limit: number | null
+          id: string
+          name: string
+          owner: string | null
+          owner_id: string | null
+          public: boolean | null
+          type: Database["storage"]["Enums"]["buckettype"]
+          updated_at: string | null
+        }
+        Insert: {
+          allowed_mime_types?: string[] | null
+          avif_autodetection?: boolean | null
+          created_at?: string | null
+          file_size_limit?: number | null
+          id: string
+          name: string
+          owner?: string | null
+          owner_id?: string | null
+          public?: boolean | null
+          type?: Database["storage"]["Enums"]["buckettype"]
+          updated_at?: string | null
+        }
+        Update: {
+          allowed_mime_types?: string[] | null
+          avif_autodetection?: boolean | null
+          created_at?: string | null
+          file_size_limit?: number | null
+          id?: string
+          name?: string
+          owner?: string | null
+          owner_id?: string | null
+          public?: boolean | null
+          type?: Database["storage"]["Enums"]["buckettype"]
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
+      buckets_analytics: {
+        Row: {
+          created_at: string
+          deleted_at: string | null
+          format: string
+          id: string
+          name: string
+          type: Database["storage"]["Enums"]["buckettype"]
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          deleted_at?: string | null
+          format?: string
+          id?: string
+          name: string
+          type?: Database["storage"]["Enums"]["buckettype"]
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          deleted_at?: string | null
+          format?: string
+          id?: string
+          name?: string
+          type?: Database["storage"]["Enums"]["buckettype"]
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      buckets_vectors: {
+        Row: {
+          created_at: string
+          id: string
+          type: Database["storage"]["Enums"]["buckettype"]
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          id: string
+          type?: Database["storage"]["Enums"]["buckettype"]
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          type?: Database["storage"]["Enums"]["buckettype"]
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      migrations: {
+        Row: {
+          executed_at: string | null
+          hash: string
+          id: number
+          name: string
+        }
+        Insert: {
+          executed_at?: string | null
+          hash: string
+          id: number
+          name: string
+        }
+        Update: {
+          executed_at?: string | null
+          hash?: string
+          id?: number
+          name?: string
+        }
+        Relationships: []
+      }
+      objects: {
+        Row: {
+          bucket_id: string | null
+          created_at: string | null
+          id: string
+          last_accessed_at: string | null
+          metadata: Json | null
+          name: string | null
+          owner: string | null
+          owner_id: string | null
+          path_tokens: string[] | null
+          updated_at: string | null
+          user_metadata: Json | null
+          version: string | null
+        }
+        Insert: {
+          bucket_id?: string | null
+          created_at?: string | null
+          id?: string
+          last_accessed_at?: string | null
+          metadata?: Json | null
+          name?: string | null
+          owner?: string | null
+          owner_id?: string | null
+          path_tokens?: string[] | null
+          updated_at?: string | null
+          user_metadata?: Json | null
+          version?: string | null
+        }
+        Update: {
+          bucket_id?: string | null
+          created_at?: string | null
+          id?: string
+          last_accessed_at?: string | null
+          metadata?: Json | null
+          name?: string | null
+          owner?: string | null
+          owner_id?: string | null
+          path_tokens?: string[] | null
+          updated_at?: string | null
+          user_metadata?: Json | null
+          version?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "objects_bucketId_fkey"
+            columns: ["bucket_id"]
+            isOneToOne: false
+            referencedRelation: "buckets"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      s3_multipart_uploads: {
+        Row: {
+          bucket_id: string
+          created_at: string
+          id: string
+          in_progress_size: number
+          key: string
+          metadata: Json | null
+          owner_id: string | null
+          upload_signature: string
+          user_metadata: Json | null
+          version: string
+        }
+        Insert: {
+          bucket_id: string
+          created_at?: string
+          id: string
+          in_progress_size?: number
+          key: string
+          metadata?: Json | null
+          owner_id?: string | null
+          upload_signature: string
+          user_metadata?: Json | null
+          version: string
+        }
+        Update: {
+          bucket_id?: string
+          created_at?: string
+          id?: string
+          in_progress_size?: number
+          key?: string
+          metadata?: Json | null
+          owner_id?: string | null
+          upload_signature?: string
+          user_metadata?: Json | null
+          version?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "s3_multipart_uploads_bucket_id_fkey"
+            columns: ["bucket_id"]
+            isOneToOne: false
+            referencedRelation: "buckets"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      s3_multipart_uploads_parts: {
+        Row: {
+          bucket_id: string
+          created_at: string
+          etag: string
+          id: string
+          key: string
+          owner_id: string | null
+          part_number: number
+          size: number
+          upload_id: string
+          version: string
+        }
+        Insert: {
+          bucket_id: string
+          created_at?: string
+          etag: string
+          id?: string
+          key: string
+          owner_id?: string | null
+          part_number: number
+          size?: number
+          upload_id: string
+          version: string
+        }
+        Update: {
+          bucket_id?: string
+          created_at?: string
+          etag?: string
+          id?: string
+          key?: string
+          owner_id?: string | null
+          part_number?: number
+          size?: number
+          upload_id?: string
+          version?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "s3_multipart_uploads_parts_bucket_id_fkey"
+            columns: ["bucket_id"]
+            isOneToOne: false
+            referencedRelation: "buckets"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "s3_multipart_uploads_parts_upload_id_fkey"
+            columns: ["upload_id"]
+            isOneToOne: false
+            referencedRelation: "s3_multipart_uploads"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      vector_indexes: {
+        Row: {
+          bucket_id: string
+          created_at: string
+          data_type: string
+          dimension: number
+          distance_metric: string
+          id: string
+          metadata_configuration: Json | null
+          name: string
+          updated_at: string
+        }
+        Insert: {
+          bucket_id: string
+          created_at?: string
+          data_type: string
+          dimension: number
+          distance_metric: string
+          id?: string
+          metadata_configuration?: Json | null
+          name: string
+          updated_at?: string
+        }
+        Update: {
+          bucket_id?: string
+          created_at?: string
+          data_type?: string
+          dimension?: number
+          distance_metric?: string
+          id?: string
+          metadata_configuration?: Json | null
+          name?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vector_indexes_bucket_id_fkey"
+            columns: ["bucket_id"]
+            isOneToOne: false
+            referencedRelation: "buckets_vectors"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      allow_any_operation: {
+        Args: { expected_operations: string[] }
+        Returns: boolean
+      }
+      allow_only_operation: {
+        Args: { expected_operation: string }
+        Returns: boolean
+      }
+      can_insert_object: {
+        Args: { bucketid: string; metadata: Json; name: string; owner: string }
+        Returns: undefined
+      }
+      extension: { Args: { name: string }; Returns: string }
+      filename: { Args: { name: string }; Returns: string }
+      foldername: { Args: { name: string }; Returns: string[] }
+      get_common_prefix: {
+        Args: { p_delimiter: string; p_key: string; p_prefix: string }
+        Returns: string
+      }
+      get_size_by_bucket: {
+        Args: never
+        Returns: {
+          bucket_id: string
+          size: number
+        }[]
+      }
+      list_multipart_uploads_with_delimiter: {
+        Args: {
+          bucket_id: string
+          delimiter_param: string
+          max_keys?: number
+          next_key_token?: string
+          next_upload_token?: string
+          prefix_param: string
+        }
+        Returns: {
+          created_at: string
+          id: string
+          key: string
+        }[]
+      }
+      list_objects_with_delimiter: {
+        Args: {
+          _bucket_id: string
+          delimiter_param: string
+          max_keys?: number
+          next_token?: string
+          prefix_param: string
+          sort_order?: string
+          start_after?: string
+        }
+        Returns: {
+          created_at: string
+          id: string
+          last_accessed_at: string
+          metadata: Json
+          name: string
+          updated_at: string
+        }[]
+      }
+      operation: { Args: never; Returns: string }
+      search: {
+        Args: {
+          bucketname: string
+          levels?: number
+          limits?: number
+          offsets?: number
+          prefix: string
+          search?: string
+          sortcolumn?: string
+          sortorder?: string
+        }
+        Returns: {
+          created_at: string
+          id: string
+          last_accessed_at: string
+          metadata: Json
+          name: string
+          updated_at: string
+        }[]
+      }
+      search_by_timestamp: {
+        Args: {
+          p_bucket_id: string
+          p_level: number
+          p_limit: number
+          p_prefix: string
+          p_sort_column: string
+          p_sort_column_after: string
+          p_sort_order: string
+          p_start_after: string
+        }
+        Returns: {
+          created_at: string
+          id: string
+          key: string
+          last_accessed_at: string
+          metadata: Json
+          name: string
+          updated_at: string
+        }[]
+      }
+      search_v2: {
+        Args: {
+          bucket_name: string
+          levels?: number
+          limits?: number
+          prefix: string
+          sort_column?: string
+          sort_column_after?: string
+          sort_order?: string
+          start_after?: string
+        }
+        Returns: {
+          created_at: string
+          id: string
+          key: string
+          last_accessed_at: string
+          metadata: Json
+          name: string
+          updated_at: string
+        }[]
+      }
+    }
+    Enums: {
+      buckettype: "STANDARD" | "ANALYTICS" | "VECTOR"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -1425,6 +2546,12 @@ export const Constants = {
   public: {
     Enums: {
       app_role: ["admin", "user"],
+      fleetops_app_role: ["shop", "admin", "guest"],
+    },
+  },
+  storage: {
+    Enums: {
+      buckettype: ["STANDARD", "ANALYTICS", "VECTOR"],
     },
   },
 } as const

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -20,3 +20,27 @@ verify_jwt = false
 
 [functions.generate-gear-review-blog-draft]
 verify_jwt = false
+
+[functions.fleetops-admin-create-shop]
+verify_jwt = false
+
+[functions.fleetops-ai-analytics]
+verify_jwt = false
+
+[functions.fleetops-create-payment-intent]
+verify_jwt = false
+
+[functions.fleetops-refund-payment]
+verify_jwt = false
+
+[functions.fleetops-seed-pos-inventory]
+verify_jwt = false
+
+[functions.fleetops-send-booking-email]
+verify_jwt = true
+
+[functions.fleetops-shop-gear-feed]
+verify_jwt = false
+
+[functions.fleetops-stripe-webhook]
+verify_jwt = false

--- a/supabase/functions/_shared/fleetopsWidgetCheckout.ts
+++ b/supabase/functions/_shared/fleetopsWidgetCheckout.ts
@@ -1,0 +1,38 @@
+export type FleetOpsWidgetCheckoutMode = "public" | "admin_only";
+
+export interface FleetOpsWidgetViewerState {
+  checkoutMode: FleetOpsWidgetCheckoutMode;
+  isAdmin: boolean;
+  isGuest: boolean;
+  canCheckout: boolean;
+}
+
+export function resolveWidgetCheckoutMode(
+  widgetConfig: unknown
+): FleetOpsWidgetCheckoutMode {
+  if (!widgetConfig || typeof widgetConfig !== "object") {
+    return "public";
+  }
+
+  return (widgetConfig as { checkoutMode?: unknown }).checkoutMode ===
+    "admin_only"
+    ? "admin_only"
+    : "public";
+}
+
+export function createWidgetViewer(
+  checkoutMode: FleetOpsWidgetCheckoutMode,
+  roles: Iterable<string>
+): FleetOpsWidgetViewerState {
+  const roleSet = new Set(Array.from(roles));
+  const isAdmin = roleSet.has("admin");
+  const isGuest = roleSet.has("guest");
+
+  return {
+    checkoutMode,
+    isAdmin,
+    isGuest,
+    canCheckout: checkoutMode === "admin_only" ? isAdmin : !isGuest,
+  };
+}
+

--- a/supabase/functions/fleetops-admin-create-shop/index.ts
+++ b/supabase/functions/fleetops-admin-create-shop/index.ts
@@ -1,0 +1,194 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+type CreateShopBody = {
+  shopName?: string;
+  email?: string;
+  password?: string;
+};
+
+function jsonResponse(body: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+function slugify(value: string) {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/[\s_]+/g, "-")
+    .replace(/-+/g, "-");
+}
+
+function createUniqueShopSlug(shopName: string) {
+  const base = slugify(shopName) || "shop";
+  return `${base}-${Date.now().toString(36)}${Math.random()
+    .toString(36)
+    .slice(2, 6)}`;
+}
+
+async function insertShopWithUniqueSlug(adminClient: ReturnType<typeof createClient>, ownerId: string, shopName: string, email: string) {
+  let lastError: unknown = null;
+
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const slug = createUniqueShopSlug(shopName);
+    const { data, error } = await adminClient
+      .from("fleetops_shops")
+      .insert({
+        owner_id: ownerId,
+        name: shopName,
+        slug,
+        contact_email: email,
+      })
+      .select("id, slug")
+      .single();
+
+    if (!error && data) {
+      return data;
+    }
+
+    lastError = error;
+    if (error?.code !== "23505") {
+      break;
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Unable to create shop.");
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "Method not allowed." }, 405);
+  }
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
+  const supabaseServiceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+
+  if (!supabaseUrl || !supabaseAnonKey || !supabaseServiceRoleKey) {
+    return jsonResponse(
+      { error: "Missing required Supabase environment variables." },
+      500
+    );
+  }
+
+  const authorization = req.headers.get("Authorization");
+  if (!authorization) {
+    return jsonResponse({ error: "Unauthorized." }, 401);
+  }
+
+  const authClient = createClient(supabaseUrl, supabaseAnonKey, {
+    global: { headers: { Authorization: authorization } },
+  });
+  const adminClient = createClient(supabaseUrl, supabaseServiceRoleKey);
+
+  try {
+    const {
+      data: { user },
+      error: authError,
+    } = await authClient.auth.getUser();
+
+    if (authError || !user) {
+      return jsonResponse({ error: "Unauthorized." }, 401);
+    }
+
+    const { data: isAdmin, error: adminError } = await authClient.rpc("fleetops_is_admin");
+    if (adminError || isAdmin !== true) {
+      return jsonResponse({ error: "Forbidden." }, 403);
+    }
+
+    let body: CreateShopBody;
+    try {
+      body = (await req.json()) as CreateShopBody;
+    } catch {
+      return jsonResponse({ error: "Invalid JSON body." }, 400);
+    }
+
+    const shopName = body.shopName?.trim() ?? "";
+    const email = body.email?.trim().toLowerCase() ?? "";
+    const password = body.password ?? "";
+
+    if (!shopName || !email || !password) {
+      return jsonResponse(
+        { error: "shopName, email, and password are required." },
+        400
+      );
+    }
+
+    if (password.length < 8) {
+      return jsonResponse(
+        { error: "Password must be at least 8 characters long." },
+        400
+      );
+    }
+
+    const { data: createdUserData, error: createUserError } =
+      await adminClient.auth.admin.createUser({
+        email,
+        password,
+        email_confirm: true,
+        user_metadata: {
+          shop_name: shopName,
+        },
+      });
+
+    if (createUserError) {
+      return jsonResponse({ error: createUserError.message }, 400);
+    }
+
+    const createdUserId = createdUserData.user?.id;
+    if (!createdUserId) {
+      return jsonResponse({ error: "User creation failed." }, 500);
+    }
+
+    try {
+      const { error: roleError } = await adminClient.from("fleetops_user_roles").insert({
+        user_id: createdUserId,
+        role: "shop",
+        assigned_by: user.id,
+      });
+
+      if (roleError) {
+        throw roleError;
+      }
+
+      const createdShop = await insertShopWithUniqueSlug(
+        adminClient,
+        createdUserId,
+        shopName,
+        email
+      );
+
+      return jsonResponse({
+        userId: createdUserId,
+        shopId: createdShop.id,
+        shopSlug: createdShop.slug,
+      });
+    } catch (error) {
+      await adminClient.auth.admin.deleteUser(createdUserId).catch(() => null);
+      throw error;
+    }
+  } catch (error) {
+    return jsonResponse(
+      {
+        error: error instanceof Error ? error.message : "Failed to create shop.",
+      },
+      500
+    );
+  }
+});

--- a/supabase/functions/fleetops-ai-analytics/index.ts
+++ b/supabase/functions/fleetops-ai-analytics/index.ts
@@ -1,0 +1,161 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+function jsonResponse(body: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+function getBearerToken(header: string | null) {
+  if (!header) return null;
+  const [scheme, token] = header.split(" ");
+  if (scheme?.toLowerCase() !== "bearer" || !token) return null;
+  return token;
+}
+
+const SYSTEM_PROMPT = `You are an expert analytics advisor for gear rental businesses (surfboards, snowboards, skis, mountain bikes, etc.). You analyze booking and revenue data to provide actionable business insights.
+
+Given the shop's analytics data, provide a concise analysis with these sections:
+
+## Revenue Forecast
+Predict revenue trends for the next 30 days based on historical patterns.
+
+## Peak Booking Periods
+Identify when demand is highest and recommend preparation strategies.
+
+## Equipment Demand
+Highlight which gear categories and items are most/least popular, and suggest inventory adjustments.
+
+## Seasonal Trends
+Note any seasonal patterns and how the shop should prepare.
+
+## Recommendations
+Provide 3-5 specific, actionable recommendations for pricing, inventory, or operations.
+
+Keep your response concise and data-driven. Use specific numbers from the provided data. Format with markdown headers and bullet points.`;
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
+    if (!supabaseUrl || !supabaseAnonKey) {
+      return jsonResponse(
+        { error: "Missing required Supabase environment variables." },
+        500
+      );
+    }
+
+    const authorization = req.headers.get("Authorization");
+    const accessToken = getBearerToken(authorization);
+    if (!accessToken || !authorization) {
+      return jsonResponse({ error: "Unauthorized." }, 401);
+    }
+
+    const authClient = createClient(supabaseUrl, supabaseAnonKey, {
+      global: { headers: { Authorization: authorization } },
+    });
+    const {
+      data: { user },
+      error: authError,
+    } = await authClient.auth.getUser();
+
+    if (authError || !user) {
+      return jsonResponse({ error: "Unauthorized." }, 401);
+    }
+
+    const { data: isAdmin, error: adminError } = await authClient.rpc("fleetops_is_admin");
+    if (adminError || isAdmin !== true) {
+      return jsonResponse({ error: "Forbidden." }, 403);
+    }
+
+    const openaiKey = Deno.env.get("OPENAI_API_KEY");
+    if (!openaiKey) {
+      return jsonResponse(
+        { error: "OpenAI API key not configured." },
+        500
+      );
+    }
+
+    const body = await req.json();
+    const { stats } = body;
+
+    if (!stats) {
+      return jsonResponse({ error: "Stats payload is required." }, 400);
+    }
+
+    const userPrompt = `Here is the analytics data for this gear rental shop:
+
+**Selected Period:** ${stats.dateRange?.from ?? "N/A"} to ${stats.dateRange?.to ?? "N/A"}
+
+**Key Metrics:**
+- Total Revenue: $${stats.totalRevenue?.toLocaleString() ?? 0}
+- Total Bookings: ${stats.totalBookings ?? 0}
+- Average Booking Value: $${stats.avgBookingValue ?? 0}
+- Total Equipment Items: ${stats.totalEquipment ?? 0}
+
+**Revenue by Month (last 6 months):**
+${(stats.revenueByMonth ?? []).map((m: { month: string; revenue: number }) => `- ${m.month}: $${m.revenue.toLocaleString()}`).join("\n") || "No monthly data available"}
+
+**Top Categories:**
+${(stats.topCategories ?? []).map((c: { category: string; bookings: number; revenue: number }) => `- ${c.category}: ${c.bookings} bookings, $${c.revenue.toLocaleString()} revenue`).join("\n") || "No category data available"}
+
+**Status Breakdown:**
+${Object.entries(stats.statusBreakdown ?? {}).map(([status, count]) => `- ${status}: ${count}`).join("\n") || "No status data available"}
+
+Please analyze this data and provide insights and predictions.`;
+
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${openaiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gpt-4o-mini",
+        messages: [
+          { role: "system", content: SYSTEM_PROMPT },
+          { role: "user", content: userPrompt },
+        ],
+        temperature: 0.7,
+        max_tokens: 1500,
+      }),
+    });
+
+    if (!response.ok) {
+      const errBody = await response.text();
+      console.error("OpenAI API error:", response.status, errBody);
+      return jsonResponse(
+        { error: "Failed to get AI response. Please try again." },
+        502
+      );
+    }
+
+    const result = await response.json();
+    const insights =
+      result.choices?.[0]?.message?.content ?? "No insights generated.";
+
+    return jsonResponse({ insights });
+  } catch (error) {
+    console.error("ai-analytics error:", error);
+    return jsonResponse(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to generate analytics insights.",
+      },
+      500
+    );
+  }
+});

--- a/supabase/functions/fleetops-create-payment-intent/index.ts
+++ b/supabase/functions/fleetops-create-payment-intent/index.ts
@@ -1,0 +1,389 @@
+import Stripe from "https://esm.sh/stripe@17?target=deno";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import {
+  createWidgetViewer,
+  resolveWidgetCheckoutMode,
+} from "../_shared/fleetopsWidgetCheckout.ts";
+
+const stripe = new Stripe(Deno.env.get("FLEETOPS_STRIPE_SECRET_KEY") || Deno.env.get("STRIPE_SECRET_KEY")!, {
+  apiVersion: "2024-12-18.acacia",
+});
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+const supabase = createClient(
+  Deno.env.get("SUPABASE_URL")!,
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
+);
+
+const BLOCKING_STATUSES = ["pending", "confirmed"];
+const PENDING_HOLD_MINUTES = 30;
+
+const CATEGORY_ALIASES: Record<string, string> = {
+  snowboard: "snowboards",
+  snowboards: "snowboards",
+  ski: "skis",
+  skis: "skis",
+  surfboard: "surfboards",
+  surfboards: "surfboards",
+  skateboard: "skateboards",
+  skateboards: "skateboards",
+  wetsuit: "wetsuits",
+  wetsuits: "wetsuits",
+  "mountain-bike": "mountain-bikes",
+  "mountain-bikes": "mountain-bikes",
+  mountainbike: "mountain-bikes",
+  mountainbikes: "mountain-bikes",
+  mtb: "mountain-bikes",
+};
+
+function jsonResponse(body: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+function normalizeDate(value: unknown, fieldName: string) {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${fieldName} is required.`);
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`${fieldName} must be a valid ISO date.`);
+  }
+
+  return parsed.toISOString().slice(0, 10);
+}
+
+function normalizeEquipmentCategory(category: unknown): string {
+  if (typeof category !== "string") return "";
+
+  const normalized = category
+    .trim()
+    .toLowerCase()
+    .replace(/[_\s]+/g, "-");
+
+  if (!normalized) return "";
+
+  return CATEGORY_ALIASES[normalized] ?? normalized;
+}
+
+function calculateBookingPrice(params: {
+  pricePerDay: number;
+  numDays: number;
+  addOns: Array<{ price_per_day: number }>;
+  damageDeposit?: number | null;
+  serviceFeeRate?: number;
+}) {
+  const {
+    pricePerDay,
+    numDays,
+    addOns,
+    damageDeposit = 0,
+    serviceFeeRate = 0.1,
+  } = params;
+
+  const basePrice = pricePerDay * numDays;
+  const addOnsTotal = addOns.reduce(
+    (sum, addOn) => sum + addOn.price_per_day * numDays,
+    0
+  );
+  const subtotal = basePrice + addOnsTotal;
+  const serviceFee = Math.round(subtotal * serviceFeeRate * 100) / 100;
+  const total =
+    Math.round((subtotal + serviceFee + Number(damageDeposit || 0)) * 100) / 100;
+
+  return {
+    numDays,
+    basePrice: Math.round(basePrice * 100) / 100,
+    addOnsTotal: Math.round(addOnsTotal * 100) / 100,
+    serviceFee,
+    damageDeposit: Math.round(Number(damageDeposit || 0) * 100) / 100,
+    total,
+  };
+}
+
+function isPendingBookingActive(booking: {
+  status: string;
+  created_at?: string | null;
+}) {
+  if (booking.status !== "pending") {
+    return booking.status === "confirmed";
+  }
+
+  if (!booking.created_at) {
+    return false;
+  }
+
+  const createdAt = new Date(booking.created_at);
+  if (Number.isNaN(createdAt.getTime())) {
+    return false;
+  }
+
+  return Date.now() - createdAt.getTime() < PENDING_HOLD_MINUTES * 60 * 1000;
+}
+
+async function resolveCallerRoles(authHeader: string | null) {
+  if (!authHeader) return [];
+
+  const jwt = authHeader.replace(/^Bearer\s+/i, "").trim();
+  if (!jwt) return [];
+
+  const { data: { user }, error: userError } = await supabase.auth.getUser(jwt);
+  if (userError || !user) return [];
+
+  const { data: roleRows, error: roleError } = await supabase
+    .from("fleetops_user_roles")
+    .select("role")
+    .eq("user_id", user.id);
+
+  if (roleError || !roleRows) return [];
+
+  return [...new Set(roleRows.map((row) => row.role).filter(Boolean))];
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const body = await req.json();
+    const shopId =
+      typeof body.shopId === "string" && body.shopId.trim()
+        ? body.shopId.trim()
+        : "";
+    const equipmentId =
+      typeof body.equipmentId === "string" && body.equipmentId.trim()
+        ? body.equipmentId.trim()
+        : "";
+    const customerName =
+      typeof body.customerName === "string" && body.customerName.trim()
+        ? body.customerName.trim()
+        : "";
+    const customerEmail =
+      typeof body.customerEmail === "string" && body.customerEmail.trim()
+        ? body.customerEmail.trim()
+        : "";
+    const customerPhone =
+      typeof body.customerPhone === "string" && body.customerPhone.trim()
+        ? body.customerPhone.trim()
+        : null;
+    const addOnIds = Array.isArray(body.addOnIds)
+      ? [...new Set(body.addOnIds.filter((value) => typeof value === "string"))]
+      : [];
+
+    if (!shopId || !equipmentId) {
+      return jsonResponse({ error: "shopId and equipmentId are required." }, 400);
+    }
+
+    if (!customerName || !customerEmail) {
+      return jsonResponse(
+        { error: "customerName and customerEmail are required." },
+        400
+      );
+    }
+
+    const { data: shop, error: shopError } = await supabase
+      .from("fleetops_shops")
+      .select("id, widget_config")
+      .eq("id", shopId)
+      .single();
+
+    if (shopError || !shop) {
+      return jsonResponse({ error: "Shop not found." }, 404);
+    }
+
+    const callerRoles = await resolveCallerRoles(
+      req.headers.get("Authorization")
+    );
+    const viewer = createWidgetViewer(
+      resolveWidgetCheckoutMode(shop.widget_config),
+      callerRoles
+    );
+
+    if (viewer.checkoutMode === "admin_only" && !viewer.isAdmin) {
+      return jsonResponse(
+        {
+          error:
+            "Checkout is only available to authenticated admin users for this shop.",
+        },
+        403
+      );
+    }
+
+    if (viewer.checkoutMode !== "admin_only" && viewer.isGuest) {
+      return jsonResponse({ error: "Booking is not available in guest mode." }, 403);
+    }
+
+    const startDate = normalizeDate(body.startDate, "startDate");
+    const endDate = normalizeDate(body.endDate, "endDate");
+
+    if (startDate > endDate) {
+      return jsonResponse(
+        { error: "startDate must be before or equal to endDate." },
+        400
+      );
+    }
+
+    const start = new Date(`${startDate}T00:00:00.000Z`);
+    const end = new Date(`${endDate}T00:00:00.000Z`);
+    const numDays =
+      Math.floor((end.getTime() - start.getTime()) / (24 * 60 * 60 * 1000)) + 1;
+
+    if (numDays < 1) {
+      return jsonResponse({ error: "Booking must be at least one day." }, 400);
+    }
+
+    const { data: equipment, error: equipmentError } = await supabase
+      .from("fleetops_equipment")
+      .select(
+        "id, shop_id, name, category, visible, status, price_per_day, damage_deposit"
+      )
+      .eq("id", equipmentId)
+      .eq("shop_id", shopId)
+      .single();
+
+    if (equipmentError || !equipment) {
+      return jsonResponse({ error: "Equipment not found." }, 404);
+    }
+
+    if (!equipment.visible || equipment.status !== "available") {
+      return jsonResponse(
+        { error: "This item is not currently available for booking." },
+        409
+      );
+    }
+
+    const { data: overlappingBookings, error: overlapError } = await supabase
+      .from("fleetops_bookings")
+      .select("id, status, created_at")
+      .eq("equipment_id", equipmentId)
+      .eq("shop_id", shopId)
+      .in("status", BLOCKING_STATUSES)
+      .lte("start_date", endDate)
+      .gte("end_date", startDate);
+
+    if (overlapError) {
+      return jsonResponse(
+        { error: "Unable to validate availability right now." },
+        500
+      );
+    }
+
+    if ((overlappingBookings ?? []).some(isPendingBookingActive)) {
+      return jsonResponse(
+        { error: "This item is no longer available for the selected dates." },
+        409
+      );
+    }
+
+    const normalizedAddOns = addOnIds.length
+      ? await supabase
+          .from("fleetops_add_ons")
+          .select("id, name, category, image_url, price_per_day, shop_id")
+          .eq("shop_id", shopId)
+          .in("id", addOnIds)
+      : { data: [], error: null };
+
+    if (normalizedAddOns.error) {
+      return jsonResponse(
+        { error: "Unable to load add-ons for this booking." },
+        500
+      );
+    }
+
+    const addOns = normalizedAddOns.data ?? [];
+    if (addOns.length !== addOnIds.length) {
+      return jsonResponse({ error: "One or more selected add-ons are invalid." }, 400);
+    }
+
+    const compatibleCategory = normalizeEquipmentCategory(equipment.category);
+    if (
+      compatibleCategory &&
+      addOns.some(
+        (addOn) =>
+          normalizeEquipmentCategory(addOn.category) !== compatibleCategory
+      )
+    ) {
+      return jsonResponse(
+        { error: "One or more selected add-ons are incompatible with this item." },
+        400
+      );
+    }
+
+    const quote = calculateBookingPrice({
+      pricePerDay: Number(equipment.price_per_day ?? 0),
+      numDays,
+      addOns,
+      damageDeposit: equipment.damage_deposit,
+    });
+
+    const bookingId = crypto.randomUUID();
+    const paymentIntent = await stripe.paymentIntents.create({
+      amount: Math.round(quote.total * 100),
+      currency: "usd",
+      receipt_email: customerEmail,
+      metadata: {
+        bookingId,
+        shopId,
+        equipmentId,
+        startDate,
+        endDate,
+      },
+    });
+
+    const { error: bookingError } = await supabase.from("fleetops_bookings").insert({
+      id: bookingId,
+      shop_id: shopId,
+      equipment_id: equipmentId,
+      customer_name: customerName,
+      customer_email: customerEmail,
+      customer_phone: customerPhone,
+      start_date: startDate,
+      end_date: endDate,
+      num_days: quote.numDays,
+      base_price: quote.basePrice,
+      add_ons_price: quote.addOnsTotal,
+      damage_deposit: quote.damageDeposit,
+      service_fee: quote.serviceFee,
+      total_price: quote.total,
+      status: "pending",
+      stripe_payment_intent_id: paymentIntent.id,
+      add_ons_snapshot: addOns.map((addOn) => ({
+        id: addOn.id,
+        shop_id: addOn.shop_id,
+        name: addOn.name,
+        category: addOn.category,
+        image_url: addOn.image_url,
+        price_per_day: Number(addOn.price_per_day ?? 0),
+      })),
+    });
+
+    if (bookingError) {
+      await stripe.paymentIntents.cancel(paymentIntent.id).catch(() => null);
+      return jsonResponse(
+        { error: "Unable to create the booking draft right now." },
+        500
+      );
+    }
+
+    return jsonResponse({
+      bookingId,
+      clientSecret: paymentIntent.client_secret,
+      paymentIntentId: paymentIntent.id,
+      quote,
+    });
+  } catch (error) {
+    return jsonResponse(
+      { error: error instanceof Error ? error.message : "Payment setup failed." },
+      400
+    );
+  }
+});

--- a/supabase/functions/fleetops-refund-payment/index.ts
+++ b/supabase/functions/fleetops-refund-payment/index.ts
@@ -30,6 +30,18 @@ function getBearerToken(header: string | null) {
   return token;
 }
 
+function logInternalError(label: string, error: unknown) {
+  if (error instanceof Error) {
+    console.error(label, {
+      name: error.name,
+      message: error.message,
+    });
+    return;
+  }
+
+  console.error(label, error);
+}
+
 Deno.serve(async (req: Request) => {
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });
@@ -142,8 +154,10 @@ Deno.serve(async (req: Request) => {
       bookingStatus: nextStatus,
     });
   } catch (error) {
-    console.error("[refund] Error:", error);
-    const message = error instanceof Error ? error.message : String(error);
-    return jsonResponse({ error: message || "Refund failed." }, 400);
+    logInternalError("[refund] Error", error);
+    return jsonResponse(
+      { error: "Unable to refund this booking right now." },
+      500
+    );
   }
 });

--- a/supabase/functions/fleetops-refund-payment/index.ts
+++ b/supabase/functions/fleetops-refund-payment/index.ts
@@ -1,0 +1,149 @@
+import Stripe from "https://esm.sh/stripe@17?target=deno";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const stripe = new Stripe(Deno.env.get("FLEETOPS_STRIPE_SECRET_KEY") || Deno.env.get("STRIPE_SECRET_KEY")!, {
+  apiVersion: "2024-12-18.acacia",
+});
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+const supabaseServiceRoleKey =
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ||
+  Deno.env.get("SERVICE_ROLE_KEY")!;
+
+function jsonResponse(body: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+function getBearerToken(header: string | null) {
+  if (!header) return null;
+  const [scheme, token] = header.split(" ");
+  if (scheme?.toLowerCase() !== "bearer" || !token) return null;
+  return token;
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const authHeader = req.headers.get("Authorization");
+    const accessToken = getBearerToken(authHeader);
+    if (!accessToken) {
+      return jsonResponse({ error: "Missing authorization header." }, 401);
+    }
+
+    console.log("[refund] Auth token received, verifying user...");
+    const adminClient = createClient(supabaseUrl, supabaseServiceRoleKey);
+    const {
+      data,
+      error: authError,
+    } = await adminClient.auth.getUser(accessToken);
+    const user = data.user;
+
+    if (authError || !user) {
+      console.error("[refund] Auth failed:", authError?.message);
+      return jsonResponse({ error: "Unauthorized." }, 401);
+    }
+
+    const { bookingId } = await req.json();
+    if (!bookingId) {
+      return jsonResponse({ error: "bookingId is required." }, 400);
+    }
+
+    console.log("[refund] Fetching booking:", bookingId);
+    const { data: booking, error: bookingError } = await adminClient
+      .from("fleetops_bookings")
+      .select(
+        "id, shop_id, status, total_price, stripe_payment_intent_id, stripe_refund_id"
+      )
+      .eq("id", bookingId)
+      .single();
+
+    if (bookingError || !booking) {
+      console.error("[refund] Booking not found:", bookingError?.message);
+      return jsonResponse({ error: "Booking not found." }, 404);
+    }
+
+    console.log("[refund] Booking found, status:", booking.status, "PI:", booking.stripe_payment_intent_id);
+
+    const { data: shop, error: shopError } = await adminClient
+      .from("fleetops_shops")
+      .select("id")
+      .eq("id", booking.shop_id)
+      .eq("owner_id", user.id)
+      .single();
+
+    if (shopError || !shop) {
+      console.error("[refund] Shop ownership check failed:", shopError?.message);
+      return jsonResponse({ error: "You do not have access to this booking." }, 403);
+    }
+
+    if (!booking.stripe_payment_intent_id) {
+      return jsonResponse(
+        { error: "This booking does not have a Stripe payment to refund." },
+        400
+      );
+    }
+
+    if (booking.status === "refunded" || booking.stripe_refund_id) {
+      return jsonResponse({ error: "This booking has already been refunded." }, 409);
+    }
+
+    console.log("[refund] Creating Stripe refund for PI:", booking.stripe_payment_intent_id);
+    const refund = await stripe.refunds.create({
+      payment_intent: booking.stripe_payment_intent_id,
+      reason: "requested_by_customer",
+      metadata: {
+        bookingId: booking.id,
+        shopId: booking.shop_id,
+      },
+    });
+
+    const fullyRefunded =
+      refund.amount === Math.round(Number(booking.total_price) * 100) &&
+      refund.status !== "failed" &&
+      refund.status !== "canceled";
+
+    const nextStatus = fullyRefunded ? "refunded" : booking.status;
+    const nextRefundedAt = fullyRefunded ? new Date().toISOString() : null;
+
+    const { error: updateError } = await adminClient
+      .from("fleetops_bookings")
+      .update({
+        status: nextStatus,
+        stripe_refund_id: refund.id,
+        refunded_at: nextRefundedAt,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", booking.id);
+
+    if (updateError) {
+      console.error("[refund] Failed to update booking after refund:", updateError);
+      return jsonResponse(
+        { error: "Refund created in Stripe, but booking update failed." },
+        500
+      );
+    }
+
+    console.log("[refund] Success! Refund:", refund.id, "Status:", refund.status, "Booking status:", nextStatus);
+    return jsonResponse({
+      refundId: refund.id,
+      refundStatus: refund.status,
+      bookingStatus: nextStatus,
+    });
+  } catch (error) {
+    console.error("[refund] Error:", error);
+    const message = error instanceof Error ? error.message : String(error);
+    return jsonResponse({ error: message || "Refund failed." }, 400);
+  }
+});

--- a/supabase/functions/fleetops-seed-pos-inventory/index.ts
+++ b/supabase/functions/fleetops-seed-pos-inventory/index.ts
@@ -1,0 +1,445 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, x-cron-secret",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+const DEMO_LIGHTSPEED_CREDENTIALS = {
+  accountId: "LS-DEMO-12345",
+  accessToken: "lsdemo_pat_4f8a1c9e7b3d2056",
+};
+
+const DEMO_BOOQABLE_CREDENTIALS = {
+  companySlug: "demostoke-rentals",
+  accessToken: "bqdemo_tok_91x7y3z8a2b6c4d0",
+};
+
+const MOCK_SOURCES = [
+  {
+    id: "summit-and-surf",
+    category: "Surfboards",
+    manufacturer: "Channel Islands",
+    image:
+      "https://images.unsplash.com/photo-1502680390548-bdbac40e4ce9?w=400",
+  },
+  {
+    id: "powder-hound-skis",
+    category: "Skis",
+    manufacturer: "Rossignol",
+    image:
+      "https://images.unsplash.com/photo-1551698618-1dfe5d97d256?w=400",
+  },
+  {
+    id: "edge-and-carve-boards",
+    category: "Snowboards",
+    manufacturer: "Burton",
+    image:
+      "https://images.unsplash.com/photo-1522056615691-da7cfe4d0c3e?w=400",
+  },
+  {
+    id: "tidewater-surf-shop",
+    category: "Surfboards",
+    manufacturer: "Firewire",
+    image:
+      "https://images.unsplash.com/photo-1531722569936-825d3dd91b15?w=400",
+  },
+  {
+    id: "trailhead-bikes",
+    category: "Mountain Bikes",
+    manufacturer: "Trek",
+    image:
+      "https://images.unsplash.com/photo-1576858574144-9ae1ebcf5ae5?w=800&auto=format&fit=crop",
+  },
+];
+
+const DEFAULT_LOCATION = {
+  lat: 37.6308,
+  lng: -119.0326,
+  address: "Mammoth Lakes, CA",
+};
+
+type SeedBody = {
+  source?: "cron" | "manual";
+  force?: boolean;
+  shopId?: string;
+};
+
+function jsonResponse(body: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+function timingSafeEqualString(actual: string, expected: string) {
+  const encoder = new TextEncoder();
+  const actualBytes = encoder.encode(actual);
+  const expectedBytes = encoder.encode(expected);
+
+  if (actualBytes.length !== expectedBytes.length) return false;
+
+  let diff = 0;
+  for (let i = 0; i < actualBytes.length; i += 1) {
+    diff |= actualBytes[i] ^ expectedBytes[i];
+  }
+  return diff === 0;
+}
+
+async function readBody(req: Request): Promise<SeedBody> {
+  try {
+    return (await req.json()) as SeedBody;
+  } catch {
+    return {};
+  }
+}
+
+function isDemoLightspeedConnection(connection: Record<string, unknown>) {
+  const credentials = (connection.credentials ?? {}) as Record<string, unknown>;
+  return (
+    credentials.accountId === DEMO_LIGHTSPEED_CREDENTIALS.accountId &&
+    credentials.accessToken === DEMO_LIGHTSPEED_CREDENTIALS.accessToken
+  );
+}
+
+async function findTargetShop(
+  supabase: ReturnType<typeof createClient>,
+  requestedShopId?: string
+) {
+  if (requestedShopId) {
+    const { data, error } = await supabase
+      .from("fleetops_shops")
+      .select("id, owner_id, name")
+      .eq("id", requestedShopId)
+      .single();
+    if (error || !data) throw error ?? new Error("Requested shop not found.");
+    return data;
+  }
+
+  const { data: connections, error: connectionError } = await supabase
+    .from("fleetops_pos_connections")
+    .select("id, shop_id, provider, credentials, is_connected")
+    .eq("provider", "lightspeed");
+
+  if (connectionError) throw connectionError;
+
+  const lightspeedConnection = (connections ?? []).find(
+    isDemoLightspeedConnection
+  );
+  if (!lightspeedConnection) {
+    throw new Error("No Lightspeed demo POS connection found.");
+  }
+
+  const { data: shop, error: shopError } = await supabase
+    .from("fleetops_shops")
+    .select("id, owner_id, name")
+    .eq("id", lightspeedConnection.shop_id)
+    .single();
+  if (shopError || !shop) throw shopError ?? new Error("Target shop not found.");
+  return shop;
+}
+
+async function ensureConnection(
+  supabase: ReturnType<typeof createClient>,
+  shopId: string,
+  provider: "lightspeed" | "booqable",
+  credentials: Record<string, string>,
+  mockShopId: string
+) {
+  const { data: existing, error: existingError } = await supabase
+    .from("fleetops_pos_connections")
+    .select("id, shop_id, provider, credentials, is_connected")
+    .eq("shop_id", shopId)
+    .eq("provider", provider)
+    .maybeSingle();
+
+  if (existingError) throw existingError;
+
+  const mergedCredentials = {
+    ...((existing?.credentials ?? {}) as Record<string, unknown>),
+    ...credentials,
+    mockShopId,
+  };
+
+  if (existing) {
+    const { data, error } = await supabase
+      .from("fleetops_pos_connections")
+      .update({
+        is_connected: true,
+        credentials: mergedCredentials,
+      })
+      .eq("id", existing.id)
+      .select("id, shop_id, provider, credentials, is_connected")
+      .single();
+
+    if (error || !data) throw error ?? new Error(`Failed to update ${provider}.`);
+    return data;
+  }
+
+  const { data, error } = await supabase
+    .from("fleetops_pos_connections")
+    .insert({
+      shop_id: shopId,
+      provider,
+      is_connected: true,
+      credentials: mergedCredentials,
+    })
+    .select("id, shop_id, provider, credentials, is_connected")
+    .single();
+
+  if (error || !data) throw error ?? new Error(`Failed to create ${provider}.`);
+  return data;
+}
+
+async function nextSequence(supabase: ReturnType<typeof createClient>) {
+  const { data, error } = await supabase
+    .from("fleetops_pos_inventory_seed_runs")
+    .select("generated_sequence")
+    .order("generated_sequence", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) throw error;
+  return Number(data?.generated_sequence ?? 0) + 1;
+}
+
+function buildSeedPayload(sequence: number, source: (typeof MOCK_SOURCES)[number]) {
+  const padded = String(sequence).padStart(4, "0");
+  const itemSuffix = `${source.category.replace(/[^A-Za-z]/g, "").toUpperCase()}-${padded}`;
+  const price = 28 + (sequence % 7) * 4;
+  const name = `Demo Sync ${source.category.slice(0, -1) || source.category} ${padded}`;
+  const bookingStory = `${name} was added by the scheduled POS seed to keep the demo inventory changing like a live ${source.category.toLowerCase()} rental catalog.`;
+
+  return {
+    lightspeed: {
+      item_id: `LS-AUTO-${itemSuffix}`,
+      description: name,
+      category: source.category,
+      manufacturer: source.manufacturer,
+      price,
+      image_url: source.image,
+      booking_story: bookingStory,
+    },
+    booqable: {
+      product_id: `BQ-AUTO-${itemSuffix}`,
+      name,
+      base_price_in_cents: Math.round(price * 100),
+      photo_url: source.image,
+      product_type: "rental",
+      group_name: source.category,
+      description: bookingStory,
+      sku: `BQ-${itemSuffix}`,
+      booking_story: bookingStory,
+    },
+  };
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "Method not allowed." }, 405);
+  }
+
+  const expectedSecret = Deno.env.get("FLEETOPS_POS_INVENTORY_SEED_CRON_SECRET") || Deno.env.get("POS_INVENTORY_SEED_CRON_SECRET")?.trim();
+  const suppliedSecret = req.headers.get("x-cron-secret")?.trim() ?? "";
+  if (
+    !expectedSecret ||
+    !timingSafeEqualString(suppliedSecret, expectedSecret)
+  ) {
+    return jsonResponse({ error: "Unauthorized." }, 401);
+  }
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!supabaseUrl || !serviceRoleKey) {
+    return jsonResponse(
+      { error: "Missing required Supabase environment variables." },
+      500
+    );
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey);
+  const body = await readBody(req);
+  const source = body.source === "manual" ? "manual" : "cron";
+  let runId: string | null = null;
+
+  try {
+    const targetShop = await findTargetShop(supabase, body.shopId);
+    const sequence = await nextSequence(supabase);
+    const mockSource = MOCK_SOURCES[(sequence - 1) % MOCK_SOURCES.length];
+    const payload = buildSeedPayload(sequence, mockSource);
+
+    const lightspeedConnection = await ensureConnection(
+      supabase,
+      targetShop.id,
+      "lightspeed",
+      DEMO_LIGHTSPEED_CREDENTIALS,
+      mockSource.id
+    );
+    const booqableConnection = await ensureConnection(
+      supabase,
+      targetShop.id,
+      "booqable",
+      DEMO_BOOQABLE_CREDENTIALS,
+      mockSource.id
+    );
+
+    const { data: run, error: runError } = await supabase
+      .from("fleetops_pos_inventory_seed_runs")
+      .insert({
+        source,
+        status: "running",
+        target_shop_id: targetShop.id,
+        target_owner_id: targetShop.owner_id,
+        lightspeed_pos_connection_id: lightspeedConnection.id,
+        booqable_pos_connection_id: booqableConnection.id,
+        mock_shop_id: mockSource.id,
+        generated_sequence: sequence,
+        lightspeed_item_id: payload.lightspeed.item_id,
+        booqable_product_id: payload.booqable.product_id,
+      })
+      .select("id")
+      .single();
+
+    if (runError || !run) {
+      throw runError ?? new Error("Failed to create seed run.");
+    }
+    runId = run.id;
+
+    const { data: lightspeedItem, error: lightspeedError } = await supabase
+      .from("fleetops_lightspeed_inventory_items")
+      .upsert(
+        {
+          shop_id: targetShop.id,
+          owner_id: targetShop.owner_id,
+          pos_connection_id: lightspeedConnection.id,
+          mock_shop_id: mockSource.id,
+          location: DEFAULT_LOCATION,
+          raw_payload: {
+            Item: {
+              itemID: payload.lightspeed.item_id,
+              description: payload.lightspeed.description,
+              Category: { name: payload.lightspeed.category },
+              Manufacturer: { name: payload.lightspeed.manufacturer },
+              Prices: {
+                ItemPrice: [
+                  {
+                    amount: String(payload.lightspeed.price),
+                    useType: "Default",
+                  },
+                ],
+              },
+              Images: {
+                Image: [{ baseImageURL: payload.lightspeed.image_url }],
+              },
+            },
+          },
+          ...payload.lightspeed,
+        },
+        { onConflict: "pos_connection_id,item_id" }
+      )
+      .select("id, item_id")
+      .single();
+
+    if (lightspeedError || !lightspeedItem) {
+      throw lightspeedError ?? new Error("Failed to seed Lightspeed item.");
+    }
+
+    const { data: booqableItem, error: booqableError } = await supabase
+      .from("fleetops_booqable_inventory_items")
+      .upsert(
+        {
+          shop_id: targetShop.id,
+          owner_id: targetShop.owner_id,
+          pos_connection_id: booqableConnection.id,
+          mock_shop_id: mockSource.id,
+          location: DEFAULT_LOCATION,
+          raw_payload: {
+            data: {
+              id: payload.booqable.product_id,
+              type: "products",
+              attributes: payload.booqable,
+            },
+          },
+          ...payload.booqable,
+        },
+        { onConflict: "pos_connection_id,product_id" }
+      )
+      .select("id, product_id")
+      .single();
+
+    if (booqableError || !booqableItem) {
+      throw booqableError ?? new Error("Failed to seed Booqable item.");
+    }
+
+    const { count: lightspeedVerification, error: lightspeedVerifyError } =
+      await supabase
+        .from("fleetops_lightspeed_inventory_items")
+        .select("id", { count: "exact", head: true })
+        .eq("id", lightspeedItem.id);
+
+    if (lightspeedVerifyError) throw lightspeedVerifyError;
+
+    const { count: booqableVerification, error: booqableVerifyError } =
+      await supabase
+        .from("fleetops_booqable_inventory_items")
+        .select("id", { count: "exact", head: true })
+        .eq("id", booqableItem.id);
+
+    if (booqableVerifyError) throw booqableVerifyError;
+
+    const verificationCounts = {
+      lightspeed: lightspeedVerification ?? 0,
+      booqable: booqableVerification ?? 0,
+    };
+
+    if (verificationCounts.lightspeed !== 1 || verificationCounts.booqable !== 1) {
+      throw new Error("Seed verification failed.");
+    }
+
+    const result = {
+      status: "success",
+      source,
+      shopId: targetShop.id,
+      sequence,
+      mockShopId: mockSource.id,
+      lightspeedItemId: lightspeedItem.item_id,
+      booqableProductId: booqableItem.product_id,
+      verificationCounts,
+    };
+
+    await supabase
+      .from("fleetops_pos_inventory_seed_runs")
+      .update({
+        status: "success",
+        lightspeed_inventory_item_id: lightspeedItem.id,
+        booqable_inventory_item_id: booqableItem.id,
+        verification_counts: verificationCounts,
+        raw_result: result,
+        completed_at: new Date().toISOString(),
+      })
+      .eq("id", runId);
+
+    return jsonResponse(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (runId) {
+      await supabase
+        .from("fleetops_pos_inventory_seed_runs")
+        .update({
+          status: "error",
+          error_message: message,
+          completed_at: new Date().toISOString(),
+        })
+        .eq("id", runId);
+    }
+
+    return jsonResponse({ error: message }, 500);
+  }
+});

--- a/supabase/functions/fleetops-send-booking-email/index.ts
+++ b/supabase/functions/fleetops-send-booking-email/index.ts
@@ -1,0 +1,209 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const SENDGRID_API_KEY = Deno.env.get("FLEETOPS_SENDGRID_API_KEY") || Deno.env.get("SENDGRID_API_KEY")!;
+const FROM_EMAIL = Deno.env.get("FLEETOPS_FROM_EMAIL") || Deno.env.get("FROM_EMAIL") || "bookings@demostoke.com";
+
+const supabase = createClient(
+  Deno.env.get("SUPABASE_URL")!,
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
+);
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+function jsonResponse(body: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+function getBearerToken(header: string | null) {
+  if (!header) return null;
+  const [scheme, token] = header.split(" ");
+  if (scheme?.toLowerCase() !== "bearer" || !token) return null;
+  return token;
+}
+
+function buildEmailHtml(booking: any, equipment: any, shop: any): string {
+  const confirmationNumber = booking.id.slice(0, 8).toUpperCase();
+
+  return `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 0; background: #f5f5f5; }
+    .container { max-width: 560px; margin: 0 auto; background: #fff; border-radius: 12px; overflow: hidden; }
+    .header { background: #2563eb; color: #fff; padding: 24px; text-align: center; }
+    .content { padding: 24px; }
+    .detail-row { display: flex; justify-content: space-between; padding: 8px 0; border-bottom: 1px solid #eee; font-size: 14px; }
+    .total-row { font-weight: bold; font-size: 16px; border-top: 2px solid #333; padding-top: 12px; margin-top: 8px; }
+    .footer { padding: 16px 24px; background: #f9fafb; text-align: center; font-size: 12px; color: #888; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <h1 style="margin:0;font-size:20px;">Booking Confirmed!</h1>
+      <p style="margin:8px 0 0;opacity:0.9;font-size:14px;">${shop.name}</p>
+    </div>
+    <div class="content">
+      <p style="font-size:14px;color:#666;">Hi ${booking.customer_name},</p>
+      <p style="font-size:14px;color:#666;">Your gear rental reservation has been confirmed. Here are your booking details:</p>
+
+      <div style="background:#f9fafb;border-radius:8px;padding:16px;margin:16px 0;">
+        <p style="margin:0 0 4px;font-size:12px;color:#888;">Confirmation #</p>
+        <p style="margin:0;font-size:18px;font-weight:bold;font-family:monospace;">${confirmationNumber}</p>
+      </div>
+
+      ${equipment.image_url ? `<img src="${equipment.image_url}" alt="${equipment.name}" style="width:100%;height:200px;object-fit:cover;border-radius:8px;margin-bottom:16px;">` : ""}
+
+      <h3 style="font-size:16px;margin:0 0 12px;">${equipment.name}</h3>
+
+      <div class="detail-row">
+        <span style="color:#666;">Dates</span>
+        <span>${booking.start_date} to ${booking.end_date}</span>
+      </div>
+      <div class="detail-row">
+        <span style="color:#666;">Duration</span>
+        <span>${booking.num_days} day${booking.num_days !== 1 ? "s" : ""}</span>
+      </div>
+      <div class="detail-row">
+        <span style="color:#666;">Base rental</span>
+        <span>$${Number(booking.base_price).toFixed(2)}</span>
+      </div>
+      ${Number(booking.add_ons_price) > 0 ? `
+      <div class="detail-row">
+        <span style="color:#666;">Add-ons</span>
+        <span>$${Number(booking.add_ons_price).toFixed(2)}</span>
+      </div>` : ""}
+      ${Number(booking.service_fee) > 0 ? `
+      <div class="detail-row">
+        <span style="color:#666;">Service fee</span>
+        <span>$${Number(booking.service_fee).toFixed(2)}</span>
+      </div>` : ""}
+      ${Number(booking.damage_deposit) > 0 ? `
+      <div class="detail-row">
+        <span style="color:#666;">Damage deposit</span>
+        <span>$${Number(booking.damage_deposit).toFixed(2)}</span>
+      </div>` : ""}
+      <div class="detail-row total-row">
+        <span>Total</span>
+        <span>$${Number(booking.total_price).toFixed(2)}</span>
+      </div>
+    </div>
+    <div class="footer">
+      <p>Questions? Contact ${shop.contact_email || shop.name}</p>
+      <p>Powered by DemoStoke</p>
+    </div>
+  </div>
+</body>
+</html>`;
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const accessToken = getBearerToken(req.headers.get("Authorization"));
+    if (!accessToken) {
+      return jsonResponse({ error: "Unauthorized." }, 401);
+    }
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser(accessToken);
+
+    if (authError || !user) {
+      return jsonResponse({ error: "Unauthorized." }, 401);
+    }
+
+    const { bookingId } = await req.json();
+    if (!bookingId) {
+      return jsonResponse({ error: "bookingId is required." }, 400);
+    }
+
+    const { data: booking, error: bookingError } = await supabase
+      .from("fleetops_bookings")
+      .select("*")
+      .eq("id", bookingId)
+      .single();
+
+    if (bookingError || !booking) {
+      return jsonResponse({ error: "Booking not found." }, 404);
+    }
+
+    const [{ data: shop }, { data: adminRole }] = await Promise.all([
+      supabase
+        .from("fleetops_shops")
+        .select("id, name, contact_email, owner_id")
+        .eq("id", booking.shop_id)
+        .single(),
+      supabase
+        .from("fleetops_user_roles")
+        .select("role")
+        .eq("user_id", user.id)
+        .eq("role", "admin")
+        .maybeSingle(),
+    ]);
+
+    if (!shop) {
+      return jsonResponse({ error: "Shop not found." }, 404);
+    }
+
+    const canSend = shop.owner_id === user.id || Boolean(adminRole);
+    if (!canSend) {
+      return jsonResponse({ error: "Forbidden." }, 403);
+    }
+
+    const { data: equipment } = await supabase
+      .from("fleetops_equipment")
+      .select("*")
+      .eq("id", booking.equipment_id)
+      .single();
+
+    if (!equipment) {
+      return jsonResponse({ error: "Equipment not found." }, 404);
+    }
+
+    const emailHtml = buildEmailHtml(booking, equipment, shop);
+
+    const response = await fetch("https://api.sendgrid.com/v3/mail/send", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${SENDGRID_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        personalizations: [
+          { to: [{ email: booking.customer_email, name: booking.customer_name }] },
+        ],
+        from: { email: FROM_EMAIL, name: shop.name },
+        subject: `Booking Confirmed - ${equipment.name}`,
+        content: [{ type: "text/html", value: emailHtml }],
+      }),
+    });
+
+    if (!response.ok) {
+      return jsonResponse(
+        { error: "Email delivery failed.", details: await response.text() },
+        502
+      );
+    }
+
+    return jsonResponse({ success: true });
+  } catch (error) {
+    return jsonResponse(
+      { error: error instanceof Error ? error.message : "Failed to send email." },
+      400
+    );
+  }
+});

--- a/supabase/functions/fleetops-shop-gear-feed/index.ts
+++ b/supabase/functions/fleetops-shop-gear-feed/index.ts
@@ -1,0 +1,659 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import {
+  createWidgetViewer,
+  resolveWidgetCheckoutMode,
+} from "../_shared/fleetopsWidgetCheckout.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+const BLOCKING_BOOKING_STATUSES = ["pending", "confirmed"];
+const PENDING_HOLD_MINUTES = 30;
+
+function toDateString(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function parseDateParam(value: string | null, fieldName: string): Date | null {
+  if (!value) return null;
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(
+      `Invalid ${fieldName}. Use an ISO date or datetime, e.g. 2026-03-04 or 2026-03-04T10:00:00Z`
+    );
+  }
+
+  return parsed;
+}
+
+function addDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+}
+
+function compareDateStrings(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+function overlaps(
+  startA: string,
+  endA: string,
+  startB: string,
+  endB: string
+): boolean {
+  return compareDateStrings(startA, endB) <= 0 &&
+    compareDateStrings(endA, startB) >= 0;
+}
+
+function plusOneDay(dateString: string): string {
+  const next = new Date(`${dateString}T00:00:00.000Z`);
+  next.setUTCDate(next.getUTCDate() + 1);
+  return toDateString(next);
+}
+
+function isPendingBookingActive(createdAt: string | null | undefined) {
+  if (!createdAt) return false;
+
+  const parsed = new Date(createdAt);
+  if (Number.isNaN(parsed.getTime())) return false;
+
+  return Date.now() - parsed.getTime() < PENDING_HOLD_MINUTES * 60 * 1000;
+}
+
+function isBlockingBooking(booking: {
+  status: string;
+  created_at?: string | null;
+}) {
+  if (booking.status === "confirmed") return true;
+  if (booking.status !== "pending") return false;
+  return isPendingBookingActive(booking.created_at);
+}
+
+function computeNextAvailableDate(
+  bookings: Array<{ start_date: string; end_date: string }>,
+  referenceDate: string
+): string | null {
+  if (!bookings.length) return null;
+
+  const sorted = [...bookings].sort((a, b) =>
+    compareDateStrings(a.start_date, b.start_date)
+  );
+
+  let cursor = referenceDate;
+  let wasBlocked = false;
+
+  for (const booking of sorted) {
+    if (compareDateStrings(booking.end_date, cursor) < 0) continue;
+
+    if (compareDateStrings(booking.start_date, cursor) > 0) {
+      // Found a gap where the item is available.
+      return wasBlocked ? cursor : null;
+    }
+
+    // booking.start_date <= cursor <= booking.end_date
+    wasBlocked = true;
+    cursor = plusOneDay(booking.end_date);
+  }
+
+  return wasBlocked ? cursor : null;
+}
+
+function safeJson(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object"
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function parseCoordinate(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value !== "string") return null;
+
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeLocation(value: unknown) {
+  const location = safeJson(value);
+  const address =
+    typeof location.address === "string" ? location.address.trim() : "";
+  const lat = parseCoordinate(location.lat);
+  const lng = parseCoordinate(location.lng);
+  const hasPlaceholderCoordinates = lat === 0 && lng === 0 && address.length > 0;
+  const normalizedLat =
+    lat !== null && lng !== null && !hasPlaceholderCoordinates ? lat : null;
+  const normalizedLng =
+    lat !== null && lng !== null && !hasPlaceholderCoordinates ? lng : null;
+
+  if (!address && normalizedLat === null && normalizedLng === null) {
+    return null;
+  }
+
+  return {
+    lat: normalizedLat,
+    lng: normalizedLng,
+    address,
+  };
+}
+
+function resolveLocation(primary: unknown, fallback: unknown) {
+  const primaryLocation = normalizeLocation(primary);
+  const fallbackLocation = normalizeLocation(fallback);
+
+  if (!primaryLocation && !fallbackLocation) {
+    return {
+      lat: null,
+      lng: null,
+      address: "",
+    };
+  }
+
+  return {
+    lat: primaryLocation?.lat ?? fallbackLocation?.lat ?? null,
+    lng: primaryLocation?.lng ?? fallbackLocation?.lng ?? null,
+    address: primaryLocation?.address || fallbackLocation?.address || "",
+  };
+}
+
+function toOrigin(value: string | null | undefined): string {
+  if (!value) return "";
+
+  try {
+    return new URL(value).origin;
+  } catch {
+    return "";
+  }
+}
+
+function toPublicImageUrl(value: unknown, publicOrigin: string): string {
+  if (typeof value !== "string") return "";
+
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  if (trimmed.startsWith("data:") || trimmed.startsWith("blob:")) return trimmed;
+
+  try {
+    return new URL(trimmed).toString();
+  } catch {
+    if (!publicOrigin) return trimmed;
+
+    if (trimmed.startsWith("/")) {
+      return `${publicOrigin}${trimmed}`;
+    }
+
+    const cleaned = trimmed.replace(/^\.?\/*/, "");
+    return cleaned ? `${publicOrigin}/${cleaned}` : "";
+  }
+}
+
+function parsePublicStoragePath(value: string, baseOrigin: string) {
+  const targetUrl = new URL(value, baseOrigin);
+  const segments = targetUrl.pathname.split("/").filter(Boolean);
+
+  if (
+    segments.length < 6 ||
+    segments[0] !== "storage" ||
+    segments[1] !== "v1" ||
+    segments[2] !== "object" ||
+    segments[3] !== "public"
+  ) {
+    throw new Error("Only public storage object URLs can be proxied.");
+  }
+
+  const bucket = segments[4];
+  const objectPath = segments.slice(5).join("/");
+
+  if (!bucket || !objectPath) {
+    throw new Error("Invalid public storage object path.");
+  }
+
+  return { bucket, objectPath };
+}
+
+async function resolveCallerRoles(
+  supabase: ReturnType<typeof createClient>,
+  authHeader: string | null
+) {
+  if (!authHeader) return [];
+
+  const jwt = authHeader.replace(/^Bearer\s+/i, "").trim();
+  if (!jwt) return [];
+
+  const { data: { user }, error: userError } = await supabase.auth.getUser(jwt);
+  if (userError || !user) return [];
+
+  const { data: roleRows, error: roleError } = await supabase
+    .from("fleetops_user_roles")
+    .select("role")
+    .eq("user_id", user.id);
+
+  if (roleError || !roleRows) return [];
+
+  return [...new Set(roleRows.map((row) => row.role).filter(Boolean))];
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    if (req.method !== "GET" && req.method !== "POST") {
+      return new Response(
+        JSON.stringify({ error: "Method not allowed." }),
+        {
+          status: 405,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseServiceRole =
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ||
+      Deno.env.get("SUPABASE_ANON_KEY");
+    const publicSupabaseOrigin =
+      toOrigin(Deno.env.get("FLEETOPS_PUBLIC_SUPABASE_URL")) ||
+      toOrigin(Deno.env.get("PUBLIC_SUPABASE_URL")) ||
+      toOrigin(Deno.env.get("SUPABASE_PUBLIC_URL")) ||
+      toOrigin(Deno.env.get("SITE_URL")) ||
+      toOrigin(req.url) ||
+      toOrigin(supabaseUrl);
+
+    if (!supabaseUrl || !supabaseServiceRole) {
+      throw new Error("Supabase environment variables are not configured.");
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseServiceRole);
+
+    const url = new URL(req.url);
+    const proxyImageUrl = url.searchParams.get("proxy_image_url")?.trim();
+    if (proxyImageUrl) {
+      const { bucket, objectPath } = parsePublicStoragePath(
+        proxyImageUrl,
+        url.origin,
+      );
+      const { data: fileData, error: downloadError } = await supabase.storage
+        .from(bucket)
+        .download(objectPath);
+
+      if (downloadError || !fileData) {
+        return new Response(
+          JSON.stringify({
+            error: `Unable to proxy image: ${downloadError?.message || "file not found"}.`,
+          }),
+          {
+            status: 404,
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      return new Response(fileData.stream(), {
+        headers: {
+          ...corsHeaders,
+          "Content-Type": fileData.type || "application/octet-stream",
+          "Cache-Control": "public, max-age=3600",
+        },
+      });
+    }
+
+    const requestBody =
+      req.method === "POST"
+        ? await req.json().catch(() => ({}))
+        : {};
+
+    const shopSlug = (
+      url.searchParams.get("shop") ||
+      url.searchParams.get("shop_slug") ||
+      (typeof requestBody.shopSlug === "string" ? requestBody.shopSlug : "") ||
+      (typeof requestBody.shop === "string" ? requestBody.shop : "") ||
+      ""
+    ).trim();
+
+    if (!shopSlug) {
+      return new Response(
+        JSON.stringify({
+          error: "Missing required query parameter: shop (shop slug).",
+        }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    const requestedStart = parseDateParam(
+      url.searchParams.get("start") ??
+        (typeof requestBody.start === "string" ? requestBody.start : null) ??
+        (typeof requestBody.startDate === "string"
+          ? requestBody.startDate
+          : null),
+      "start"
+    );
+    const requestedEnd = parseDateParam(
+      url.searchParams.get("end") ??
+        (typeof requestBody.end === "string" ? requestBody.end : null) ??
+        (typeof requestBody.endDate === "string" ? requestBody.endDate : null),
+      "end"
+    );
+
+    if ((requestedStart && !requestedEnd) || (!requestedStart && requestedEnd)) {
+      return new Response(
+        JSON.stringify({
+          error:
+            "Both start and end must be provided together for date/time availability filtering.",
+        }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    if (
+      requestedStart &&
+      requestedEnd &&
+      requestedStart.getTime() > requestedEnd.getTime()
+    ) {
+      return new Response(
+        JSON.stringify({
+          error: "start must be before or equal to end.",
+        }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    const { data: shop, error: shopError } = await supabase
+      .from("fleetops_shops")
+      .select(
+        "id, slug, name, description, logo_url, location, widget_config"
+      )
+      .eq("slug", shopSlug)
+      .single();
+
+    if (shopError || !shop) {
+      return new Response(
+        JSON.stringify({
+          error: `Shop not found for slug "${shopSlug}".`,
+        }),
+        {
+          status: 404,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    const callerRoles = await resolveCallerRoles(
+      supabase,
+      req.headers.get("Authorization")
+    );
+    const viewer = createWidgetViewer(
+      resolveWidgetCheckoutMode(shop.widget_config),
+      callerRoles
+    );
+
+    let equipmentQuery = supabase
+      .from("fleetops_equipment")
+      .select(
+        "id, shop_id, name, category, subcategory, description, price_per_day, price_per_hour, price_per_week, damage_deposit, image_url, rating, review_count, status, is_featured, visible, location, specifications, availability, created_at, updated_at, equipment_images:fleetops_equipment_images(image_url, display_order), pricing_options:fleetops_pricing_options(id, duration, price)"
+      )
+      .eq("shop_id", shop.id);
+
+    equipmentQuery = equipmentQuery.eq("visible", true);
+
+    const { data: equipmentRows, error: equipmentError } = await equipmentQuery
+      .order("is_featured", { ascending: false })
+      .order("created_at", { ascending: false });
+
+    if (equipmentError) throw equipmentError;
+
+    const equipment = equipmentRows ?? [];
+    const equipmentIds = equipment.map((row) => row.id);
+
+    const now = new Date();
+    const today = toDateString(now);
+    const requestedStartDate = requestedStart
+      ? toDateString(requestedStart)
+      : today;
+    const requestedEndDate = requestedEnd ? toDateString(requestedEnd) : today;
+
+    const availabilityWindowStart = requestedStartDate;
+    // Always fetch a forward horizon so nextAvailableDate can be computed
+    // correctly even when there are back-to-back bookings beyond requested_end.
+    const availabilityWindowEnd = toDateString(
+      addDays(requestedStart ?? now, 365)
+    );
+
+    let bookingsByEquipment = new Map<
+      string,
+      Array<{
+        id: string;
+        equipment_id: string;
+        start_date: string;
+        end_date: string;
+        status: string;
+      }>
+    >();
+
+    if (equipmentIds.length > 0) {
+      const { data: bookings, error: bookingsError } = await supabase
+        .from("fleetops_bookings")
+        .select("id, equipment_id, start_date, end_date, status, created_at")
+        .eq("shop_id", shop.id)
+        .in("equipment_id", equipmentIds)
+        .in("status", BLOCKING_BOOKING_STATUSES)
+        .lte("start_date", availabilityWindowEnd)
+        .gte("end_date", availabilityWindowStart)
+        .order("start_date", { ascending: true });
+
+      if (bookingsError) throw bookingsError;
+
+      bookingsByEquipment = (bookings ?? [])
+        .filter((booking) => isBlockingBooking(booking))
+        .reduce((acc, booking) => {
+        const existing = acc.get(booking.equipment_id) ?? [];
+        existing.push(booking);
+        acc.set(booking.equipment_id, existing);
+        return acc;
+      }, new Map());
+    }
+
+    const { data: addOnRows, error: addOnError } = await supabase
+      .from("fleetops_add_ons")
+      .select("id, shop_id, name, category, image_url, price_per_day")
+      .eq("shop_id", shop.id)
+      .order("category")
+      .order("name");
+
+    if (addOnError) throw addOnError;
+
+    const gear = equipment.map((row) => {
+      const primaryImage = toPublicImageUrl(row.image_url, publicSupabaseOrigin);
+      const normalizedImageList = Array.isArray(row.equipment_images)
+        ? [...row.equipment_images]
+            .sort((a, b) => (a.display_order ?? 0) - (b.display_order ?? 0))
+            .map((img) => toPublicImageUrl(img.image_url, publicSupabaseOrigin))
+            .filter((url) => !!url)
+        : [];
+      const images =
+        normalizedImageList.length > 0
+          ? normalizedImageList
+          : primaryImage
+          ? [primaryImage]
+          : [];
+
+      const pricingOptions = Array.isArray(row.pricing_options)
+        ? row.pricing_options.map((opt) => ({
+            id: opt.id,
+            duration: opt.duration,
+            price: Number(opt.price ?? 0),
+          }))
+        : [];
+
+      const bookings = bookingsByEquipment.get(row.id) ?? [];
+
+      const hasRequestedConflict = bookings.some((booking) =>
+        overlaps(
+          booking.start_date,
+          booking.end_date,
+          requestedStartDate,
+          requestedEndDate
+        )
+      );
+
+      const nextAvailableDate = computeNextAvailableDate(
+        bookings,
+        requestedStartDate
+      );
+
+      const normalizedAvailability = safeJson(row.availability);
+      const location = resolveLocation(row.location, shop.location);
+      const specs = safeJson(row.specifications);
+      const availableByStatus = row.status === "available";
+      const available = availableByStatus && !hasRequestedConflict;
+
+      return {
+        id: row.id,
+        shop_id: row.shop_id,
+        name: row.name,
+        category: row.category,
+        subcategory: row.subcategory,
+        description: row.description ?? "",
+        image_url: images[0] ?? primaryImage,
+        images,
+        price_per_day: Number(row.price_per_day ?? 0),
+        price_per_hour:
+          row.price_per_hour !== null && row.price_per_hour !== undefined
+            ? Number(row.price_per_hour)
+            : null,
+        price_per_week:
+          row.price_per_week !== null && row.price_per_week !== undefined
+            ? Number(row.price_per_week)
+            : null,
+        damage_deposit:
+          row.damage_deposit !== null && row.damage_deposit !== undefined
+            ? Number(row.damage_deposit)
+            : null,
+        rating: Number(row.rating ?? 0),
+        review_count: Number(row.review_count ?? 0),
+        status: row.status ?? "available",
+        is_featured: !!row.is_featured,
+        visible: !!row.visible,
+        visible_on_map: !!row.visible,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+        distance: null,
+        location,
+        specifications: {
+          size: String(specs.size ?? ""),
+          weight: String(specs.weight ?? ""),
+          material: String(specs.material ?? ""),
+          suitable: String(specs.suitable ?? ""),
+          details: String(specs.details ?? ""),
+          booking_story: String(
+            specs.booking_story ?? specs.bookingStory ?? ""
+          ),
+        },
+        pricing_options: pricingOptions,
+        owner: {
+          id: shop.id,
+          name: shop.name,
+          slug: shop.slug,
+          logo_url: shop.logo_url ?? null,
+          imageUrl: shop.logo_url ?? null,
+          rating: 0,
+          reviewCount: 0,
+          responseRate: 0,
+          shopId: shop.id,
+          partyId: null,
+        },
+        availability: {
+          available,
+          available_by_status: availableByStatus,
+          has_requested_conflict: hasRequestedConflict,
+          nextAvailableDate:
+            normalizedAvailability.nextAvailableDate ??
+            normalizedAvailability.next_available_date ??
+            nextAvailableDate,
+          next_available_date:
+            normalizedAvailability.nextAvailableDate ??
+            normalizedAvailability.next_available_date ??
+            nextAvailableDate,
+          requested_start: requestedStartDate,
+          requested_end: requestedEndDate,
+        },
+        booked_ranges: bookings.map((booking) => ({
+          booking_id: booking.id,
+          status: booking.status,
+          start_date: booking.start_date,
+          end_date: booking.end_date,
+          start_at: `${booking.start_date}T00:00:00.000Z`,
+          end_at: `${booking.end_date}T23:59:59.999Z`,
+          all_day: true,
+        })),
+      };
+    });
+
+    return new Response(
+      JSON.stringify({
+        fetched_at: new Date().toISOString(),
+        shop: {
+          id: shop.id,
+          slug: shop.slug,
+          name: shop.name,
+          description: shop.description,
+          logo_url: shop.logo_url,
+          location: normalizeLocation(shop.location),
+          widget_config: safeJson(shop.widget_config),
+        },
+        viewer,
+        filters: {
+          requested_start: requestedStartDate,
+          requested_end: requestedEndDate,
+          availability_window_start: availabilityWindowStart,
+          availability_window_end: availabilityWindowEnd,
+          include_hidden: false,
+        },
+        add_ons: (addOnRows ?? []).map((row) => ({
+          id: row.id,
+          shop_id: row.shop_id,
+          name: row.name,
+          category: row.category,
+          image_url: row.image_url,
+          price_per_day: Number(row.price_per_day ?? 0),
+        })),
+        total: gear.length,
+        gear,
+      }),
+      {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      }
+    );
+  } catch (error) {
+    return new Response(
+      JSON.stringify({
+        error: error?.message ?? "Failed to load shop gear feed.",
+      }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      }
+    );
+  }
+});

--- a/supabase/functions/fleetops-stripe-webhook/index.ts
+++ b/supabase/functions/fleetops-stripe-webhook/index.ts
@@ -1,0 +1,280 @@
+import Stripe from "https://esm.sh/stripe@17?target=deno";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const stripe = new Stripe(Deno.env.get("FLEETOPS_STRIPE_SECRET_KEY") || Deno.env.get("STRIPE_SECRET_KEY")!, {
+  apiVersion: "2024-12-18.acacia",
+});
+
+const supabase = createClient(
+  Deno.env.get("SUPABASE_URL")!,
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
+);
+
+const SENDGRID_API_KEY = Deno.env.get("FLEETOPS_SENDGRID_API_KEY") || Deno.env.get("SENDGRID_API_KEY");
+const FROM_EMAIL = Deno.env.get("FLEETOPS_FROM_EMAIL") || Deno.env.get("FROM_EMAIL") || "bookings@demostoke.com";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, stripe-signature",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+function buildEmailHtml(booking: any, equipment: any, shop: any): string {
+  const confirmationNumber = booking.id.slice(0, 8).toUpperCase();
+
+  return `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 0; background: #f5f5f5; }
+    .container { max-width: 560px; margin: 0 auto; background: #fff; border-radius: 12px; overflow: hidden; }
+    .header { background: #2563eb; color: #fff; padding: 24px; text-align: center; }
+    .content { padding: 24px; }
+    .detail-row { display: flex; justify-content: space-between; padding: 8px 0; border-bottom: 1px solid #eee; font-size: 14px; }
+    .total-row { font-weight: bold; font-size: 16px; border-top: 2px solid #333; padding-top: 12px; margin-top: 8px; }
+    .footer { padding: 16px 24px; background: #f9fafb; text-align: center; font-size: 12px; color: #888; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <h1 style="margin:0;font-size:20px;">Booking Confirmed!</h1>
+      <p style="margin:8px 0 0;opacity:0.9;font-size:14px;">${shop.name}</p>
+    </div>
+    <div class="content">
+      <p style="font-size:14px;color:#666;">Hi ${booking.customer_name},</p>
+      <p style="font-size:14px;color:#666;">Your gear rental reservation has been confirmed. Here are your booking details:</p>
+
+      <div style="background:#f9fafb;border-radius:8px;padding:16px;margin:16px 0;">
+        <p style="margin:0 0 4px;font-size:12px;color:#888;">Confirmation #</p>
+        <p style="margin:0;font-size:18px;font-weight:bold;font-family:monospace;">${confirmationNumber}</p>
+      </div>
+
+      ${equipment.image_url ? `<img src="${equipment.image_url}" alt="${equipment.name}" style="width:100%;height:200px;object-fit:cover;border-radius:8px;margin-bottom:16px;">` : ""}
+
+      <h3 style="font-size:16px;margin:0 0 12px;">${equipment.name}</h3>
+
+      <div class="detail-row">
+        <span style="color:#666;">Dates</span>
+        <span>${booking.start_date} to ${booking.end_date}</span>
+      </div>
+      <div class="detail-row">
+        <span style="color:#666;">Duration</span>
+        <span>${booking.num_days} day${booking.num_days !== 1 ? "s" : ""}</span>
+      </div>
+      <div class="detail-row">
+        <span style="color:#666;">Base rental</span>
+        <span>$${Number(booking.base_price).toFixed(2)}</span>
+      </div>
+      ${Number(booking.add_ons_price) > 0 ? `
+      <div class="detail-row">
+        <span style="color:#666;">Add-ons</span>
+        <span>$${Number(booking.add_ons_price).toFixed(2)}</span>
+      </div>` : ""}
+      ${Number(booking.service_fee) > 0 ? `
+      <div class="detail-row">
+        <span style="color:#666;">Service fee</span>
+        <span>$${Number(booking.service_fee).toFixed(2)}</span>
+      </div>` : ""}
+      ${Number(booking.damage_deposit) > 0 ? `
+      <div class="detail-row">
+        <span style="color:#666;">Damage deposit</span>
+        <span>$${Number(booking.damage_deposit).toFixed(2)}</span>
+      </div>` : ""}
+      <div class="detail-row total-row">
+        <span>Total</span>
+        <span>$${Number(booking.total_price).toFixed(2)}</span>
+      </div>
+    </div>
+    <div class="footer">
+      <p>Questions? Contact ${shop.contact_email || shop.name}</p>
+      <p>Powered by DemoStoke</p>
+    </div>
+  </div>
+</body>
+</html>`;
+}
+
+async function sendBookingEmail(bookingId: string) {
+  if (!SENDGRID_API_KEY) {
+    console.warn("SENDGRID_API_KEY is not configured; skipping booking email.");
+    return;
+  }
+
+  const { data: booking, error: bookingError } = await supabase
+    .from("fleetops_bookings")
+    .select("*")
+    .eq("id", bookingId)
+    .single();
+
+  if (bookingError || !booking) {
+    console.error("Failed to load booking for email:", bookingError);
+    return;
+  }
+
+  const [{ data: equipment }, { data: shop }] = await Promise.all([
+    supabase.from("fleetops_equipment").select("*").eq("id", booking.equipment_id).single(),
+    supabase.from("fleetops_shops").select("*").eq("id", booking.shop_id).single(),
+  ]);
+
+  if (!equipment || !shop) {
+    console.error("Unable to load equipment or shop for booking email:", bookingId);
+    return;
+  }
+
+  const emailHtml = buildEmailHtml(booking, equipment, shop);
+
+  const response = await fetch("https://api.sendgrid.com/v3/mail/send", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${SENDGRID_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      personalizations: [
+        { to: [{ email: booking.customer_email, name: booking.customer_name }] },
+      ],
+      from: { email: FROM_EMAIL, name: shop.name },
+      subject: `Booking Confirmed - ${equipment.name}`,
+      content: [{ type: "text/html", value: emailHtml }],
+    }),
+  });
+
+  if (!response.ok) {
+    console.error("SendGrid booking email failed:", await response.text());
+  }
+}
+
+async function resolveBookingId(paymentIntent: Stripe.PaymentIntent) {
+  const metadataBookingId =
+    typeof paymentIntent.metadata?.bookingId === "string"
+      ? paymentIntent.metadata.bookingId
+      : null;
+
+  if (metadataBookingId) {
+    return metadataBookingId;
+  }
+
+  const { data: booking } = await supabase
+    .from("fleetops_bookings")
+    .select("id")
+    .eq("stripe_payment_intent_id", paymentIntent.id)
+    .single();
+
+  return booking?.id ?? null;
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, {
+      status: 200,
+      headers: corsHeaders,
+    });
+  }
+
+  const signature = req.headers.get("stripe-signature");
+  const body = await req.text();
+
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(
+      body,
+      signature!,
+      Deno.env.get("FLEETOPS_STRIPE_WEBHOOK_SECRET") || Deno.env.get("STRIPE_WEBHOOK_SECRET")!
+    );
+  } catch (err) {
+    return new Response(`Webhook Error: ${err.message}`, {
+      status: 400,
+      headers: corsHeaders,
+    });
+  }
+
+  if (event.type === "payment_intent.succeeded") {
+    const paymentIntent = event.data.object as Stripe.PaymentIntent;
+    const bookingId = await resolveBookingId(paymentIntent);
+
+    if (bookingId) {
+      const { data: confirmedBooking, error } = await supabase
+        .from("fleetops_bookings")
+        .update({
+          status: "confirmed",
+          stripe_charge_id:
+            typeof paymentIntent.latest_charge === "string"
+              ? paymentIntent.latest_charge
+              : paymentIntent.latest_charge?.id ?? null,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", bookingId)
+        .eq("status", "pending")
+        .select("id")
+        .maybeSingle();
+
+      if (error) {
+        console.error("Failed to update booking:", error);
+      } else if (confirmedBooking) {
+        await sendBookingEmail(bookingId);
+      }
+    } else {
+      console.error("No booking found for payment intent:", paymentIntent.id);
+    }
+  }
+
+  if (
+    event.type === "payment_intent.payment_failed" ||
+    event.type === "payment_intent.canceled"
+  ) {
+    const paymentIntent = event.data.object as Stripe.PaymentIntent;
+    const bookingId = await resolveBookingId(paymentIntent);
+
+    if (bookingId) {
+      const { error } = await supabase
+        .from("fleetops_bookings")
+        .update({
+          status: "cancelled",
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", bookingId)
+        .eq("status", "pending");
+
+      if (error) {
+        console.error("Failed to cancel pending booking:", error);
+      }
+    }
+  }
+
+  if (event.type === "charge.refunded") {
+    const charge = event.data.object as Stripe.Charge;
+    const latestRefund = charge.refunds.data.at(-1) ?? null;
+    const paymentIntentId =
+      typeof charge.payment_intent === "string"
+        ? charge.payment_intent
+        : charge.payment_intent?.id ?? null;
+
+    let query = supabase
+      .from("fleetops_bookings")
+      .update({
+        status: charge.refunded ? "refunded" : "confirmed",
+        stripe_charge_id: charge.id,
+        stripe_refund_id: latestRefund?.id ?? null,
+        refunded_at: charge.refunded ? new Date().toISOString() : null,
+        updated_at: new Date().toISOString(),
+      });
+
+    query = paymentIntentId
+      ? query.eq("stripe_payment_intent_id", paymentIntentId)
+      : query.eq("stripe_charge_id", charge.id);
+
+    const { error } = await query;
+
+    if (error) {
+      console.error("Failed to update refunded booking:", error);
+    }
+  }
+
+  return new Response(JSON.stringify({ received: true }), {
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+});

--- a/supabase/migrations/20260608130000_import_fleetops_prefixed_schema.sql
+++ b/supabase/migrations/20260608130000_import_fleetops_prefixed_schema.sql
@@ -1,0 +1,664 @@
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_type t
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE n.nspname = 'public'
+      AND t.typname = 'fleetops_app_role'
+  ) THEN
+    CREATE TYPE public.fleetops_app_role AS ENUM ('shop', 'admin', 'guest');
+  END IF;
+END;
+$$;
+
+CREATE TABLE IF NOT EXISTS public.fleetops_shops (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_id uuid NOT NULL,
+  name text NOT NULL,
+  slug text NOT NULL UNIQUE,
+  description text,
+  logo_url text,
+  website_url text,
+  contact_email text,
+  contact_phone text,
+  location jsonb,
+  widget_config jsonb DEFAULT '{}'::jsonb,
+  stripe_account_id text,
+  created_at timestamp with time zone DEFAULT now(),
+  updated_at timestamp with time zone DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_fleetops_shops_owner_unique
+  ON public.fleetops_shops(owner_id);
+CREATE INDEX IF NOT EXISTS idx_fleetops_shops_owner
+  ON public.fleetops_shops(owner_id);
+CREATE INDEX IF NOT EXISTS idx_fleetops_shops_slug
+  ON public.fleetops_shops(slug);
+
+CREATE TABLE IF NOT EXISTS public.fleetops_user_roles (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL,
+  role public.fleetops_app_role NOT NULL,
+  assigned_by uuid,
+  assigned_at timestamp with time zone NOT NULL DEFAULT now(),
+  UNIQUE (user_id, role)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fleetops_user_roles_user_id
+  ON public.fleetops_user_roles(user_id);
+
+CREATE TABLE IF NOT EXISTS public.fleetops_shop_viewers (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  viewer_user_id uuid NOT NULL,
+  shop_id uuid NOT NULL REFERENCES public.fleetops_shops(id) ON DELETE CASCADE,
+  UNIQUE (viewer_user_id, shop_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fleetops_shop_viewers_viewer
+  ON public.fleetops_shop_viewers(viewer_user_id);
+
+CREATE TABLE IF NOT EXISTS public.fleetops_equipment (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  shop_id uuid NOT NULL REFERENCES public.fleetops_shops(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  category text NOT NULL,
+  subcategory text,
+  description text,
+  price_per_day numeric(10,2) NOT NULL,
+  price_per_hour numeric(10,2),
+  price_per_week numeric(10,2),
+  damage_deposit numeric(10,2),
+  image_url text,
+  rating numeric(3,2) DEFAULT 0,
+  review_count integer DEFAULT 0,
+  status text DEFAULT 'available'::text,
+  is_featured boolean DEFAULT false,
+  visible boolean DEFAULT true,
+  location jsonb,
+  specifications jsonb DEFAULT '{}'::jsonb,
+  availability jsonb DEFAULT '{"available": true}'::jsonb,
+  created_at timestamp with time zone DEFAULT now(),
+  updated_at timestamp with time zone DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_fleetops_equipment_category
+  ON public.fleetops_equipment(category);
+CREATE INDEX IF NOT EXISTS idx_fleetops_equipment_shop
+  ON public.fleetops_equipment(shop_id);
+
+CREATE TABLE IF NOT EXISTS public.fleetops_equipment_images (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  equipment_id uuid NOT NULL REFERENCES public.fleetops_equipment(id) ON DELETE CASCADE,
+  image_url text NOT NULL,
+  display_order integer DEFAULT 0,
+  created_at timestamp with time zone DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_fleetops_equipment_images_equip
+  ON public.fleetops_equipment_images(equipment_id);
+
+CREATE TABLE IF NOT EXISTS public.fleetops_pricing_options (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  equipment_id uuid NOT NULL REFERENCES public.fleetops_equipment(id) ON DELETE CASCADE,
+  duration text NOT NULL,
+  price numeric(10,2) NOT NULL,
+  created_at timestamp with time zone DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_fleetops_pricing_options_equip
+  ON public.fleetops_pricing_options(equipment_id);
+
+CREATE TABLE IF NOT EXISTS public.fleetops_add_ons (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  shop_id uuid NOT NULL REFERENCES public.fleetops_shops(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  category text NOT NULL,
+  image_url text,
+  price_per_day numeric(10,2) NOT NULL,
+  created_at timestamp with time zone DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_fleetops_add_ons_shop
+  ON public.fleetops_add_ons(shop_id);
+
+CREATE TABLE IF NOT EXISTS public.fleetops_bookings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  shop_id uuid NOT NULL REFERENCES public.fleetops_shops(id) ON DELETE CASCADE,
+  equipment_id uuid NOT NULL REFERENCES public.fleetops_equipment(id),
+  customer_name text NOT NULL,
+  customer_email text NOT NULL,
+  customer_phone text,
+  start_date date NOT NULL,
+  end_date date NOT NULL,
+  num_days integer NOT NULL,
+  base_price numeric(10,2) NOT NULL,
+  add_ons_price numeric(10,2) DEFAULT 0,
+  damage_deposit numeric(10,2) DEFAULT 0,
+  service_fee numeric(10,2) DEFAULT 0,
+  total_price numeric(10,2) NOT NULL,
+  status text DEFAULT 'pending'::text,
+  stripe_payment_intent_id text,
+  stripe_charge_id text,
+  add_ons_snapshot jsonb DEFAULT '[]'::jsonb,
+  notes text,
+  created_at timestamp with time zone DEFAULT now(),
+  updated_at timestamp with time zone DEFAULT now(),
+  stripe_refund_id text,
+  refunded_at timestamp with time zone
+);
+
+CREATE INDEX IF NOT EXISTS idx_fleetops_bookings_dates
+  ON public.fleetops_bookings(start_date, end_date);
+CREATE INDEX IF NOT EXISTS idx_fleetops_bookings_equipment
+  ON public.fleetops_bookings(equipment_id);
+CREATE INDEX IF NOT EXISTS idx_fleetops_bookings_shop
+  ON public.fleetops_bookings(shop_id);
+
+CREATE TABLE IF NOT EXISTS public.fleetops_pos_connections (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  shop_id uuid NOT NULL REFERENCES public.fleetops_shops(id) ON DELETE CASCADE,
+  provider text NOT NULL,
+  is_connected boolean DEFAULT false,
+  credentials jsonb DEFAULT '{}'::jsonb,
+  last_sync_at timestamp with time zone,
+  field_mapping jsonb DEFAULT '{}'::jsonb,
+  created_at timestamp with time zone DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_fleetops_pos_connections_shop
+  ON public.fleetops_pos_connections(shop_id);
+
+CREATE TABLE IF NOT EXISTS public.fleetops_lightspeed_inventory_items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  shop_id uuid NOT NULL REFERENCES public.fleetops_shops(id) ON DELETE CASCADE,
+  owner_id uuid NOT NULL,
+  pos_connection_id uuid NOT NULL REFERENCES public.fleetops_pos_connections(id) ON DELETE CASCADE,
+  mock_shop_id text NOT NULL,
+  item_id text NOT NULL,
+  description text NOT NULL,
+  category text NOT NULL,
+  manufacturer text,
+  price numeric(10,2) NOT NULL,
+  image_url text NOT NULL,
+  location jsonb DEFAULT '{}'::jsonb,
+  booking_story text NOT NULL DEFAULT ''::text,
+  raw_payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  UNIQUE (pos_connection_id, item_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fleetops_lightspeed_inventory_items_mock_shop
+  ON public.fleetops_lightspeed_inventory_items(shop_id, mock_shop_id);
+CREATE INDEX IF NOT EXISTS idx_fleetops_lightspeed_inventory_items_owner
+  ON public.fleetops_lightspeed_inventory_items(owner_id);
+CREATE INDEX IF NOT EXISTS idx_fleetops_lightspeed_inventory_items_shop
+  ON public.fleetops_lightspeed_inventory_items(shop_id);
+
+CREATE TABLE IF NOT EXISTS public.fleetops_booqable_inventory_items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  shop_id uuid NOT NULL REFERENCES public.fleetops_shops(id) ON DELETE CASCADE,
+  owner_id uuid NOT NULL,
+  pos_connection_id uuid NOT NULL REFERENCES public.fleetops_pos_connections(id) ON DELETE CASCADE,
+  mock_shop_id text NOT NULL,
+  product_id text NOT NULL,
+  name text NOT NULL,
+  base_price_in_cents integer NOT NULL,
+  photo_url text NOT NULL,
+  product_type text NOT NULL DEFAULT 'rental'::text,
+  group_name text NOT NULL,
+  description text,
+  sku text,
+  location jsonb DEFAULT '{}'::jsonb,
+  booking_story text NOT NULL DEFAULT ''::text,
+  raw_payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  UNIQUE (pos_connection_id, product_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fleetops_booqable_inventory_items_mock_shop
+  ON public.fleetops_booqable_inventory_items(shop_id, mock_shop_id);
+CREATE INDEX IF NOT EXISTS idx_fleetops_booqable_inventory_items_owner
+  ON public.fleetops_booqable_inventory_items(owner_id);
+CREATE INDEX IF NOT EXISTS idx_fleetops_booqable_inventory_items_shop
+  ON public.fleetops_booqable_inventory_items(shop_id);
+
+CREATE TABLE IF NOT EXISTS public.fleetops_pos_inventory_seed_runs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  source text NOT NULL CHECK (source = ANY (ARRAY['cron'::text, 'manual'::text])),
+  status text NOT NULL CHECK (status = ANY (ARRAY['running'::text, 'success'::text, 'error'::text])),
+  target_shop_id uuid REFERENCES public.fleetops_shops(id) ON DELETE SET NULL,
+  target_owner_id uuid,
+  lightspeed_pos_connection_id uuid REFERENCES public.fleetops_pos_connections(id) ON DELETE SET NULL,
+  booqable_pos_connection_id uuid REFERENCES public.fleetops_pos_connections(id) ON DELETE SET NULL,
+  mock_shop_id text,
+  generated_sequence integer NOT NULL,
+  lightspeed_item_id text,
+  booqable_product_id text,
+  lightspeed_inventory_item_id uuid REFERENCES public.fleetops_lightspeed_inventory_items(id) ON DELETE SET NULL,
+  booqable_inventory_item_id uuid REFERENCES public.fleetops_booqable_inventory_items(id) ON DELETE SET NULL,
+  verification_counts jsonb NOT NULL DEFAULT '{}'::jsonb,
+  error_message text,
+  raw_result jsonb NOT NULL DEFAULT '{}'::jsonb,
+  started_at timestamp with time zone NOT NULL DEFAULT now(),
+  completed_at timestamp with time zone,
+  created_at timestamp with time zone NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_fleetops_pos_inventory_seed_runs_sequence
+  ON public.fleetops_pos_inventory_seed_runs(generated_sequence);
+CREATE INDEX IF NOT EXISTS idx_fleetops_pos_inventory_seed_runs_status_created
+  ON public.fleetops_pos_inventory_seed_runs(status, created_at DESC);
+
+CREATE OR REPLACE FUNCTION public.fleetops_is_admin(
+  target_user_id uuid DEFAULT auth.uid()
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  SELECT COALESCE(public.is_admin(target_user_id), false)
+    OR EXISTS (
+      SELECT 1
+      FROM public.fleetops_user_roles ur
+      WHERE ur.user_id = target_user_id
+        AND ur.role = 'admin'::public.fleetops_app_role
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION public.fleetops_is_shop_viewer(
+  target_shop_id uuid
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.fleetops_shop_viewers sv
+    WHERE sv.viewer_user_id = auth.uid()
+      AND sv.shop_id = target_shop_id
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.fleetops_set_pos_inventory_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public', 'pg_temp'
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS set_fleetops_lightspeed_inventory_items_updated_at
+  ON public.fleetops_lightspeed_inventory_items;
+CREATE TRIGGER set_fleetops_lightspeed_inventory_items_updated_at
+BEFORE UPDATE ON public.fleetops_lightspeed_inventory_items
+FOR EACH ROW
+EXECUTE FUNCTION public.fleetops_set_pos_inventory_updated_at();
+
+DROP TRIGGER IF EXISTS set_fleetops_booqable_inventory_items_updated_at
+  ON public.fleetops_booqable_inventory_items;
+CREATE TRIGGER set_fleetops_booqable_inventory_items_updated_at
+BEFORE UPDATE ON public.fleetops_booqable_inventory_items
+FOR EACH ROW
+EXECUTE FUNCTION public.fleetops_set_pos_inventory_updated_at();
+
+GRANT EXECUTE ON FUNCTION public.fleetops_is_admin(uuid) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.fleetops_is_shop_viewer(uuid) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.fleetops_set_pos_inventory_updated_at() TO anon, authenticated, service_role;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fleetops_shops TO authenticated, service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fleetops_user_roles TO authenticated, service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fleetops_shop_viewers TO authenticated, service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fleetops_equipment TO authenticated, service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fleetops_equipment_images TO authenticated, service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fleetops_pricing_options TO authenticated, service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fleetops_add_ons TO authenticated, service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fleetops_bookings TO authenticated, service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fleetops_pos_connections TO authenticated, service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fleetops_lightspeed_inventory_items TO authenticated, service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fleetops_booqable_inventory_items TO authenticated, service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fleetops_pos_inventory_seed_runs TO authenticated, service_role;
+
+ALTER TABLE public.fleetops_shops ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.fleetops_user_roles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.fleetops_shop_viewers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.fleetops_equipment ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.fleetops_equipment_images ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.fleetops_pricing_options ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.fleetops_add_ons ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.fleetops_bookings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.fleetops_pos_connections ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.fleetops_lightspeed_inventory_items ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.fleetops_booqable_inventory_items ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.fleetops_pos_inventory_seed_runs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "FleetOps admins can view roles" ON public.fleetops_user_roles;
+CREATE POLICY "FleetOps admins can view roles"
+ON public.fleetops_user_roles
+FOR SELECT
+USING (auth.uid() = user_id OR public.fleetops_is_admin());
+
+DROP POLICY IF EXISTS "FleetOps admins can manage roles" ON public.fleetops_user_roles;
+CREATE POLICY "FleetOps admins can manage roles"
+ON public.fleetops_user_roles
+FOR ALL
+USING (public.fleetops_is_admin())
+WITH CHECK (public.fleetops_is_admin());
+
+DROP POLICY IF EXISTS "FleetOps admins can manage shop viewers" ON public.fleetops_shop_viewers;
+CREATE POLICY "FleetOps admins can manage shop viewers"
+ON public.fleetops_shop_viewers
+FOR ALL
+USING (public.fleetops_is_admin())
+WITH CHECK (public.fleetops_is_admin());
+
+DROP POLICY IF EXISTS "FleetOps viewers can read own viewer rows" ON public.fleetops_shop_viewers;
+CREATE POLICY "FleetOps viewers can read own viewer rows"
+ON public.fleetops_shop_viewers
+FOR SELECT
+USING (auth.uid() = viewer_user_id OR public.fleetops_is_admin());
+
+DROP POLICY IF EXISTS "FleetOps shop access" ON public.fleetops_shops;
+CREATE POLICY "FleetOps shop access"
+ON public.fleetops_shops
+FOR SELECT
+USING (auth.uid() = owner_id OR public.fleetops_is_shop_viewer(id) OR public.fleetops_is_admin());
+
+DROP POLICY IF EXISTS "FleetOps shop owners can insert shops" ON public.fleetops_shops;
+CREATE POLICY "FleetOps shop owners can insert shops"
+ON public.fleetops_shops
+FOR INSERT
+WITH CHECK (auth.uid() = owner_id OR public.fleetops_is_admin());
+
+DROP POLICY IF EXISTS "FleetOps shop owners can update shops" ON public.fleetops_shops;
+CREATE POLICY "FleetOps shop owners can update shops"
+ON public.fleetops_shops
+FOR UPDATE
+USING (auth.uid() = owner_id OR public.fleetops_is_admin())
+WITH CHECK (auth.uid() = owner_id OR public.fleetops_is_admin());
+
+DROP POLICY IF EXISTS "FleetOps shop scoped add ons access" ON public.fleetops_add_ons;
+CREATE POLICY "FleetOps shop scoped add ons access"
+ON public.fleetops_add_ons
+FOR SELECT
+USING (
+  shop_id IN (SELECT s.id FROM public.fleetops_shops s WHERE s.owner_id = auth.uid())
+  OR shop_id IN (SELECT sv.shop_id FROM public.fleetops_shop_viewers sv WHERE sv.viewer_user_id = auth.uid())
+  OR public.fleetops_is_admin()
+);
+
+DROP POLICY IF EXISTS "FleetOps shop owners manage add ons" ON public.fleetops_add_ons;
+CREATE POLICY "FleetOps shop owners manage add ons"
+ON public.fleetops_add_ons
+FOR ALL
+USING (
+  shop_id IN (SELECT s.id FROM public.fleetops_shops s WHERE s.owner_id = auth.uid())
+  OR public.fleetops_is_admin()
+)
+WITH CHECK (
+  shop_id IN (SELECT s.id FROM public.fleetops_shops s WHERE s.owner_id = auth.uid())
+  OR public.fleetops_is_admin()
+);
+
+DROP POLICY IF EXISTS "FleetOps shop scoped equipment access" ON public.fleetops_equipment;
+CREATE POLICY "FleetOps shop scoped equipment access"
+ON public.fleetops_equipment
+FOR SELECT
+USING (
+  shop_id IN (SELECT s.id FROM public.fleetops_shops s WHERE s.owner_id = auth.uid())
+  OR shop_id IN (SELECT sv.shop_id FROM public.fleetops_shop_viewers sv WHERE sv.viewer_user_id = auth.uid())
+  OR public.fleetops_is_admin()
+);
+
+DROP POLICY IF EXISTS "FleetOps shop owners manage equipment" ON public.fleetops_equipment;
+CREATE POLICY "FleetOps shop owners manage equipment"
+ON public.fleetops_equipment
+FOR ALL
+USING (
+  shop_id IN (SELECT s.id FROM public.fleetops_shops s WHERE s.owner_id = auth.uid())
+  OR public.fleetops_is_admin()
+)
+WITH CHECK (
+  shop_id IN (SELECT s.id FROM public.fleetops_shops s WHERE s.owner_id = auth.uid())
+  OR public.fleetops_is_admin()
+);
+
+DROP POLICY IF EXISTS "FleetOps shop scoped image access" ON public.fleetops_equipment_images;
+CREATE POLICY "FleetOps shop scoped image access"
+ON public.fleetops_equipment_images
+FOR SELECT
+USING (
+  equipment_id IN (
+    SELECT e.id
+    FROM public.fleetops_equipment e
+    JOIN public.fleetops_shops s ON s.id = e.shop_id
+    WHERE s.owner_id = auth.uid()
+  )
+  OR equipment_id IN (
+    SELECT e.id
+    FROM public.fleetops_equipment e
+    JOIN public.fleetops_shop_viewers sv ON sv.shop_id = e.shop_id
+    WHERE sv.viewer_user_id = auth.uid()
+  )
+  OR public.fleetops_is_admin()
+);
+
+DROP POLICY IF EXISTS "FleetOps shop owners manage images" ON public.fleetops_equipment_images;
+CREATE POLICY "FleetOps shop owners manage images"
+ON public.fleetops_equipment_images
+FOR ALL
+USING (
+  equipment_id IN (
+    SELECT e.id
+    FROM public.fleetops_equipment e
+    JOIN public.fleetops_shops s ON s.id = e.shop_id
+    WHERE s.owner_id = auth.uid()
+  )
+  OR public.fleetops_is_admin()
+)
+WITH CHECK (
+  equipment_id IN (
+    SELECT e.id
+    FROM public.fleetops_equipment e
+    JOIN public.fleetops_shops s ON s.id = e.shop_id
+    WHERE s.owner_id = auth.uid()
+  )
+  OR public.fleetops_is_admin()
+);
+
+DROP POLICY IF EXISTS "FleetOps shop scoped pricing access" ON public.fleetops_pricing_options;
+CREATE POLICY "FleetOps shop scoped pricing access"
+ON public.fleetops_pricing_options
+FOR SELECT
+USING (
+  equipment_id IN (
+    SELECT e.id
+    FROM public.fleetops_equipment e
+    JOIN public.fleetops_shops s ON s.id = e.shop_id
+    WHERE s.owner_id = auth.uid()
+  )
+  OR equipment_id IN (
+    SELECT e.id
+    FROM public.fleetops_equipment e
+    JOIN public.fleetops_shop_viewers sv ON sv.shop_id = e.shop_id
+    WHERE sv.viewer_user_id = auth.uid()
+  )
+  OR public.fleetops_is_admin()
+);
+
+DROP POLICY IF EXISTS "FleetOps shop owners manage pricing" ON public.fleetops_pricing_options;
+CREATE POLICY "FleetOps shop owners manage pricing"
+ON public.fleetops_pricing_options
+FOR ALL
+USING (
+  equipment_id IN (
+    SELECT e.id
+    FROM public.fleetops_equipment e
+    JOIN public.fleetops_shops s ON s.id = e.shop_id
+    WHERE s.owner_id = auth.uid()
+  )
+  OR public.fleetops_is_admin()
+)
+WITH CHECK (
+  equipment_id IN (
+    SELECT e.id
+    FROM public.fleetops_equipment e
+    JOIN public.fleetops_shops s ON s.id = e.shop_id
+    WHERE s.owner_id = auth.uid()
+  )
+  OR public.fleetops_is_admin()
+);
+
+DROP POLICY IF EXISTS "FleetOps shop scoped booking access" ON public.fleetops_bookings;
+CREATE POLICY "FleetOps shop scoped booking access"
+ON public.fleetops_bookings
+FOR SELECT
+USING (
+  shop_id IN (SELECT s.id FROM public.fleetops_shops s WHERE s.owner_id = auth.uid())
+  OR shop_id IN (SELECT sv.shop_id FROM public.fleetops_shop_viewers sv WHERE sv.viewer_user_id = auth.uid())
+  OR public.fleetops_is_admin()
+);
+
+DROP POLICY IF EXISTS "FleetOps shop owners update bookings" ON public.fleetops_bookings;
+CREATE POLICY "FleetOps shop owners update bookings"
+ON public.fleetops_bookings
+FOR UPDATE
+USING (
+  shop_id IN (SELECT s.id FROM public.fleetops_shops s WHERE s.owner_id = auth.uid())
+  OR public.fleetops_is_admin()
+)
+WITH CHECK (
+  shop_id IN (SELECT s.id FROM public.fleetops_shops s WHERE s.owner_id = auth.uid())
+  OR public.fleetops_is_admin()
+);
+
+DROP POLICY IF EXISTS "FleetOps shop scoped pos connections access" ON public.fleetops_pos_connections;
+CREATE POLICY "FleetOps shop scoped pos connections access"
+ON public.fleetops_pos_connections
+FOR SELECT
+USING (
+  shop_id IN (SELECT s.id FROM public.fleetops_shops s WHERE s.owner_id = auth.uid())
+  OR shop_id IN (SELECT sv.shop_id FROM public.fleetops_shop_viewers sv WHERE sv.viewer_user_id = auth.uid())
+  OR public.fleetops_is_admin()
+);
+
+DROP POLICY IF EXISTS "FleetOps shop owners manage pos connections" ON public.fleetops_pos_connections;
+CREATE POLICY "FleetOps shop owners manage pos connections"
+ON public.fleetops_pos_connections
+FOR ALL
+USING (
+  shop_id IN (SELECT s.id FROM public.fleetops_shops s WHERE s.owner_id = auth.uid())
+  OR public.fleetops_is_admin()
+)
+WITH CHECK (
+  shop_id IN (SELECT s.id FROM public.fleetops_shops s WHERE s.owner_id = auth.uid())
+  OR public.fleetops_is_admin()
+);
+
+DROP POLICY IF EXISTS "FleetOps shop owners view lightspeed inventory items" ON public.fleetops_lightspeed_inventory_items;
+CREATE POLICY "FleetOps shop owners view lightspeed inventory items"
+ON public.fleetops_lightspeed_inventory_items
+FOR SELECT
+USING (auth.uid() = owner_id OR public.fleetops_is_admin());
+
+DROP POLICY IF EXISTS "FleetOps shop owners view booqable inventory items" ON public.fleetops_booqable_inventory_items;
+CREATE POLICY "FleetOps shop owners view booqable inventory items"
+ON public.fleetops_booqable_inventory_items
+FOR SELECT
+USING (auth.uid() = owner_id OR public.fleetops_is_admin());
+
+DROP POLICY IF EXISTS "FleetOps shop owners view pos inventory seed runs" ON public.fleetops_pos_inventory_seed_runs;
+CREATE POLICY "FleetOps shop owners view pos inventory seed runs"
+ON public.fleetops_pos_inventory_seed_runs
+FOR SELECT
+USING (auth.uid() = target_owner_id OR public.fleetops_is_admin());
+
+INSERT INTO storage.buckets (id, name, public)
+VALUES
+  ('fleetops-equipment-images', 'fleetops-equipment-images', true),
+  ('fleetops-shop-logos', 'fleetops-shop-logos', true)
+ON CONFLICT (id) DO UPDATE
+SET name = EXCLUDED.name,
+    public = EXCLUDED.public;
+
+DROP POLICY IF EXISTS "FleetOps public read equipment images" ON storage.objects;
+CREATE POLICY "FleetOps public read equipment images"
+ON storage.objects
+FOR SELECT
+USING (bucket_id = 'fleetops-equipment-images');
+
+DROP POLICY IF EXISTS "FleetOps public read shop logos" ON storage.objects;
+CREATE POLICY "FleetOps public read shop logos"
+ON storage.objects
+FOR SELECT
+USING (bucket_id = 'fleetops-shop-logos');
+
+DROP POLICY IF EXISTS "FleetOps shop owners upload equipment images" ON storage.objects;
+CREATE POLICY "FleetOps shop owners upload equipment images"
+ON storage.objects
+FOR INSERT
+WITH CHECK (
+  bucket_id = 'fleetops-equipment-images'
+  AND auth.role() = 'authenticated'
+  AND (
+    split_part(name, '/', 1) IN (
+      SELECT s.id::text
+      FROM public.fleetops_shops s
+      WHERE s.owner_id = auth.uid()
+    )
+    OR public.fleetops_is_admin()
+  )
+);
+
+DROP POLICY IF EXISTS "FleetOps shop owners upload shop logos" ON storage.objects;
+CREATE POLICY "FleetOps shop owners upload shop logos"
+ON storage.objects
+FOR INSERT
+WITH CHECK (
+  bucket_id = 'fleetops-shop-logos'
+  AND auth.role() = 'authenticated'
+  AND (
+    split_part(name, '/', 1) IN (
+      SELECT s.id::text
+      FROM public.fleetops_shops s
+      WHERE s.owner_id = auth.uid()
+    )
+    OR public.fleetops_is_admin()
+  )
+);
+
+DO $$
+DECLARE
+  v_job_id bigint;
+BEGIN
+  SELECT jobid
+  INTO v_job_id
+  FROM cron.job
+  WHERE jobname = 'fleetops-pos-inventory-seed-2am-pt'
+  LIMIT 1;
+
+  IF v_job_id IS NOT NULL THEN
+    PERFORM cron.unschedule(v_job_id);
+  END IF;
+END;
+$$;
+
+UPDATE public.fleetops_pos_inventory_seed_config
+SET enabled = false,
+    fleetops_function_url = 'https://qtlhqsqanbxgfbcjigrl.supabase.co/functions/v1/fleetops-seed-pos-inventory',
+    updated_at = now()
+WHERE id = true;
+
+DROP FUNCTION IF EXISTS public.trigger_fleetops_pos_inventory_seed_cron(boolean);


### PR DESCRIPTION
## Summary

Imports the FleetOps database, storage, and Edge Function surface into the linked main DemoStoke Supabase project using isolated `fleetops_` database objects and `fleetops-` storage/function names. The old cross-project FleetOps POS seed cron in main DemoStoke is retired so main no longer posts scheduled seed jobs into the separate FleetOps project.

The import preserves FleetOps public table UUIDs and current rows, rewrites FleetOps storage URLs to the new main DemoStoke buckets, deploys the prefixed Edge Functions, and keeps FleetOps auth users out of the migration. Main DemoStoke admins can administer imported FleetOps data through the new `fleetops_is_admin()` bridge.

## Changes

- `supabase/migrations/20260608130000_import_fleetops_prefixed_schema.sql` — creates `fleetops_app_role`, 12 prefixed FleetOps tables, indexes, RLS policies, helper RPCs, public FleetOps storage buckets, and retires `fleetops-pos-inventory-seed-2am-pt` / `trigger_fleetops_pos_inventory_seed_cron(boolean)`.
- `supabase/functions/fleetops-*` — adds prefixed FleetOps Edge Functions for shop creation, analytics, Stripe payment/refund/webhook handling, booking email, shop feed, and POS inventory seeding.
- `supabase/functions/_shared/fleetopsWidgetCheckout.ts` — vendors the FleetOps widget checkout helper used by imported functions.
- `supabase/config.toml` — configures verify-JWT behavior for the new prefixed functions.
- `src/integrations/supabase/types.ts` — regenerates linked Supabase types with the imported FleetOps schema/RPCs and removed old trigger RPC.
- `AGENTS.md` — documents imported FleetOps tables, buckets, functions, secrets, and the disabled/retired cron state.

## Test plan

- [x] `supabase db push --linked --dry-run` (remote up to date after live apply)
- [x] Live migration row confirmed in `supabase_migrations.schema_migrations`
- [x] Row-count validation for imported `fleetops_` tables matched source counts
- [x] Storage validation for `fleetops-equipment-images` and `fleetops-shop-logos` matched source object counts and byte totals
- [x] Cron validation: no FleetOps cron rows remain, `fleetops_pos_inventory_seed_config.enabled = false`, and `trigger_fleetops_pos_inventory_seed_cron(boolean)` is absent
- [x] `supabase functions list --project-ref qtlhqsqanbxgfbcjigrl` confirmed all eight `fleetops-` functions active
- [x] Edge Function probes: all `OPTIONS` returned 200; invalid/no-auth requests returned expected 400/401 without side effects
- [x] Feed probe returned 21 gear, 1 add-on, 0 source-project URLs, 22 `fleetops-equipment-images` URLs, and 1 `fleetops-shop-logos` URL
- [x] Seed-run count stayed at 5 after probes, confirming no seed run was triggered
- [x] `npm run type-check`
- [x] `npm run build`
- [x] `npm run lint` (passes with one existing warning in `ContactInfoModal.tsx`)
- [x] `git diff --check`

Created by Codex
