### PR TITLE
Allow public reCAPTCHA verification

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -44,3 +44,6 @@ verify_jwt = false
 
 [functions.fleetops-stripe-webhook]
 verify_jwt = false
+
+[functions.verify-recaptcha]
+verify_jwt = false


### PR DESCRIPTION
## Summary

Fleet Ops production login was failing before the `verify-recaptcha` function body ran. Supabase Edge Runtime was enforcing JWT verification on the shared `verify-recaptcha` function, while the Fleet Ops frontend invokes it before sign-in using the publishable Supabase key. That key is not a JWT, so production returned `UNAUTHORIZED_INVALID_JWT_FORMAT` / `UNAUTHORIZED_NO_AUTH_HEADER` instead of validating the captcha token.

This change marks `verify-recaptcha` as a public Edge Function in Supabase config and the function has already been redeployed to the linked DemoStoke project `qtlhqsqanbxgfbcjigrl` with JWT verification disabled.

## Changes

- `supabase/config.toml` — adds `[functions.verify-recaptcha] verify_jwt = false` so unauthenticated login flows can reach the captcha verifier.

## Test plan

- [x] Before deploy: unauthenticated production probe returned `401 UNAUTHORIZED_NO_AUTH_HEADER` before function execution.
- [x] Deployed `verify-recaptcha` to linked project `qtlhqsqanbxgfbcjigrl` with `npx supabase functions deploy verify-recaptcha --project-ref qtlhqsqanbxgfbcjigrl --no-verify-jwt --use-api`.
- [x] After deploy: unauthenticated production probe reaches handler and returns expected `400` JSON for an invalid captcha token.
- [x] `git diff --check`

Created by Codex