### PR TITLE
Mark Eastern Time Zone seed batch as applied in agent memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,14 +351,9 @@ Do not re-seed any shop already in this table. Do not seed Hawaii Surfboard Rent
 
 ## Seed Data — Pending Local Seed Batches
 
-These files exist locally but have **not** been pushed/applied to the linked DemoStoke Supabase project. Do not describe these shops as live until the migrations are explicitly applied.
+There are currently no pending local seed batches. Any seed migration listed under `supabase/migrations/` is applied to the linked project (verified via `supabase migration list --linked`).
 
-- Eastern Time Zone all-category batch, status `local pending`, created May 30, 2026:
-  - shops migration: `supabase/migrations/20260530120000_seed_eastern_time_zone_all_categories_shops.sql`
-  - gear migrations: `20260530120100_seed_eastern_time_zone_surfboards_gear.sql`, `20260530120200_seed_eastern_time_zone_skis_gear.sql`, `20260530120300_seed_eastern_time_zone_snowboards_gear.sql`, `20260530120400_seed_eastern_time_zone_mountain_bikes_gear.sql`
-  - audit folder: `demostoke_seed_batches/eastern_time_zone_all_categories/`
-  - shops: Belleayre Mountain; Highland Mountain Bike Park; Thunder Mountain Bike Park; Ride Kanuga; REAL Watersports; Warm Winds Surf Shop; Cinnamon Rainbows Surf Co.
-  - planned gear counts: surfboards 14, skis 5, snowboards 2, mountain-bikes 19
+- The Eastern Time Zone all-category batch (migrations `20260530120000` through `20260530120400`, audit folder `demostoke_seed_batches/eastern_time_zone_all_categories/`) was applied to the linked project; verified June 11, 2026 via `supabase migration list --linked` and read-only profile checks. Its shops appear in the Current Seeded Shops table above.
 
 ## Seed Data — Historical Hermes Migration Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,14 +351,9 @@ Do not re-seed any shop already in this table. Do not seed Hawaii Surfboard Rent
 
 ## Seed Data — Pending Local Seed Batches
 
-These files exist locally but have **not** been pushed/applied to the linked DemoStoke Supabase project. Do not describe these shops as live until the migrations are explicitly applied.
+There are currently no pending local seed batches. Any seed migration listed under `supabase/migrations/` is applied to the linked project (verified via `supabase migration list --linked`).
 
-- Eastern Time Zone all-category batch, status `local pending`, created May 30, 2026:
-  - shops migration: `supabase/migrations/20260530120000_seed_eastern_time_zone_all_categories_shops.sql`
-  - gear migrations: `20260530120100_seed_eastern_time_zone_surfboards_gear.sql`, `20260530120200_seed_eastern_time_zone_skis_gear.sql`, `20260530120300_seed_eastern_time_zone_snowboards_gear.sql`, `20260530120400_seed_eastern_time_zone_mountain_bikes_gear.sql`
-  - audit folder: `demostoke_seed_batches/eastern_time_zone_all_categories/`
-  - shops: Belleayre Mountain; Highland Mountain Bike Park; Thunder Mountain Bike Park; Ride Kanuga; REAL Watersports; Warm Winds Surf Shop; Cinnamon Rainbows Surf Co.
-  - planned gear counts: surfboards 14, skis 5, snowboards 2, mountain-bikes 19
+- The Eastern Time Zone all-category batch (migrations `20260530120000` through `20260530120400`, audit folder `demostoke_seed_batches/eastern_time_zone_all_categories/`) was applied to the linked project; verified June 11, 2026 via `supabase migration list --linked` and read-only profile checks. Its shops appear in the Current Seeded Shops table above.
 
 ## Seed Data — Historical Hermes Migration Notes
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -351,14 +351,9 @@ Do not re-seed any shop already in this table. Do not seed Hawaii Surfboard Rent
 
 ## Seed Data — Pending Local Seed Batches
 
-These files exist locally but have **not** been pushed/applied to the linked DemoStoke Supabase project. Do not describe these shops as live until the migrations are explicitly applied.
+There are currently no pending local seed batches. Any seed migration listed under `supabase/migrations/` is applied to the linked project (verified via `supabase migration list --linked`).
 
-- Eastern Time Zone all-category batch, status `local pending`, created May 30, 2026:
-  - shops migration: `supabase/migrations/20260530120000_seed_eastern_time_zone_all_categories_shops.sql`
-  - gear migrations: `20260530120100_seed_eastern_time_zone_surfboards_gear.sql`, `20260530120200_seed_eastern_time_zone_skis_gear.sql`, `20260530120300_seed_eastern_time_zone_snowboards_gear.sql`, `20260530120400_seed_eastern_time_zone_mountain_bikes_gear.sql`
-  - audit folder: `demostoke_seed_batches/eastern_time_zone_all_categories/`
-  - shops: Belleayre Mountain; Highland Mountain Bike Park; Thunder Mountain Bike Park; Ride Kanuga; REAL Watersports; Warm Winds Surf Shop; Cinnamon Rainbows Surf Co.
-  - planned gear counts: surfboards 14, skis 5, snowboards 2, mountain-bikes 19
+- The Eastern Time Zone all-category batch (migrations `20260530120000` through `20260530120400`, audit folder `demostoke_seed_batches/eastern_time_zone_all_categories/`) was applied to the linked project; verified June 11, 2026 via `supabase migration list --linked` and read-only profile checks. Its shops appear in the Current Seeded Shops table above.
 
 ## Seed Data — Historical Hermes Migration Notes
 


### PR DESCRIPTION
## Summary
- The "Seed Data — Pending Local Seed Batches" section in AGENTS.md still listed the Eastern Time Zone all-category batch (migrations `20260530120000`–`20260530120400`) as `local pending`, contradicting the Current Seeded Shops table in the same file.
- Verified the batch is actually applied: `supabase migration list --linked` shows all five versions applied locally and remotely, and a read-only REST check confirmed all seven Eastern shops (Belleayre Mountain, Highland Mountain Bike Park, Thunder Mountain Bike Park, Ride Kanuga, REAL Watersports, Warm Winds Surf Shop, Cinnamon Rainbows Surf Co.) exist in `public_profiles`.
- Replaced the stale entry with a note that no pending local seed batches exist and a record of the verified apply.
- Re-copied CLAUDE.md and GEMINI.md from AGENTS.md so all three stay identical.

Docs-only change; no migrations or edge functions touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)