### PR TITLE
Fix invisible dark-mode text in prose containers

### DIFF
--- a/src/components/blog/ContentRenderer.tsx
+++ b/src/components/blog/ContentRenderer.tsx
@@ -29,7 +29,7 @@ const ContentRenderer: React.FC<ContentRendererProps> = ({ content, className = 
     default:
       // For plain text, preserve line breaks and basic formatting with custom text color
       return (
-        <div className={`prose prose-lg max-w-none ${className}`}>
+        <div className={`prose prose-lg dark:prose-invert max-w-none ${className}`}>
           {content.split('\n\n').map((paragraph, index) => (
             <p key={index} className={`mb-4 ${textColor} leading-relaxed`}>
               {paragraph.split('\n').map((line, lineIndex) => (

--- a/src/components/blog/EnhancedMarkdownRenderer.tsx
+++ b/src/components/blog/EnhancedMarkdownRenderer.tsx
@@ -11,7 +11,7 @@ interface EnhancedMarkdownRendererProps {
 
 const EnhancedMarkdownRenderer: React.FC<EnhancedMarkdownRendererProps> = ({ text, className = "", textColor = "text-foreground" }) => {
   return (
-    <div className={`prose prose-lg max-w-none ${className}`}>
+    <div className={`prose prose-lg dark:prose-invert max-w-none ${className}`}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{

--- a/src/components/blog/SafeHtmlRenderer.tsx
+++ b/src/components/blog/SafeHtmlRenderer.tsx
@@ -38,7 +38,7 @@ const SafeHtmlRenderer: React.FC<SafeHtmlRendererProps> = ({ html, className = "
 
   return (
     <div
-      className={`prose prose-lg max-w-none ${getProseTextClass(textColor)} prose-a:text-primary ${className}`}
+      className={`prose prose-lg dark:prose-invert max-w-none ${getProseTextClass(textColor)} prose-a:text-primary ${className}`}
       dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
     />
   );

--- a/src/pages/PrivacyPolicyPage.tsx
+++ b/src/pages/PrivacyPolicyPage.tsx
@@ -23,7 +23,7 @@ const PrivacyPolicyPage = () => {
       <div className="container px-4 md:px-6 py-16 max-w-4xl mx-auto">
         <h1 className={legalPageHeadingClassName}>Privacy Policy</h1>
         
-        <div className="prose prose-lg max-w-none space-y-8">
+        <div className="prose prose-lg dark:prose-invert max-w-none space-y-8">
           <section>
             <p className="text-muted-foreground mb-6">
               <strong className="text-muted-foreground">Effective Date:</strong> July 5, 2026

--- a/src/pages/TermsOfServicePage.tsx
+++ b/src/pages/TermsOfServicePage.tsx
@@ -22,7 +22,7 @@ const TermsOfServicePage = () => {
       <div className="container px-4 md:px-6 py-16 max-w-4xl mx-auto">
         <h1 className={legalPageHeadingClassName}>Terms of Service</h1>
         
-        <div className="prose prose-lg max-w-none space-y-8">
+        <div className="prose prose-lg dark:prose-invert max-w-none space-y-8">
           <section>
             <p className="text-muted-foreground mb-6">
               <strong className="text-muted-foreground">Effective Date:</strong> July 5, 2026


### PR DESCRIPTION
## What changed

Added `dark:prose-invert` to every Tailwind `prose` container that was missing it:

- `src/pages/PrivacyPolicyPage.tsx` — the reported page, where `<code>` tokens like `ui-theme`, `cookie-consent`, `_ga`, `_ga_*`, and `AMP_*` were invisible in dark mode
- `src/pages/TermsOfServicePage.tsx` — same legal-page pattern
- `src/components/blog/ContentRenderer.tsx`, `EnhancedMarkdownRenderer.tsx`, `SafeHtmlRenderer.tsx` — blog renderers with the same latent issue for elements their explicit color overrides don't cover (tables, hr, etc.)

## Why

Tailwind Typography's `prose` class assigns a fixed near-black color to `<code>` and other elements it styles. Without `dark:prose-invert`, that color never adapts to dark mode, so the cookie-name code text on the Privacy Policy page rendered nearly invisible against the dark background.

## Notes for reviewers

- Safe for existing styling: the typography plugin uses zero-specificity `:where()` selectors, so all explicit `text-foreground` / `text-muted-foreground` classes on these pages still win. Only previously unstyled elements pick up inverted colors.
- Verified in the browser: dark mode now renders the code text white (`rgb(255,255,255)`) on the dark background; light mode is byte-for-byte unchanged (`rgb(17,24,39)`). No console errors.
- Other `<code>` usages in the app (admin tools, API docs page) sit outside `prose` containers and inherit their parent color, so they were already fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)