### PR TITLE
Consolidate edge function secrets and port email HTML escaping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,12 +213,37 @@ If a grant is missing, PostgREST returns error code `42501` with the exact GRANT
   - `VITE_SHOP_GEAR_FEED_INCLUDE_HIDDEN`
   - `VITE_SHOP_GEAR_FEED_APIKEY`
 - Theme flicker fix can be disabled with `VITE_ENABLE_THEME_FLICKER_FIX=false`.
-- Edge functions rely on combinations of `SUPABASE_SERVICE_ROLE_KEY`, `OPENAI_API_KEY`, `MAPBOX_TOKEN`, `GOOGLE_API_KEY`, `GOOGLE_CSE_ID`, `GOOGLE_SEARCH_API_KEY`, `GOOGLE_SEARCH_ENGINE_ID`, `GOOGLE_RECAPTCHA_SECRET_KEY`, and `HCAPTCHA_SECRET` (legacy, no longer read).
+
+### Where Secrets Actually Live
+
+There are five distinct stores. Do not assume the root `.env` is the app's config.
+
+1. **Root `.env` (gitignored) - local tooling only, not read by app code.** Holds `SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEY`, `SUPABASE_SECRET_KEY`, `SUPABASE_ACCESS_TOKEN` (Supabase CLI), and `MIXPANEL_SA_USERNAME` / `MIXPANEL_SA_SECRET` (Mixpanel service account for API/agent access). None carry a `VITE_` prefix, so Vite never exposes them and the SSR server never reads them. It is the only env file in the tree; there is no `.env.example`.
+2. **Supabase Edge Function secrets** (`supabase secrets set`, or the dashboard) - the real secret store. See the full inventory below.
+3. **Hardcoded public keys in the repo** - `src/integrations/supabase/config.js` (project URL + anon JWT), `index.html` (Mixpanel project token, `GTM-MHM2XTTV`, `G-KKQJ9P2ECC`), and `src/components/Recaptcha.tsx` (`RECAPTCHA_SITE_KEY`). All are public-by-design client keys. Never add a private key to these files.
+4. **The database** - Supabase Vault secret `auto_assign_internal_secret`, plus `gear_review_blog_generation_config.cron_secret` and `fleetops_pos_inventory_seed_config.cron_secret`.
+5. **The SSR host** - the `VITE_*` vars the client and `server/index.js` read are set in whatever platform runs `npm start`. There is no hosting config in this repo (no `vercel.json`, `netlify.toml`, `Dockerfile`, or `fly.toml`), so that configuration lives outside the codebase.
+
+CI holds no repository secrets; `.github/workflows/security.yml` uses only the auto-provided `secrets.GITHUB_TOKEN`.
+
+- Edge function secret inventory, by area:
+  - Supabase (auto-injected into every function): `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY`
+  - AI: `OPENAI_API_KEY`, `GEAR_REVIEW_BLOG_MODEL` (model id override, not a credential)
+  - Google: `GOOGLE_API_KEY`, `GOOGLE_CSE_ID`, `GOOGLE_SEARCH_API_KEY`, `GOOGLE_SEARCH_ENGINE_ID`, `GOOGLE_RECAPTCHA_SECRET_KEY`, `YOUTUBE_V3_API_KEY`
+  - Maps: `MAPBOX_TOKEN` (used by `get-mapbox-token` and `admin-create-user`)
+  - Crawling: `FIRECRAWL_API_KEY` (`rental-discovery-agent`, `discover-demo-events`, `crawl-retailer-details`)
+  - Email: `RESEND_API_KEY` (`send-contact-email`)
+  - Internal auth: `AUTO_ASSIGN_INTERNAL_SECRET`
+  - FleetOps: see the prefixed list below
+- `HCAPTCHA_SECRET` and `HCAPTCHA_SITE_KEY` are legacy and no longer read by any function. `AUTH_SEND_EMAIL_HOOK_SECRET`, `DS_DESIGN_SYSTEM_TOKEN` (design-system tables were dropped in `20260608120000`), `HUGGING_FACE_ACCESS_TOKEN`, and `LOVABLE_API_KEY` are also set on the linked project but unreferenced in this repo. Leave them alone unless the user explicitly asks to prune them.
+- The client never receives the Mapbox token as an env var. It calls the `get-mapbox-token` edge function, which reads `MAPBOX_TOKEN` server-side. Keep it that way.
+- To audit what is actually set on the linked project, run `supabase secrets list` (prints names and value digests, never plaintext).
 - `generate-gear-review-blog-draft` also relies on `SUPABASE_SERVICE_ROLE_KEY`, `OPENAI_API_KEY`, and the Google Custom Search image/web keys. It is protected by the `gear_review_blog_generation_config.cron_secret` value passed as `x-cron-secret`, compared in constant time via `_shared/timingSafeEqual.ts`.
 - `auto-assign-gear-images` is no longer anonymous. It now requires either an admin JWT or a shared internal secret `AUTO_ASSIGN_INTERNAL_SECRET` passed as the `x-internal-secret` header. The `on_equipment_created` DB trigger (`notify_new_equipment`) sends that header, reading the value from the Vault secret named `auto_assign_internal_secret` (migration `20260611120000_auto_assign_secret_vault_fallback.sql`), falling back to the `app.auto_assign_internal_secret` GUC. Persisting custom GUCs via `ALTER DATABASE/ROLE ... SET` is denied on Supabase managed Postgres, which is why Vault is the primary source. Keep the Vault secret and the function secret set to the same value.
 - SSRF-prone image/fetch functions (`download-store-image`, `convert-image-to-webp`, `convert-to-jpeg`, `scan-broken-images`) validate user/DB-supplied URLs through `_shared/urlSafety.ts`, which requires https and rejects private/reserved hosts.
 - Imported FleetOps storage uses public buckets `fleetops-equipment-images` and `fleetops-shop-logos`.
-- Imported FleetOps Edge Functions use prefixed secrets where available: `FLEETOPS_STRIPE_SECRET_KEY`, `FLEETOPS_STRIPE_WEBHOOK_SECRET`, `FLEETOPS_SENDGRID_API_KEY`, `FLEETOPS_FROM_EMAIL`, `FLEETOPS_PUBLIC_SUPABASE_URL`, and `FLEETOPS_POS_INVENTORY_SEED_CRON_SECRET`. The retained `fleetops_pos_inventory_seed_config.cron_secret` should stay synchronized with the prefixed POS function secret if the disabled seed flow is ever re-enabled.
+- Imported FleetOps Edge Functions read `FLEETOPS_`-prefixed secrets exclusively: `FLEETOPS_STRIPE_SECRET_KEY`, `FLEETOPS_STRIPE_WEBHOOK_SECRET`, `FLEETOPS_SENDGRID_API_KEY`, `FLEETOPS_FROM_EMAIL`, `FLEETOPS_PUBLIC_SUPABASE_URL`, and `FLEETOPS_POS_INVENTORY_SEED_CRON_SECRET`. The unprefixed fallbacks (`STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `SENDGRID_API_KEY`, `FROM_EMAIL`, `PUBLIC_SUPABASE_URL`, `SITE_URL`, `POS_INVENTORY_SEED_CRON_SECRET`, `SERVICE_ROLE_KEY`) were removed in August 2026; they were never set on the linked project, so they were dead code that made the real source of each value ambiguous. Do not reintroduce them. `FLEETOPS_FROM_EMAIL` is intentionally optional and defaults to `bookings@demostoke.com`.
+- The retained `fleetops_pos_inventory_seed_config.cron_secret` should stay synchronized with `FLEETOPS_POS_INVENTORY_SEED_CRON_SECRET` if the disabled seed flow is ever re-enabled.
 - Do not introduce new hardcoded secrets. Keep public browser tokens and service secrets clearly separated.
 
 ## Critical Invariants and Gotchas

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,12 +213,37 @@ If a grant is missing, PostgREST returns error code `42501` with the exact GRANT
   - `VITE_SHOP_GEAR_FEED_INCLUDE_HIDDEN`
   - `VITE_SHOP_GEAR_FEED_APIKEY`
 - Theme flicker fix can be disabled with `VITE_ENABLE_THEME_FLICKER_FIX=false`.
-- Edge functions rely on combinations of `SUPABASE_SERVICE_ROLE_KEY`, `OPENAI_API_KEY`, `MAPBOX_TOKEN`, `GOOGLE_API_KEY`, `GOOGLE_CSE_ID`, `GOOGLE_SEARCH_API_KEY`, `GOOGLE_SEARCH_ENGINE_ID`, `GOOGLE_RECAPTCHA_SECRET_KEY`, and `HCAPTCHA_SECRET` (legacy, no longer read).
+
+### Where Secrets Actually Live
+
+There are five distinct stores. Do not assume the root `.env` is the app's config.
+
+1. **Root `.env` (gitignored) - local tooling only, not read by app code.** Holds `SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEY`, `SUPABASE_SECRET_KEY`, `SUPABASE_ACCESS_TOKEN` (Supabase CLI), and `MIXPANEL_SA_USERNAME` / `MIXPANEL_SA_SECRET` (Mixpanel service account for API/agent access). None carry a `VITE_` prefix, so Vite never exposes them and the SSR server never reads them. It is the only env file in the tree; there is no `.env.example`.
+2. **Supabase Edge Function secrets** (`supabase secrets set`, or the dashboard) - the real secret store. See the full inventory below.
+3. **Hardcoded public keys in the repo** - `src/integrations/supabase/config.js` (project URL + anon JWT), `index.html` (Mixpanel project token, `GTM-MHM2XTTV`, `G-KKQJ9P2ECC`), and `src/components/Recaptcha.tsx` (`RECAPTCHA_SITE_KEY`). All are public-by-design client keys. Never add a private key to these files.
+4. **The database** - Supabase Vault secret `auto_assign_internal_secret`, plus `gear_review_blog_generation_config.cron_secret` and `fleetops_pos_inventory_seed_config.cron_secret`.
+5. **The SSR host** - the `VITE_*` vars the client and `server/index.js` read are set in whatever platform runs `npm start`. There is no hosting config in this repo (no `vercel.json`, `netlify.toml`, `Dockerfile`, or `fly.toml`), so that configuration lives outside the codebase.
+
+CI holds no repository secrets; `.github/workflows/security.yml` uses only the auto-provided `secrets.GITHUB_TOKEN`.
+
+- Edge function secret inventory, by area:
+  - Supabase (auto-injected into every function): `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY`
+  - AI: `OPENAI_API_KEY`, `GEAR_REVIEW_BLOG_MODEL` (model id override, not a credential)
+  - Google: `GOOGLE_API_KEY`, `GOOGLE_CSE_ID`, `GOOGLE_SEARCH_API_KEY`, `GOOGLE_SEARCH_ENGINE_ID`, `GOOGLE_RECAPTCHA_SECRET_KEY`, `YOUTUBE_V3_API_KEY`
+  - Maps: `MAPBOX_TOKEN` (used by `get-mapbox-token` and `admin-create-user`)
+  - Crawling: `FIRECRAWL_API_KEY` (`rental-discovery-agent`, `discover-demo-events`, `crawl-retailer-details`)
+  - Email: `RESEND_API_KEY` (`send-contact-email`)
+  - Internal auth: `AUTO_ASSIGN_INTERNAL_SECRET`
+  - FleetOps: see the prefixed list below
+- `HCAPTCHA_SECRET` and `HCAPTCHA_SITE_KEY` are legacy and no longer read by any function. `AUTH_SEND_EMAIL_HOOK_SECRET`, `DS_DESIGN_SYSTEM_TOKEN` (design-system tables were dropped in `20260608120000`), `HUGGING_FACE_ACCESS_TOKEN`, and `LOVABLE_API_KEY` are also set on the linked project but unreferenced in this repo. Leave them alone unless the user explicitly asks to prune them.
+- The client never receives the Mapbox token as an env var. It calls the `get-mapbox-token` edge function, which reads `MAPBOX_TOKEN` server-side. Keep it that way.
+- To audit what is actually set on the linked project, run `supabase secrets list` (prints names and value digests, never plaintext).
 - `generate-gear-review-blog-draft` also relies on `SUPABASE_SERVICE_ROLE_KEY`, `OPENAI_API_KEY`, and the Google Custom Search image/web keys. It is protected by the `gear_review_blog_generation_config.cron_secret` value passed as `x-cron-secret`, compared in constant time via `_shared/timingSafeEqual.ts`.
 - `auto-assign-gear-images` is no longer anonymous. It now requires either an admin JWT or a shared internal secret `AUTO_ASSIGN_INTERNAL_SECRET` passed as the `x-internal-secret` header. The `on_equipment_created` DB trigger (`notify_new_equipment`) sends that header, reading the value from the Vault secret named `auto_assign_internal_secret` (migration `20260611120000_auto_assign_secret_vault_fallback.sql`), falling back to the `app.auto_assign_internal_secret` GUC. Persisting custom GUCs via `ALTER DATABASE/ROLE ... SET` is denied on Supabase managed Postgres, which is why Vault is the primary source. Keep the Vault secret and the function secret set to the same value.
 - SSRF-prone image/fetch functions (`download-store-image`, `convert-image-to-webp`, `convert-to-jpeg`, `scan-broken-images`) validate user/DB-supplied URLs through `_shared/urlSafety.ts`, which requires https and rejects private/reserved hosts.
 - Imported FleetOps storage uses public buckets `fleetops-equipment-images` and `fleetops-shop-logos`.
-- Imported FleetOps Edge Functions use prefixed secrets where available: `FLEETOPS_STRIPE_SECRET_KEY`, `FLEETOPS_STRIPE_WEBHOOK_SECRET`, `FLEETOPS_SENDGRID_API_KEY`, `FLEETOPS_FROM_EMAIL`, `FLEETOPS_PUBLIC_SUPABASE_URL`, and `FLEETOPS_POS_INVENTORY_SEED_CRON_SECRET`. The retained `fleetops_pos_inventory_seed_config.cron_secret` should stay synchronized with the prefixed POS function secret if the disabled seed flow is ever re-enabled.
+- Imported FleetOps Edge Functions read `FLEETOPS_`-prefixed secrets exclusively: `FLEETOPS_STRIPE_SECRET_KEY`, `FLEETOPS_STRIPE_WEBHOOK_SECRET`, `FLEETOPS_SENDGRID_API_KEY`, `FLEETOPS_FROM_EMAIL`, `FLEETOPS_PUBLIC_SUPABASE_URL`, and `FLEETOPS_POS_INVENTORY_SEED_CRON_SECRET`. The unprefixed fallbacks (`STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `SENDGRID_API_KEY`, `FROM_EMAIL`, `PUBLIC_SUPABASE_URL`, `SITE_URL`, `POS_INVENTORY_SEED_CRON_SECRET`, `SERVICE_ROLE_KEY`) were removed in August 2026; they were never set on the linked project, so they were dead code that made the real source of each value ambiguous. Do not reintroduce them. `FLEETOPS_FROM_EMAIL` is intentionally optional and defaults to `bookings@demostoke.com`.
+- The retained `fleetops_pos_inventory_seed_config.cron_secret` should stay synchronized with `FLEETOPS_POS_INVENTORY_SEED_CRON_SECRET` if the disabled seed flow is ever re-enabled.
 - Do not introduce new hardcoded secrets. Keep public browser tokens and service secrets clearly separated.
 
 ## Critical Invariants and Gotchas

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -213,12 +213,37 @@ If a grant is missing, PostgREST returns error code `42501` with the exact GRANT
   - `VITE_SHOP_GEAR_FEED_INCLUDE_HIDDEN`
   - `VITE_SHOP_GEAR_FEED_APIKEY`
 - Theme flicker fix can be disabled with `VITE_ENABLE_THEME_FLICKER_FIX=false`.
-- Edge functions rely on combinations of `SUPABASE_SERVICE_ROLE_KEY`, `OPENAI_API_KEY`, `MAPBOX_TOKEN`, `GOOGLE_API_KEY`, `GOOGLE_CSE_ID`, `GOOGLE_SEARCH_API_KEY`, `GOOGLE_SEARCH_ENGINE_ID`, `GOOGLE_RECAPTCHA_SECRET_KEY`, and `HCAPTCHA_SECRET` (legacy, no longer read).
+
+### Where Secrets Actually Live
+
+There are five distinct stores. Do not assume the root `.env` is the app's config.
+
+1. **Root `.env` (gitignored) - local tooling only, not read by app code.** Holds `SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEY`, `SUPABASE_SECRET_KEY`, `SUPABASE_ACCESS_TOKEN` (Supabase CLI), and `MIXPANEL_SA_USERNAME` / `MIXPANEL_SA_SECRET` (Mixpanel service account for API/agent access). None carry a `VITE_` prefix, so Vite never exposes them and the SSR server never reads them. It is the only env file in the tree; there is no `.env.example`.
+2. **Supabase Edge Function secrets** (`supabase secrets set`, or the dashboard) - the real secret store. See the full inventory below.
+3. **Hardcoded public keys in the repo** - `src/integrations/supabase/config.js` (project URL + anon JWT), `index.html` (Mixpanel project token, `GTM-MHM2XTTV`, `G-KKQJ9P2ECC`), and `src/components/Recaptcha.tsx` (`RECAPTCHA_SITE_KEY`). All are public-by-design client keys. Never add a private key to these files.
+4. **The database** - Supabase Vault secret `auto_assign_internal_secret`, plus `gear_review_blog_generation_config.cron_secret` and `fleetops_pos_inventory_seed_config.cron_secret`.
+5. **The SSR host** - the `VITE_*` vars the client and `server/index.js` read are set in whatever platform runs `npm start`. There is no hosting config in this repo (no `vercel.json`, `netlify.toml`, `Dockerfile`, or `fly.toml`), so that configuration lives outside the codebase.
+
+CI holds no repository secrets; `.github/workflows/security.yml` uses only the auto-provided `secrets.GITHUB_TOKEN`.
+
+- Edge function secret inventory, by area:
+  - Supabase (auto-injected into every function): `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY`
+  - AI: `OPENAI_API_KEY`, `GEAR_REVIEW_BLOG_MODEL` (model id override, not a credential)
+  - Google: `GOOGLE_API_KEY`, `GOOGLE_CSE_ID`, `GOOGLE_SEARCH_API_KEY`, `GOOGLE_SEARCH_ENGINE_ID`, `GOOGLE_RECAPTCHA_SECRET_KEY`, `YOUTUBE_V3_API_KEY`
+  - Maps: `MAPBOX_TOKEN` (used by `get-mapbox-token` and `admin-create-user`)
+  - Crawling: `FIRECRAWL_API_KEY` (`rental-discovery-agent`, `discover-demo-events`, `crawl-retailer-details`)
+  - Email: `RESEND_API_KEY` (`send-contact-email`)
+  - Internal auth: `AUTO_ASSIGN_INTERNAL_SECRET`
+  - FleetOps: see the prefixed list below
+- `HCAPTCHA_SECRET` and `HCAPTCHA_SITE_KEY` are legacy and no longer read by any function. `AUTH_SEND_EMAIL_HOOK_SECRET`, `DS_DESIGN_SYSTEM_TOKEN` (design-system tables were dropped in `20260608120000`), `HUGGING_FACE_ACCESS_TOKEN`, and `LOVABLE_API_KEY` are also set on the linked project but unreferenced in this repo. Leave them alone unless the user explicitly asks to prune them.
+- The client never receives the Mapbox token as an env var. It calls the `get-mapbox-token` edge function, which reads `MAPBOX_TOKEN` server-side. Keep it that way.
+- To audit what is actually set on the linked project, run `supabase secrets list` (prints names and value digests, never plaintext).
 - `generate-gear-review-blog-draft` also relies on `SUPABASE_SERVICE_ROLE_KEY`, `OPENAI_API_KEY`, and the Google Custom Search image/web keys. It is protected by the `gear_review_blog_generation_config.cron_secret` value passed as `x-cron-secret`, compared in constant time via `_shared/timingSafeEqual.ts`.
 - `auto-assign-gear-images` is no longer anonymous. It now requires either an admin JWT or a shared internal secret `AUTO_ASSIGN_INTERNAL_SECRET` passed as the `x-internal-secret` header. The `on_equipment_created` DB trigger (`notify_new_equipment`) sends that header, reading the value from the Vault secret named `auto_assign_internal_secret` (migration `20260611120000_auto_assign_secret_vault_fallback.sql`), falling back to the `app.auto_assign_internal_secret` GUC. Persisting custom GUCs via `ALTER DATABASE/ROLE ... SET` is denied on Supabase managed Postgres, which is why Vault is the primary source. Keep the Vault secret and the function secret set to the same value.
 - SSRF-prone image/fetch functions (`download-store-image`, `convert-image-to-webp`, `convert-to-jpeg`, `scan-broken-images`) validate user/DB-supplied URLs through `_shared/urlSafety.ts`, which requires https and rejects private/reserved hosts.
 - Imported FleetOps storage uses public buckets `fleetops-equipment-images` and `fleetops-shop-logos`.
-- Imported FleetOps Edge Functions use prefixed secrets where available: `FLEETOPS_STRIPE_SECRET_KEY`, `FLEETOPS_STRIPE_WEBHOOK_SECRET`, `FLEETOPS_SENDGRID_API_KEY`, `FLEETOPS_FROM_EMAIL`, `FLEETOPS_PUBLIC_SUPABASE_URL`, and `FLEETOPS_POS_INVENTORY_SEED_CRON_SECRET`. The retained `fleetops_pos_inventory_seed_config.cron_secret` should stay synchronized with the prefixed POS function secret if the disabled seed flow is ever re-enabled.
+- Imported FleetOps Edge Functions read `FLEETOPS_`-prefixed secrets exclusively: `FLEETOPS_STRIPE_SECRET_KEY`, `FLEETOPS_STRIPE_WEBHOOK_SECRET`, `FLEETOPS_SENDGRID_API_KEY`, `FLEETOPS_FROM_EMAIL`, `FLEETOPS_PUBLIC_SUPABASE_URL`, and `FLEETOPS_POS_INVENTORY_SEED_CRON_SECRET`. The unprefixed fallbacks (`STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `SENDGRID_API_KEY`, `FROM_EMAIL`, `PUBLIC_SUPABASE_URL`, `SITE_URL`, `POS_INVENTORY_SEED_CRON_SECRET`, `SERVICE_ROLE_KEY`) were removed in August 2026; they were never set on the linked project, so they were dead code that made the real source of each value ambiguous. Do not reintroduce them. `FLEETOPS_FROM_EMAIL` is intentionally optional and defaults to `bookings@demostoke.com`.
+- The retained `fleetops_pos_inventory_seed_config.cron_secret` should stay synchronized with `FLEETOPS_POS_INVENTORY_SEED_CRON_SECRET` if the disabled seed flow is ever re-enabled.
 - Do not introduce new hardcoded secrets. Keep public browser tokens and service secrets clearly separated.
 
 ## Critical Invariants and Gotchas

--- a/supabase/functions/admin-create-user/index.ts
+++ b/supabase/functions/admin-create-user/index.ts
@@ -60,10 +60,7 @@ const jsonResponse = (status: number, body: Record<string, unknown>) =>
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const getMapboxToken = (): string | null =>
-  Deno.env.get("MAPBOX_TOKEN") ??
-  Deno.env.get("VITE_MAPBOX_TOKEN") ??
-  Deno.env.get("REACT_APP_MAPBOX_TOKEN") ??
-  null;
+  Deno.env.get("MAPBOX_TOKEN") ?? null;
 
 async function geocodeAddress(address: string): Promise<GeocodeResult | null> {
   const token = getMapboxToken();

--- a/supabase/functions/fleetops-create-payment-intent/index.ts
+++ b/supabase/functions/fleetops-create-payment-intent/index.ts
@@ -5,7 +5,7 @@ import {
   resolveWidgetCheckoutMode,
 } from "../_shared/fleetopsWidgetCheckout.ts";
 
-const stripe = new Stripe(Deno.env.get("FLEETOPS_STRIPE_SECRET_KEY") || Deno.env.get("STRIPE_SECRET_KEY")!, {
+const stripe = new Stripe(Deno.env.get("FLEETOPS_STRIPE_SECRET_KEY")!, {
   apiVersion: "2024-12-18.acacia",
 });
 

--- a/supabase/functions/fleetops-refund-payment/index.ts
+++ b/supabase/functions/fleetops-refund-payment/index.ts
@@ -1,7 +1,7 @@
 import Stripe from "https://esm.sh/stripe@17?target=deno";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
-const stripe = new Stripe(Deno.env.get("FLEETOPS_STRIPE_SECRET_KEY") || Deno.env.get("STRIPE_SECRET_KEY")!, {
+const stripe = new Stripe(Deno.env.get("FLEETOPS_STRIPE_SECRET_KEY")!, {
   apiVersion: "2024-12-18.acacia",
 });
 
@@ -12,9 +12,7 @@ const corsHeaders = {
 };
 
 const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
-const supabaseServiceRoleKey =
-  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ||
-  Deno.env.get("SERVICE_ROLE_KEY")!;
+const supabaseServiceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 
 function jsonResponse(body: Record<string, unknown>, status = 200) {
   return new Response(JSON.stringify(body), {

--- a/supabase/functions/fleetops-seed-pos-inventory/index.ts
+++ b/supabase/functions/fleetops-seed-pos-inventory/index.ts
@@ -245,7 +245,7 @@ Deno.serve(async (req: Request) => {
     return jsonResponse({ error: "Method not allowed." }, 405);
   }
 
-  const expectedSecret = Deno.env.get("FLEETOPS_POS_INVENTORY_SEED_CRON_SECRET") || Deno.env.get("POS_INVENTORY_SEED_CRON_SECRET")?.trim();
+  const expectedSecret = Deno.env.get("FLEETOPS_POS_INVENTORY_SEED_CRON_SECRET")?.trim();
   const suppliedSecret = req.headers.get("x-cron-secret")?.trim() ?? "";
   if (
     !expectedSecret ||

--- a/supabase/functions/fleetops-send-booking-email/index.ts
+++ b/supabase/functions/fleetops-send-booking-email/index.ts
@@ -1,7 +1,7 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
-const SENDGRID_API_KEY = Deno.env.get("FLEETOPS_SENDGRID_API_KEY") || Deno.env.get("SENDGRID_API_KEY")!;
-const FROM_EMAIL = Deno.env.get("FLEETOPS_FROM_EMAIL") || Deno.env.get("FROM_EMAIL") || "bookings@demostoke.com";
+const SENDGRID_API_KEY = Deno.env.get("FLEETOPS_SENDGRID_API_KEY")!;
+const FROM_EMAIL = Deno.env.get("FLEETOPS_FROM_EMAIL") || "bookings@demostoke.com";
 
 const supabase = createClient(
   Deno.env.get("SUPABASE_URL")!,

--- a/supabase/functions/fleetops-send-booking-email/index.ts
+++ b/supabase/functions/fleetops-send-booking-email/index.ts
@@ -28,8 +28,31 @@ function getBearerToken(header: string | null) {
   return token;
 }
 
+function escapeHtml(value: unknown): string {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// Only allow https image URLs into the src attribute; reject anything else so
+// untrusted equipment data cannot break out of the attribute or load
+// javascript:/data: payloads.
+function safeImageSrc(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" ? url.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
 function buildEmailHtml(booking: any, equipment: any, shop: any): string {
   const confirmationNumber = booking.id.slice(0, 8).toUpperCase();
+  const imageSrc = safeImageSrc(equipment.image_url);
 
   return `
 <!DOCTYPE html>
@@ -50,10 +73,10 @@ function buildEmailHtml(booking: any, equipment: any, shop: any): string {
   <div class="container">
     <div class="header">
       <h1 style="margin:0;font-size:20px;">Booking Confirmed!</h1>
-      <p style="margin:8px 0 0;opacity:0.9;font-size:14px;">${shop.name}</p>
+      <p style="margin:8px 0 0;opacity:0.9;font-size:14px;">${escapeHtml(shop.name)}</p>
     </div>
     <div class="content">
-      <p style="font-size:14px;color:#666;">Hi ${booking.customer_name},</p>
+      <p style="font-size:14px;color:#666;">Hi ${escapeHtml(booking.customer_name)},</p>
       <p style="font-size:14px;color:#666;">Your gear rental reservation has been confirmed. Here are your booking details:</p>
 
       <div style="background:#f9fafb;border-radius:8px;padding:16px;margin:16px 0;">
@@ -61,9 +84,9 @@ function buildEmailHtml(booking: any, equipment: any, shop: any): string {
         <p style="margin:0;font-size:18px;font-weight:bold;font-family:monospace;">${confirmationNumber}</p>
       </div>
 
-      ${equipment.image_url ? `<img src="${equipment.image_url}" alt="${equipment.name}" style="width:100%;height:200px;object-fit:cover;border-radius:8px;margin-bottom:16px;">` : ""}
+      ${imageSrc ? `<img src="${escapeHtml(imageSrc)}" alt="${escapeHtml(equipment.name)}" style="width:100%;height:200px;object-fit:cover;border-radius:8px;margin-bottom:16px;">` : ""}
 
-      <h3 style="font-size:16px;margin:0 0 12px;">${equipment.name}</h3>
+      <h3 style="font-size:16px;margin:0 0 12px;">${escapeHtml(equipment.name)}</h3>
 
       <div class="detail-row">
         <span style="color:#666;">Dates</span>
@@ -98,7 +121,7 @@ function buildEmailHtml(booking: any, equipment: any, shop: any): string {
       </div>
     </div>
     <div class="footer">
-      <p>Questions? Contact ${shop.contact_email || shop.name}</p>
+      <p>Questions? Contact ${escapeHtml(shop.contact_email || shop.name)}</p>
       <p>Powered by DemoStoke</p>
     </div>
   </div>

--- a/supabase/functions/fleetops-shop-gear-feed/index.ts
+++ b/supabase/functions/fleetops-shop-gear-feed/index.ts
@@ -266,9 +266,6 @@ Deno.serve(async (req: Request) => {
       Deno.env.get("SUPABASE_ANON_KEY");
     const publicSupabaseOrigin =
       toOrigin(Deno.env.get("FLEETOPS_PUBLIC_SUPABASE_URL")) ||
-      toOrigin(Deno.env.get("PUBLIC_SUPABASE_URL")) ||
-      toOrigin(Deno.env.get("SUPABASE_PUBLIC_URL")) ||
-      toOrigin(Deno.env.get("SITE_URL")) ||
       toOrigin(req.url) ||
       toOrigin(supabaseUrl);
 

--- a/supabase/functions/fleetops-stripe-webhook/index.ts
+++ b/supabase/functions/fleetops-stripe-webhook/index.ts
@@ -20,8 +20,31 @@ const corsHeaders = {
   "Access-Control-Allow-Methods": "POST, OPTIONS",
 };
 
+function escapeHtml(value: unknown): string {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// Only allow https image URLs into the src attribute; reject anything else so
+// untrusted equipment data cannot break out of the attribute or load
+// javascript:/data: payloads.
+function safeImageSrc(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" ? url.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
 function buildEmailHtml(booking: any, equipment: any, shop: any): string {
   const confirmationNumber = booking.id.slice(0, 8).toUpperCase();
+  const imageSrc = safeImageSrc(equipment.image_url);
 
   return `
 <!DOCTYPE html>
@@ -42,10 +65,10 @@ function buildEmailHtml(booking: any, equipment: any, shop: any): string {
   <div class="container">
     <div class="header">
       <h1 style="margin:0;font-size:20px;">Booking Confirmed!</h1>
-      <p style="margin:8px 0 0;opacity:0.9;font-size:14px;">${shop.name}</p>
+      <p style="margin:8px 0 0;opacity:0.9;font-size:14px;">${escapeHtml(shop.name)}</p>
     </div>
     <div class="content">
-      <p style="font-size:14px;color:#666;">Hi ${booking.customer_name},</p>
+      <p style="font-size:14px;color:#666;">Hi ${escapeHtml(booking.customer_name)},</p>
       <p style="font-size:14px;color:#666;">Your gear rental reservation has been confirmed. Here are your booking details:</p>
 
       <div style="background:#f9fafb;border-radius:8px;padding:16px;margin:16px 0;">
@@ -53,9 +76,9 @@ function buildEmailHtml(booking: any, equipment: any, shop: any): string {
         <p style="margin:0;font-size:18px;font-weight:bold;font-family:monospace;">${confirmationNumber}</p>
       </div>
 
-      ${equipment.image_url ? `<img src="${equipment.image_url}" alt="${equipment.name}" style="width:100%;height:200px;object-fit:cover;border-radius:8px;margin-bottom:16px;">` : ""}
+      ${imageSrc ? `<img src="${escapeHtml(imageSrc)}" alt="${escapeHtml(equipment.name)}" style="width:100%;height:200px;object-fit:cover;border-radius:8px;margin-bottom:16px;">` : ""}
 
-      <h3 style="font-size:16px;margin:0 0 12px;">${equipment.name}</h3>
+      <h3 style="font-size:16px;margin:0 0 12px;">${escapeHtml(equipment.name)}</h3>
 
       <div class="detail-row">
         <span style="color:#666;">Dates</span>
@@ -90,7 +113,7 @@ function buildEmailHtml(booking: any, equipment: any, shop: any): string {
       </div>
     </div>
     <div class="footer">
-      <p>Questions? Contact ${shop.contact_email || shop.name}</p>
+      <p>Questions? Contact ${escapeHtml(shop.contact_email || shop.name)}</p>
       <p>Powered by DemoStoke</p>
     </div>
   </div>

--- a/supabase/functions/fleetops-stripe-webhook/index.ts
+++ b/supabase/functions/fleetops-stripe-webhook/index.ts
@@ -1,7 +1,7 @@
 import Stripe from "https://esm.sh/stripe@17?target=deno";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
-const stripe = new Stripe(Deno.env.get("FLEETOPS_STRIPE_SECRET_KEY") || Deno.env.get("STRIPE_SECRET_KEY")!, {
+const stripe = new Stripe(Deno.env.get("FLEETOPS_STRIPE_SECRET_KEY")!, {
   apiVersion: "2024-12-18.acacia",
 });
 
@@ -10,8 +10,8 @@ const supabase = createClient(
   Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
 );
 
-const SENDGRID_API_KEY = Deno.env.get("FLEETOPS_SENDGRID_API_KEY") || Deno.env.get("SENDGRID_API_KEY");
-const FROM_EMAIL = Deno.env.get("FLEETOPS_FROM_EMAIL") || Deno.env.get("FROM_EMAIL") || "bookings@demostoke.com";
+const SENDGRID_API_KEY = Deno.env.get("FLEETOPS_SENDGRID_API_KEY");
+const FROM_EMAIL = Deno.env.get("FLEETOPS_FROM_EMAIL") || "bookings@demostoke.com";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -183,7 +183,7 @@ Deno.serve(async (req: Request) => {
     event = stripe.webhooks.constructEvent(
       body,
       signature!,
-      Deno.env.get("FLEETOPS_STRIPE_WEBHOOK_SECRET") || Deno.env.get("STRIPE_WEBHOOK_SECRET")!
+      Deno.env.get("FLEETOPS_STRIPE_WEBHOOK_SECRET")!
     );
   } catch (err) {
     return new Response(`Webhook Error: ${err.message}`, {

--- a/supabase/functions/get-mapbox-token/index.ts
+++ b/supabase/functions/get-mapbox-token/index.ts
@@ -23,10 +23,7 @@ serve(async (req) => {
   try {
     console.log('🔑 Processing get-mapbox-token request');
     
-    // Try multiple environment variable names
-    const MAPBOX_TOKEN = Deno.env.get('MAPBOX_TOKEN') || 
-                        Deno.env.get('VITE_MAPBOX_TOKEN') || 
-                        Deno.env.get('REACT_APP_MAPBOX_TOKEN');
+    const MAPBOX_TOKEN = Deno.env.get('MAPBOX_TOKEN');
     
     if (!MAPBOX_TOKEN) {
       console.error('❌ No Mapbox token found in environment variables');


### PR DESCRIPTION
## What changed

**Secret consolidation (7 edge functions).** Every FleetOps function read a `FLEETOPS_`-prefixed secret with an unprefixed fallback (`STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `SENDGRID_API_KEY`, `FROM_EMAIL`, `PUBLIC_SUPABASE_URL`, `SITE_URL`, `POS_INVENTORY_SEED_CRON_SECRET`, `SERVICE_ROLE_KEY`). `supabase secrets list` confirmed none of the unprefixed names are set on the linked project, so the fallbacks were dead code that obscured where each value actually comes from. Same for the `VITE_MAPBOX_TOKEN` / `REACT_APP_MAPBOX_TOKEN` fallbacks in `get-mapbox-token` and `admin-create-user`.

**Latent bug fix.** In `fleetops-seed-pos-inventory`, `.trim()` bound only to the dead fallback (`get(A) || get(B)?.trim()`), so a `FLEETOPS_POS_INVENTORY_SEED_CRON_SECRET` value with stray whitespace would never match the `x-cron-secret` header and every cron run would 401. The trim now applies to the value actually used.

**Email HTML-escaping port.** `fleetops-send-booking-email` and `fleetops-stripe-webhook` were last deployed from the `demostoke-fleet-ops` repo, whose copies escape untrusted booking data (`shop.name`, `customer_name`, `equipment.name`) via `escapeHtml()` and restrict `equipment.image_url` to https URLs via `safeImageSrc()` before interpolating into confirmation-email HTML — 8 call sites per file. This repo's copies had none of it, so deploying from here would have regressed live security. The files were copied verbatim from fleet-ops, then the dead fallbacks removed to match the rest of this branch.

**Docs.** New "Where Secrets Actually Live" section in `AGENTS.md`/`CLAUDE.md`/`GEMINI.md` documenting the five actual secret stores (root `.env` is CLI tooling only, edge function secrets, hardcoded public keys, DB/Vault, SSR host), plus the previously undocumented `FIRECRAWL_API_KEY`, `RESEND_API_KEY`, `YOUTUBE_V3_API_KEY`, and `GEAR_REVIEW_BLOG_MODEL`.

## Reviewer notes

- **Already deployed.** All 8 affected functions were deployed from this branch on Aug 10, 2026 (each bumped one version, `verify_jwt` verified unchanged on every function). Production currently runs this branch's code, so this PR should merge promptly to keep `main` in sync with live.
- Expected runtime effect: none, except the cron-secret trim fix. Removed fallbacks were never set; the email hardening matches what was already live from the fleet-ops deploys.
- `deno check` error sets on all changed functions are byte-identical to `main` (28 pre-existing FleetOps typing issues, zero introduced). `lint`, `type-check`, `test:unit` (224 passed), and `build` all pass.
- The three memory files are intentionally byte-identical copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)