### PR TITLE
Fix blog generation, switch AI functions to gpt-5.4-mini

### DIFF
--- a/src/pages/BlogCreatePage.tsx
+++ b/src/pages/BlogCreatePage.tsx
@@ -56,6 +56,7 @@ function BlogCreatePageInner() {
   const [thumbnailUrl, setThumbnailUrl] = useState("");
   const [youtubeUrl, setYoutubeUrl] = useState("");
   const [publishedDate, setPublishedDate] = useState<Date>();
+  const [publishedDateOpen, setPublishedDateOpen] = useState(false);
   const [title, setTitle] = useState("");
   const [excerpt, setExcerpt] = useState("");
   const [content, setContent] = useState("");
@@ -496,7 +497,7 @@ function BlogCreatePageInner() {
 
                       <div>
                         <Label>Published Date *</Label>
-                        <Popover>
+                        <Popover open={publishedDateOpen} onOpenChange={setPublishedDateOpen}>
                           <PopoverTrigger asChild>
                             <Button
                               variant="outline"
@@ -513,7 +514,12 @@ function BlogCreatePageInner() {
                             <Calendar
                               mode="single"
                               selected={publishedDate}
-                              onSelect={setPublishedDate}
+                              onSelect={(date) => {
+                                setPublishedDate(date);
+                                if (date) {
+                                  setPublishedDateOpen(false);
+                                }
+                              }}
                               initialFocus
                             />
                           </PopoverContent>

--- a/supabase/functions/ai-search/index.ts
+++ b/supabase/functions/ai-search/index.ts
@@ -197,7 +197,7 @@ RESPOND WITH VALID JSON ONLY in this exact format:
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        model: 'gpt-5-mini',
+        model: 'gpt-5.4-mini',
         messages: [
           {
             role: 'system',

--- a/supabase/functions/analyze-blog-seo/index.ts
+++ b/supabase/functions/analyze-blog-seo/index.ts
@@ -113,7 +113,7 @@ Provide detailed SEO analysis with actionable suggestions for 2024-2025 search o
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        model: 'gpt-5-mini',
+        model: 'gpt-5.4-mini',
         messages: [
           { role: 'system', content: systemPrompt },
           { role: 'user', content: userPrompt }

--- a/supabase/functions/discover-demo-events/index.ts
+++ b/supabase/functions/discover-demo-events/index.ts
@@ -481,7 +481,7 @@ async function parseEventsFromPage(page: ScrapedPage): Promise<ParsedEvent[]> {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      model: "gpt-5-mini",
+      model: "gpt-5.4-mini",
       messages: [
         {
           role: "system",

--- a/supabase/functions/extract-gear-from-html/index.ts
+++ b/supabase/functions/extract-gear-from-html/index.ts
@@ -74,7 +74,7 @@ IMPORTANT FOR SIZES:
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      model: "gpt-5-mini",
+      model: "gpt-5.4-mini",
       messages: [
         { role: "system", content: prompt },
         { role: "user", content: html.slice(0, 200000) },

--- a/supabase/functions/fleetops-ai-analytics/index.ts
+++ b/supabase/functions/fleetops-ai-analytics/index.ts
@@ -122,7 +122,7 @@ Please analyze this data and provide insights and predictions.`;
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        model: "gpt-4o-mini",
+        model: "gpt-5.4-mini",
         messages: [
           { role: "system", content: SYSTEM_PROMPT },
           { role: "user", content: userPrompt },

--- a/supabase/functions/fleetops-ai-analytics/index.ts
+++ b/supabase/functions/fleetops-ai-analytics/index.ts
@@ -127,8 +127,7 @@ Please analyze this data and provide insights and predictions.`;
           { role: "system", content: SYSTEM_PROMPT },
           { role: "user", content: userPrompt },
         ],
-        temperature: 0.7,
-        max_tokens: 1500,
+        max_completion_tokens: 1500,
       }),
     });
 

--- a/supabase/functions/gear-quiz-analysis/index.ts
+++ b/supabase/functions/gear-quiz-analysis/index.ts
@@ -226,7 +226,7 @@ serve(async (req) => {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        model: 'gpt-4o-mini',
+        model: 'gpt-5.4-mini',
         messages: [
           { role: 'system', content: systemPrompt },
           { role: 'user', content: userPrompt }

--- a/supabase/functions/gear-quiz-analysis/index.ts
+++ b/supabase/functions/gear-quiz-analysis/index.ts
@@ -231,7 +231,7 @@ serve(async (req) => {
           { role: 'system', content: systemPrompt },
           { role: 'user', content: userPrompt }
         ],
-        max_tokens: 5000,
+        max_completion_tokens: 5000,
       }),
     });
 

--- a/supabase/functions/generate-blog-post/index.ts
+++ b/supabase/functions/generate-blog-post/index.ts
@@ -117,7 +117,14 @@ Format the response as a JSON object with the following structure:
     const data = await response.json();
     console.log('✅ OpenAI API response received');
     
-    const generatedContent = data.choices[0].message.content;
+    const generatedContent = data.choices?.[0]?.message?.content;
+    if (!generatedContent || generatedContent.trim().length === 0) {
+      console.error('OpenAI returned empty content. Finish reason:', data.choices?.[0]?.finish_reason);
+      return new Response(
+        JSON.stringify({ error: 'OpenAI returned empty content. Please try again.' }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
     console.log('📄 Generated content length:', generatedContent.length);
 
     // Parse the JSON response from OpenAI

--- a/supabase/functions/generate-blog-post/index.ts
+++ b/supabase/functions/generate-blog-post/index.ts
@@ -53,7 +53,8 @@ serve(async (req) => {
       );
     }
 
-    const systemPrompt = `You are a professional content writer specializing in outdoor gear and adventure sports. Create engaging blog posts that are informative, well-structured, and appeal to outdoor enthusiasts.`;
+    const systemPrompt = `You are a professional content writer specializing in outdoor gear and adventure sports. Create engaging blog posts that are informative, well-structured, and appeal to outdoor enthusiasts.
+Never use em dashes (—) anywhere in the title, excerpt, or content. Rewrite any sentence that would use one; if a stronger break than a comma is needed, use a semicolon (;) instead.`;
 
     const userPrompt = `Write a comprehensive blog post based on this prompt: "${requestData.prompt}"
 

--- a/supabase/functions/generate-blog-post/index.ts
+++ b/supabase/functions/generate-blog-post/index.ts
@@ -94,7 +94,7 @@ Format the response as a JSON object with the following structure:
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        model: 'gpt-5-mini',
+        model: 'gpt-5.4-mini',
         messages: [
           { role: 'system', content: systemPrompt },
           { role: 'user', content: userPrompt }

--- a/supabase/functions/generate-blog-text/index.ts
+++ b/supabase/functions/generate-blog-text/index.ts
@@ -53,9 +53,10 @@ Deno.serve(async (req: Request) => {
         messages: [
           {
             role: 'system',
-            content: `You are an expert outdoor gear and adventure sports content writer. 
+            content: `You are an expert outdoor gear and adventure sports content writer.
 Write engaging, informative blog content with proper HTML formatting.
 Use headings (<h2>, <h3>), paragraphs (<p>), lists (<ul>, <ol>), and emphasis (<strong>, <em>) appropriately.
+Never use em dashes (—) anywhere in the output. Rewrite any sentence that would use one; if a stronger break than a comma is needed, use a semicolon (;) instead.
 Return ONLY the content HTML - no full page structure.`
           },
           {
@@ -107,7 +108,8 @@ Return ONLY the content HTML - no full page structure.`
 Return a JSON object with "title" and "excerpt" fields.
 - Title: 50-70 characters, catchy and SEO-friendly
 - Excerpt: 120-160 characters, engaging summary
-- Make both title and excerpt compelling for search engines and readers`
+- Make both title and excerpt compelling for search engines and readers
+- Never use em dashes (—) in the title or excerpt; use a semicolon (;) instead if a stronger break than a comma is needed`
           },
           {
             role: 'user',

--- a/supabase/functions/generate-blog-text/index.ts
+++ b/supabase/functions/generate-blog-text/index.ts
@@ -49,7 +49,7 @@ Deno.serve(async (req: Request) => {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        model: 'gpt-5-mini',
+        model: 'gpt-5.4-mini',
         messages: [
           {
             role: 'system',
@@ -99,7 +99,7 @@ Return ONLY the content HTML - no full page structure.`
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        model: 'gpt-5-mini',
+        model: 'gpt-5.4-mini',
         messages: [
           {
             role: 'system',

--- a/supabase/functions/generate-description/index.ts
+++ b/supabase/functions/generate-description/index.ts
@@ -59,7 +59,7 @@ serve(async (req) => {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        model: 'gpt-5-mini',
+        model: 'gpt-5.4-mini',
         messages: [
           { 
             role: 'system', 

--- a/supabase/functions/generate-gear-review-blog-draft/index.ts
+++ b/supabase/functions/generate-gear-review-blog-draft/index.ts
@@ -62,7 +62,7 @@ const GOOGLE_API_KEY =
   Deno.env.get("GOOGLE_SEARCH_API_KEY") ?? Deno.env.get("GOOGLE_API_KEY") ?? "";
 const GOOGLE_SEARCH_ENGINE_ID =
   Deno.env.get("GOOGLE_SEARCH_ENGINE_ID") ?? Deno.env.get("GOOGLE_CSE_ID") ?? "";
-const OPENAI_MODEL = Deno.env.get("GEAR_REVIEW_BLOG_MODEL") ?? "gpt-5-mini";
+const OPENAI_MODEL = Deno.env.get("GEAR_REVIEW_BLOG_MODEL") ?? "gpt-5.4-mini";
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 

--- a/supabase/functions/generate-tricks/index.ts
+++ b/supabase/functions/generate-tricks/index.ts
@@ -67,7 +67,7 @@ Respond with a JSON object containing a "tricks" array with objects having: name
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        model: "gpt-5-mini",
+        model: "gpt-5.4-mini",
         messages: [
           { role: "system", content: systemPrompt },
           { role: "user", content: userPrompt }

--- a/supabase/functions/rental-discovery-agent/index.ts
+++ b/supabase/functions/rental-discovery-agent/index.ts
@@ -220,7 +220,7 @@ async function parserAgent(scrapedData: any[], _shopUserId: string) {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            model: "gpt-5-mini",
+            model: "gpt-5.4-mini",
             messages: [
               { role: "system", content: "You are a data extraction expert. Return only valid JSON array." },
               { role: "user", content: `${prompt}\n\nContent:\n${content?.substring(0, 12000)}` },


### PR DESCRIPTION
## What changed

### Fix manual blog generation (original bug)
- `generate-blog-text` was failing with `LOVABLE_API_KEY is not registered`. The source had already migrated off the Lovable gateway to OpenAI (2026-05-06) but the deployed function was stale (2026-03-24). Redeployed; no code change was needed for that bug itself.

### Switch all AI edge functions to `gpt-5.4-mini`
- Updated the model id from `gpt-5-mini` / `gpt-4o-mini` to `gpt-5.4-mini` across all 12 OpenAI-backed edge functions, plus the `GEAR_REVIEW_BLOG_MODEL` default in `generate-gear-review-blog-draft`.
- Set the `GEAR_REVIEW_BLOG_MODEL` project secret to `gpt-5.4-mini`.

### Fix params incompatible with the GPT-5-family model
`gpt-5.4-mini` rejects `max_tokens` and non-default `temperature`:
- `gear-quiz-analysis`: `max_tokens` → `max_completion_tokens`.
- `fleetops-ai-analytics`: dropped `temperature: 0.7`, `max_tokens` → `max_completion_tokens`.
- `generate-blog-post`: added a null/empty guard on the OpenAI response so it returns a clear 500 (with `finish_reason`) instead of throwing a `TypeError`.

### Blog UX + content rules
- `BlogCreatePage`: the "Published Date" popover is now controlled and closes as soon as a date is selected.
- `generate-blog-text` / `generate-blog-post`: instruct the model to never use em dashes and to use a semicolon when a stronger break than a comma is needed.

## Verification
- `gpt-5.4-mini` confirmed valid via live 200 responses from: generate-tricks, generate-blog-text, generate-description, analyze-blog-seo, ai-search, extract-gear-from-html, and gear-quiz-analysis (after fix).
- `npm run type-check` passes for the client change.

## Notes for reviewers
- All edge function changes in this PR have already been deployed to the linked Supabase project (`qtlhqsqanbxgfbcjigrl`), and the `GEAR_REVIEW_BLOG_MODEL` secret is set.
- `rental-discovery-agent`, `discover-demo-events`, and `generate-gear-review-blog-draft` were not live-tested (DB writes / external calls / cron-secret gated) but use compatible params (`max_completion_tokens`, no temperature override).

🤖 Generated with [Claude Code](https://claude.com/claude-code)